### PR TITLE
Release v1.11.0: full workspace metadata discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2026-09-05
+
+### Changed
+
+- Reduced item and object node widths and restored clear horizontal and vertical spacing in lineage views.
+- Made the standard governance baseline explicit: 70% for each of the six pillars.
+
+### Fixed
+
+- Item type and health filters now replace an incompatible selection instead of retaining it outside the filtered type.
+- Changing the object table filter now selects that table and clears the previous incompatible object selection.
+
 ## [1.10.0] - 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-09-05
+
+### Added
+
+- A grouped Catalog table with sorting by item name, health, documented owner and last refresh, alongside the existing cards.
+- Personal compact and comfortable display density, with browser-local settings separated by user and workspace.
+- A resizable lineage inspector with keyboard controls and a remembered width.
+- Evidence-bound access-review history. Changed permissions require a fresh decision, while earlier decisions remain visible.
+- Shared workspace governance targets, with a default of 70% for each of the six posture pillars.
+- Justified, expiring governance exceptions, separate from personal Radar acknowledgements and mutes.
+- Full before/after schema and DAX details, with impact evaluated from the selected historical snapshot, including removed objects.
+
+### Changed
+
+- Reduced page-header space and standardized toolbar typography and density-aware rows.
+- Improved lineage label readability and the visibility of inactive context without moving nodes when selection changes.
+- Kept Radar compact when it has no new priority risk, preserving the first-snapshot baseline and the exact comparison link.
+- Distinguished Owner permissions from documented item ownership.
+
+### Fixed
+
+- Overview health now excludes unknown statuses from its denominator and displays health coverage separately.
+- Unavailable visibility and source metadata no longer appear as confirmed visibility or a recorded source.
+
+### Security
+
+- Added governance policy and exception entities with shared authenticated reads and writes restricted to the configured synchronization administrator.
+- Added personal, append-only access-review events without deleting legacy review records or synchronized snapshots.
+
+### Documentation
+
+- Updated the README for the P1 features and browser-local display settings.
+- Recorded all deferred P2 and P3 work in the v2 roadmap, including scheduled synchronization and the shared action plan.
+
 ## [1.9.2] - 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-09-05
+
+### Added
+
+- Generic deep discovery for every KQL Database in the configured workspace, including tables, columns, stored functions and materialized views.
+- Generic Fabric SQL Database discovery through workspace-resolved endpoints and constant read-only system-catalog queries.
+- First-class Ontology, Graph Model, Data Agent, KQL Queryset and KQL Dashboard item types.
+- Ontology entity, property, time-series property, relationship, binding and contextualization inventory.
+- Graph Model node, edge, property and physical-source mapping inventory.
+- Data Agent draft/published source inventory and selected table, column, measure, KQL, ontology and graph objects.
+- Verified object lineage for physical source bindings, ontology relationships, Graph Model mappings and Data Agent selections.
+- Object-level impact, filtering, search, deep links and historical comparison for the new metadata types.
+- A cited Fabric metadata coverage audit in `docs/fabric-metadata-coverage-audit.md`.
+
+### Changed
+
+- Asset Catalog now uses workload-specific object labels instead of presenting every object as a table or column.
+- Map object mode uses verified metadata edges when available and retains the existing DAX graph as the Semantic Model fallback.
+- Snapshot persistence stores safe item metadata and verified object edges in bounded hidden `ConfigEntry` chunks.
+- Synchronization acquires separate optional Kusto, Azure SQL and OneLake audience tokens for the same authenticated Fabric user.
+
+### Security
+
+- SQL discovery uses allowlisted `*.database.fabric.microsoft.com` endpoints, a constant `sys.*` query, read-only application intent and token-based authentication.
+- KQL discovery runs only fixed read-only metadata commands against allowlisted Fabric Kusto endpoints.
+- Definition sanitization removes Data Agent instructions and few-shots, KQL function bodies, SQL module definitions, graph filter literals and instances, and Ontology documents or resource links.
+- Optional metadata failures remain visible as capability status and never replace the last validated snapshot with fabricated or partial success.
+
+### Documentation
+
+- Updated the README coverage matrix, installation permissions, architecture and data model for generic workspace discovery.
+
 ## [1.10.1] - 2026-09-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ are not product defaults or a reference architecture.
 Fabric workspaces spread operational metadata across many portal pages and APIs.
 Fabric Atlas collects that metadata without copying business data.
 
-- Browse workspace items and their internal objects.
+- Browse workspace items as cards or a sortable table, then inspect their internal objects.
 - Inspect Lakehouse, Warehouse and SQL Database tables or views, Semantic Model
   columns and measures, and Report pages when Fabric exposes them.
 - Trace item and object lineage from source to report.
@@ -96,14 +96,16 @@ Fabric Atlas collects that metadata without copying business data.
 | Functionality | What it provides |
 |---|---|
 | Findings | Actionable access, metadata, operations and lineage checks based on synchronized evidence |
-| Governance Radar | Establishes a visible first-snapshot baseline, shows only new priority risks, and links non-risky changes to the exact latest comparison |
+| Governance Radar | Establishes a visible first-snapshot baseline, shows new priority risks, and keeps the no-new-risk state compact with a link to the exact latest comparison |
 | Personal Radar state | Acknowledges one occurrence or mutes a stable finding for the signed-in user |
 | Change Center | Compares any two validated snapshots across items, schema, access, sensitivity, lineage and jobs |
+| Full change evidence | Shows complete before/after values and DAX expressions, with impact computed from the selected historical snapshot, including removed objects |
 | Shareable comparisons | Preserves both selected snapshots, section and filters in the URL |
 | Governance history | Tracks items, labels, external principals, failures, lineage and schema inventory over time |
 | Lazy Change Center evidence | Keeps the ledger immediate and hydrates older detailed catalogs only for the selected comparison |
 | Metadata coverage | Separates collected gaps from metadata that Fabric did not expose, using explicit `N/A` states |
-| Posture targets | Scores six reproducible pillars, compares targets and tracks historical trends without false zeroes |
+| Posture targets | Scores six reproducible pillars against shared, configurable workspace targets, all set to 70% by default |
+| Governance exceptions | Records an administrator's justification and expiry beside a finding without hiding the finding or changing its raw score |
 | Sensitivity posture | Groups protected and unlabeled items and surfaces confidential assets |
 | Saved governance views | Persists personal filters such as metadata gaps, external access or failed operations |
 
@@ -115,11 +117,13 @@ Fabric Atlas collects that metadata without copying business data.
 | Functionality | What it provides |
 |---|---|
 | Workspace catalog | Groups Fabric items by type with search, health, ownership, labels, tags and detail drawers |
+| Catalog table | Keeps cards available and adds sorting by name, health, documented owner or last refresh within collapsed item-type groups |
 | Asset Catalog | Lists tables, views, columns and measures under their parent Fabric item, while keeping synchronized schema-capable items visible when no objects are exposed |
 | Deep metadata | Shows data types, descriptions, visibility, sources, row counts, measure expressions and collection provenance when available |
 | DAX dependency evidence | Resolves measure references only to real synchronized columns or measures and labels inferred source hops |
 | Item context | Keeps properties, lineage, access, configuration and job history beside the selected item |
 | Collapsed groups | Starts inventory lists grouped and collapsed for faster scanning |
+| Ownership labels | Distinguishes documented item ownership from an Owner permission in the access evidence |
 
 </details>
 
@@ -135,6 +139,7 @@ Fabric Atlas collects that metadata without copying business data.
 | Accessible relationships | Exposes item and object edges as text and distinguishes upstream paths with a dashed pattern |
 | Multi-selection | Moves several selected item or object nodes together |
 | Layout controls | Provides zoom, fit, reset, filters, minimap and persistent deep links |
+| Readable map and inspector | Wraps node labels, keeps inactive context readable and supports pointer or keyboard resizing of the details inspector |
 | Impact reports | Exports verified dependency evidence as Markdown for an item or schema object |
 | Object-level impact | Switches to DAX-resolved object granularity when evidence exists and preserves item fallback otherwise |
 
@@ -150,7 +155,8 @@ Fabric Atlas collects that metadata without copying business data.
 | Access Review matrix | Reviews every reachable principal and item pair with permission, source and evidence |
 | Responsive access ledger | Uses one keyboard-navigable representation across mobile and desktop without hidden duplicate rows |
 | Principal review | Groups all reachable items under collapsible principal sections |
-| Review decisions | Persists Reviewed, Accepted or Needs action status with an optional personal note |
+| Review decisions | Appends personal Reviewed, Accepted, Needs action and clear events with retained notes and history |
+| Evidence revalidation | Marks a decision Needs review when its permission evidence changes, including changed underlying grants that leave the strongest permission unchanged |
 | CSV export | Downloads the currently filtered access evidence |
 | Risk filters | Isolates external, broad, service-principal, admin and unresolved access |
 | Departure packs | Finds sole ownership, urgent orphan risk, downstream blast radius and deterministic reassignment candidates |
@@ -164,6 +170,7 @@ Fabric Atlas collects that metadata without copying business data.
 | Functionality | What it provides |
 |---|---|
 | Jobs and health | Groups refresh, pipeline and notebook activity with status, duration and errors |
+| Health and coverage | Calculates observed health from assessed items and separately shows how much of the workspace has a known health status |
 | Responsive job timeline | Shows compact mobile cards and an aligned desktop grid without horizontal table scrolling |
 | Job filters | Searches run history, isolates failures and saves recurring operational views |
 | Active filter chips | Removes search, status, focused item or focused run constraints independently |
@@ -183,6 +190,8 @@ Fabric Atlas collects that metadata without copying business data.
 | Targeted navigation | Opens the matching drawer, asset, review, job or Workspace Hub section |
 | Shareable view state | Keeps active sections, filters, searches, selected assets and focused runs in namespaced URL parameters |
 | Personal saved views | Stores user-scoped filter presets in the Fabric-backed Rayfin database |
+| Display density | Switches between comfortable and compact spacing without reducing the text size |
+| Browser-local display preferences | Remembers density, catalog layout and inspector width separately for each signed-in user and workspace on this browser |
 | Light and dark themes | Uses a Fabric-aligned light mode by default with an optional persistent dark mode |
 | Responsive navigation | Keeps grouped Explore, Govern, Operate and System sections usable on smaller screens |
 | Keyboard-first controls | Adds managed dialogs, focus restoration, skip navigation and Arrow/Home/End tab navigation |
@@ -310,6 +319,26 @@ See [Architecture](docs/architecture.md) for the full data flow.
 
 ## Roadmap
 
+### v2 backlog
+
+The following P2 and P3 work is planned for the v2 series. It is outside the
+v1.10 release scope. The table describes intended behaviour, not features
+available in the current app.
+
+| Priority | Planned feature | Scope |
+|---|---|---|
+| P2 | Scheduled synchronization | Refresh metadata on the server without an open browser, using an identity supported by the required APIs and write policies |
+| P2 | Shared action plan | Assign findings, set deadlines and track team resolution, including actions from departure packs |
+| P2 | Teams and email notifications | Notify the team about relevant new findings and synchronization failures |
+| P2 | Simultaneous departures | Assess several departing principals together so reassignment does not depend on another departing person |
+| P2 | More complete SQL inventory | Extend supported catalog connections to collect tables, views and columns that the current metadata APIs do not expose |
+| P2 | Entra group membership | Expand group evidence where permissions allow it, while distinguishing direct grants from membership-derived access |
+| P2 | Multi-workspace catalog and verified lineage | Index an explicitly selected workspace scope and show cross-workspace relationships only when Microsoft exposes the evidence |
+| P2 | Resumable synchronization | Process bounded batches and resume failed work without discarding the last validated snapshot |
+| P3 | Report visual field usage | Read supported report definitions to trace measure and column references to visuals, subject to report permissions and sensitivity restrictions |
+
+### Multi-workspace milestones
+
 Multi-workspace catalog support is planned and tracked in
 [#4](https://github.com/fredgis/FabricAtlas/issues/4). The implementation will
 stay focused on a controlled set of workspaces rather than scanning an entire
@@ -411,6 +440,18 @@ audience through the Fabric app and workspace access settings.
 Saved views, access-review decisions and Governance Radar acknowledgements are
 different: Rayfin policies bind those records to the authenticated subject, so
 each user sees only their own personal state.
+
+Access decisions are now append-only events. Older decisions remain in the
+history but require a new review because they do not contain a permission
+fingerprint. Clearing a decision appends an event rather than deleting history.
+
+Governance targets and exceptions are shared workspace settings. Only the
+configured synchronization administrator can change them. All six targets
+default to 70%; the same current targets apply to Overview and historical
+posture comparisons. Historical versions of the target policy are not stored.
+An exception needs a reason and a future expiry. It annotates the finding
+without hiding it or improving the underlying score, and it remains separate
+from a user's personal mute.
 
 Team notes are append-only in v1.x. Creation is bound to the authenticated
 email and subject. Atlas resolves a unique synchronized Fabric principal by

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ Fabric workspaces spread operational metadata across many portal pages and APIs.
 Fabric Atlas collects that metadata without copying business data.
 
 - Browse workspace items as cards or a sortable table, then inspect their internal objects.
-- Inspect Lakehouse, Warehouse and SQL Database tables or views, Semantic Model
-  columns and measures, and Report pages when Fabric exposes them.
-- Trace item and object lineage from source to report.
+- Inspect Lakehouse, Warehouse, SQL Database and KQL tables, views, columns,
+  functions and materialized views when the required metadata access is available.
+- Explore Ontology entities, properties, relationships and bindings, Graph Model
+  node and edge types, and Data Agent source selections.
+- Trace item and verified object lineage from physical sources through models,
+  ontologies, graphs, agents and reports.
 - Review effective access, direct shares and external principals.
 - Check sensitivity coverage and confidential assets.
 - Compare validated snapshots and review governance findings.
@@ -118,9 +121,14 @@ Fabric Atlas collects that metadata without copying business data.
 |---|---|
 | Workspace catalog | Groups Fabric items by type with search, health, ownership, labels, tags and detail drawers |
 | Catalog table | Keeps cards available and adds sorting by name, health, documented owner or last refresh within collapsed item-type groups |
-| Asset Catalog | Lists tables, views, columns and measures under their parent Fabric item, while keeping synchronized schema-capable items visible when no objects are exposed |
+| Asset Catalog | Lists relational, KQL, ontology, graph and Data Agent objects under their parent Fabric item, while keeping synchronized schema-capable items visible when no objects are exposed |
 | Deep metadata | Shows data types, descriptions, visibility, sources, row counts, measure expressions and collection provenance when available |
 | DAX dependency evidence | Resolves measure references only to real synchronized columns or measures and labels inferred source hops |
+| KQL inventory | Discovers databases, tables, columns, stored functions and materialized views through read-only Kusto metadata |
+| SQL Database inventory | Discovers schemas, tables, views and columns through read-only system catalogs |
+| Ontology inventory | Decodes entity types, properties, time-series properties, source bindings, relationship types and contextualizations |
+| Graph Model inventory | Shows node and edge types plus source and property mappings without reading graph instances |
+| Data Agent inventory | Shows draft/published sources and selected tables, columns, measures, KQL objects, ontology entities and graph types without retaining prompts |
 | Item context | Keeps properties, lineage, access, configuration and job history beside the selected item |
 | Collapsed groups | Starts inventory lists grouped and collapsed for faster scanning |
 | Ownership labels | Distinguishes documented item ownership from an Owner permission in the access evidence |
@@ -133,7 +141,7 @@ Fabric Atlas collects that metadata without copying business data.
 | Functionality | What it provides |
 |---|---|
 | Item lineage | Places Fabric items in lifecycle stages from orchestration to consumption |
-| Object mode | Expands synchronized tables, columns and measures without claiming unsupported field bindings |
+| Object mode | Expands relational, KQL, semantic, ontology, graph and Data Agent objects using verified snapshot relationships |
 | Impact tracing | Highlights upstream and downstream paths without moving the selected node |
 | Indexed graph engine | Reuses adjacency indexes for traversal, impact, connected groups and staged layout |
 | Accessible relationships | Exposes item and object edges as text and distinguishes upstream paths with a dashed pattern |
@@ -142,6 +150,8 @@ Fabric Atlas collects that metadata without copying business data.
 | Readable map and inspector | Wraps node labels, keeps inactive context readable and supports pointer or keyboard resizing of the details inspector |
 | Impact reports | Exports verified dependency evidence as Markdown for an item or schema object |
 | Object-level impact | Switches to DAX-resolved object granularity when evidence exists and preserves item fallback otherwise |
+| Ontology and graph lineage | Connects physical objects to ontology properties and entities, then follows verified entity relationships and graph mappings |
+| Data Agent lineage | Connects selected source objects to their Data Agent source and element nodes for downstream impact analysis |
 
 </details>
 
@@ -185,7 +195,7 @@ Fabric Atlas collects that metadata without copying business data.
 
 | Functionality | What it provides |
 |---|---|
-| Global `Ctrl+K` search | Searches items, tables, views, columns, measures, principals, jobs, configuration and notes |
+| Global `Ctrl+K` search | Searches items, relational/KQL objects, ontology and graph types, Data Agent selections, principals, jobs, configuration and notes |
 | Debounced workspace index | Reuses one index per snapshot and never activates results from an earlier query |
 | Targeted navigation | Opens the matching drawer, asset, review, job or Workspace Hub section |
 | Shareable view state | Keeps active sections, filters, searches, selected assets and focused runs in namespaced URL parameters |
@@ -205,8 +215,10 @@ Fabric Atlas collects that metadata without copying business data.
 | Functionality | What it provides |
 |---|---|
 | Fabric brokered authentication | Runs inside the Fabric portal with the signed-in Entra identity |
-| Bound token selection | Matches the Power BI token account and tenant to the current Fabric user |
+| Bound token selection | Matches every Fabric, Kusto and SQL token account and tenant to the current signed-in Fabric user |
 | Metadata-only storage | Allowlists governance metadata and excludes rows, datasource details, connections and Power Query or source expressions |
+| Definition sanitization | Excludes Data Agent instructions and few-shots, graph filter values, ontology documents/resource links, KQL function bodies and SQL module definitions |
+| Scoped enrichment | Keeps advanced KQL, SQL and definition scans optional and reports missing token, permission or encrypted-label capability explicitly |
 | User-scoped preferences | Protects saved views and access-review decisions with Rayfin row policies |
 | User-scoped Radar actions | Protects acknowledgements and mutes through the authenticated subject claim |
 | Fabric deployment | Builds, migrates the schema and deploys the app through `npx rayfin up` |
@@ -322,7 +334,7 @@ See [Architecture](docs/architecture.md) for the full data flow.
 ### v2 backlog
 
 The following P2 and P3 work is planned for the v2 series. It is outside the
-v1.10 release scope. The table describes intended behaviour, not features
+v1.11 release scope. The table describes intended behaviour, not features
 available in the current app.
 
 | Priority | Planned feature | Scope |
@@ -331,7 +343,6 @@ available in the current app.
 | P2 | Shared action plan | Assign findings, set deadlines and track team resolution, including actions from departure packs |
 | P2 | Teams and email notifications | Notify the team about relevant new findings and synchronization failures |
 | P2 | Simultaneous departures | Assess several departing principals together so reassignment does not depend on another departing person |
-| P2 | More complete SQL inventory | Extend supported catalog connections to collect tables, views and columns that the current metadata APIs do not expose |
 | P2 | Entra group membership | Expand group evidence where permissions allow it, while distinguishing direct grants from membership-derived access |
 | P2 | Multi-workspace catalog and verified lineage | Index an explicitly selected workspace scope and show cross-workspace relationships only when Microsoft exposes the evidence |
 | P2 | Resumable synchronization | Process bounded batches and resume failed work without discarding the last validated snapshot |
@@ -502,6 +513,7 @@ Pull requests are welcome. Read
 - [Installation](docs/installation.md)
 - [Architecture](docs/architecture.md)
 - [Data model](docs/data-model.md)
+- [Metadata coverage audit](docs/fabric-metadata-coverage-audit.md)
 - [Security policy](.github/SECURITY.md)
 - [Code of conduct](.github/CODE_OF_CONDUCT.md)
 
@@ -517,7 +529,7 @@ metadata capability was not collected; it is not treated as a missing value.</su
 | <sub>Workspace</sub> | <sub>Name, ID, capacity and region</sub> | <sub>Not applicable</sub> | <sub>Not applicable</sub> | <sub>Workspace role assignments</sub> | <sub>Not applicable</sub> | <sub>One workspace per `v1.x` deployment</sub> |
 | <sub>Lakehouse</sub> | <sub>Description, OneLake paths, default schema and SQL endpoint status</sub> | <sub>Tables and columns from Lakehouse REST, scanner metadata or a downstream-model subset</sub> | <sub>Scanner relations and SQL endpoint path</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Schema-enabled variants may require the downstream Semantic Model path</sub> |
 | <sub>Warehouse</sub> | <sub>Description, collation, created and updated dates</sub> | <sub>Tables, views and columns from the scanner; downstream-model subset fallback</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Complete inventory can require SQL catalog connectivity</sub> |
-| <sub>SQL Database</sub> | <sub>Database name, collation and backup retention</sub> | <sub>Tables, views and columns from the scanner; downstream-model subset fallback</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Complete inventory can require SQL catalog connectivity</sub> |
+| <sub>SQL Database</sub> | <sub>Database identity, endpoint, collation and backup metadata</sub> | <sub>Schemas, tables, views and columns from a constant read-only system-catalog query; scanner subset fallback</sub> | <sub>Scanner relations and verified downstream bindings</sub> | <sub>Workspace roles, item users and SQL metadata visibility</sub> | <sub>When supported</sub> | <sub>Requires an Azure SQL delegated token; no rows or module definitions are read</sub> |
 | <sub>SQL endpoint</sub> | <sub>Item identity and scanner metadata</sub> | <sub>No dedicated internal-object scan</sub> | <sub>Storage-to-endpoint-to-model relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Used primarily as a lineage bridge</sub> |
 | <sub>Semantic Model</sub> | <sub>Description, storage mode, provider and documented `configuredBy` owner</sub> | <sub>Tables, columns, measures, descriptions, hidden flags, measure DAX and resolved object dependencies</sub> | <sub>Scanner item relations plus DAX-verified measure dependencies and explicitly inferred unique source hops</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Requires scanner schema and expression options; unresolved/ambiguous references and source or Power Query expressions are discarded</sub> |
 | <sub>Report</sub> | <sub>Report type, bound Semantic Model, documented `createdBy` owner and page inventory</sub> | <sub>Pages and order</sub> | <sub>Model binding plus scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Visuals and field bindings are not exposed by this flow</sub> |
@@ -526,8 +538,12 @@ metadata capability was not collected; it is not treated as a missing value.</su
 | <sub>Data Pipeline</sub> | <sub>Item description and modified metadata when returned</sub> | <sub>Activities and expressions are not expanded</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>Up to 3 returned instances</sub> | <sub>No owner is inferred and pipeline definitions are not copied</sub> |
 | <sub>Dataflow</sub> | <sub>Item metadata and documented `configuredBy` owner</sub> | <sub>Entities and Power Query definitions are not expanded</sub> | <sub>Official upstream Dataflow/Datamart IDs plus scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Cross-workspace dependencies are omitted; query content is not copied</sub> |
 | <sub>Datamart</sub> | <sub>Item metadata and documented `configuredBy` owner</sub> | <sub>No deep object inventory</sub> | <sub>Official upstream Dataflow/Datamart IDs plus scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Cross-workspace dependencies are omitted</sub> |
-| <sub>Eventhouse</sub> | <sub>Item and scanner metadata</sub> | <sub>No KQL object inventory</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Hosted database objects are not expanded</sub> |
-| <sub>KQL Database</sub> | <sub>Item and scanner metadata</sub> | <sub>Tables, functions and policies are not expanded</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>KQL catalog connectivity is not used</sub> |
+| <sub>Eventhouse</sub> | <sub>Item metadata and contained KQL Database IDs</sub> | <sub>Databases remain separate catalog items</sub> | <sub>Verified Eventhouse-to-database relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Eventhouse hosts databases; tables belong to each KQL Database</sub> |
+| <sub>KQL Database</sub> | <sub>Parent Eventhouse, query endpoint and database type</sub> | <sub>Tables, columns, functions and materialized views from read-only Kusto metadata</sub> | <sub>Parent, materialization and verified consumer relations</sub> | <sub>Workspace roles, item users and KQL database reader access</sub> | <sub>When supported</sub> | <sub>Requires a separate Kusto delegated token; function bodies and rows are excluded</sub> |
+| <sub>KQL Queryset / Dashboard</sub> | <sub>Top-level item metadata</sub> | <sub>No saved query text or dashboard payload</sub> | <sub>Scanner or explicit source relations when returned</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Query text and visual definitions remain outside the metadata boundary</sub> |
+| <sub>Ontology</sub> | <sub>Item metadata and definition capability</sub> | <sub>Entity types, properties, time-series properties, bindings, relationship types and contextualizations</sub> | <sub>Physical source-to-property bindings and entity-relationship-entity paths</sub> | <sub>Workspace/item access; definition enrichment requires read-write item permission</sub> | <sub>Not applicable</sub> | <sub>Preview; encrypted labels can block definition retrieval; documents, resource links and instances are excluded</sub> |
+| <sub>Graph Model</sub> | <sub>Item metadata and definition capability</sub> | <sub>Node types, edge types, properties and source mappings</sub> | <sub>Physical source-to-node/edge/property mappings</sub> | <sub>Workspace/item access; definition enrichment requires read-write item permission</sub> | <sub>Not applicable</sub> | <sub>Preview; filter literals and graph instances are excluded</sub> |
+| <sub>Data Agent</sub> | <sub>Published state and description when exposed</sub> | <sub>Configured source items and selected tables, columns, measures, KQL objects, ontology entities and graph types</sub> | <sub>Selected source objects feed Data Agent source and element nodes</sub> | <sub>Workspace/item access; definition enrichment requires read-write item permission</sub> | <sub>Not applicable</sub> | <sub>AI instructions, data-source instructions, few-shot questions/queries and answers are excluded</sub> |
 | <sub>Eventstream</sub> | <sub>Item and scanner metadata</sub> | <sub>Internal stream topology is not expanded</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Event payloads are never read</sub> |
 | <sub>Mirrored Database</sub> | <sub>Item and scanner metadata</sub> | <sub>Mirrored tables are not expanded</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Source data and replication contents are not read</sub> |
 | <sub>User Data Function</sub> | <sub>Item and scanner metadata</sub> | <sub>Function source and endpoints are not expanded</sub> | <sub>Scanner relations</sub> | <sub>Workspace roles and item users</sub> | <sub>When supported</sub> | <sub>Function code is not copied</sub> |

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ The local app uses the included AlpineRent preview estate.
 
 ```powershell
 npx rayfin login --tenant <tenant-id> --select
+$env:RAYFIN_PUBLIC_ATLAS_SYNC_ADMIN_EMAIL = "<authorized-sync-user>"
 npx rayfin up --workspace "<workspace-name>"
 ```
 
@@ -392,7 +393,9 @@ RAYFIN_PUBLIC_ATLAS_PREVIOUS_SYNC_WRITERS=<former-user@example.com>
 RAYFIN_PUBLIC_ATLAS_SENSITIVITY_RANKS='{"<label-id>":3,"<lower-label-id>":1}'
 ```
 
-Run `npx rayfin up` again. The app opens on a guided synchronization screen.
+Keep the configured synchronizer available in the CLI process environment when
+running `npx rayfin up`: it is needed to compile the database policies, not just
+the frontend. The app opens on a guided synchronization screen.
 
 The complete Entra, UDF and deployment steps are in
 [docs/installation.md](docs/installation.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,14 +78,17 @@ or delete action.
 
 ## Sync
 
-The Sync button calls `runFabricSync` (`src/atlas/backend.ts`). When deployed, the browser invokes
-the published `sync_all` Fabric User Data Function. That server-side function reads Fabric and
-Power BI metadata APIs with the user's delegated token. The app maps the response, writes it through
-the Rayfin Data API, and records a `SyncRun`.
+The Sync button calls `runFabricSync` (`src/atlas/backend.ts`). When deployed,
+the browser invokes the published `sync_all` Fabric User Data Function. The
+required Fabric/Power BI token is accompanied by optional Kusto, Azure SQL and
+OneLake tokens acquired for the same signed-in identity. Each token is used
+only by its matching metadata collector. The app maps the response, writes it
+through the Rayfin Data API, and records a `SyncRun`.
 
 Contract version 2 separates required sections from optional enrichment and
-records metadata capabilities for ownership, sensitivity, endorsement and
-tags. Required-section failure rejects the refresh. Optional endpoint failures
+records metadata capabilities for ownership, sensitivity, endorsement, tags,
+KQL schema, SQL schema and item definitions. Required-section failure rejects
+the refresh. Optional token, permission, encrypted-label or endpoint failures
 remain visible as evidence but do not invalidate otherwise authoritative
 metadata. Valid empty workspaces are accepted.
 
@@ -130,7 +133,8 @@ the new snapshot together before background reconciliation.
 
 The MSAL account used for Sync must match the current Rayfin user and tenant.
 Tokens use session storage so switching Fabric users cannot silently reuse the
-first account from a persistent browser cache.
+first account from a persistent browser cache. Optional audience acquisition
+fails closed and never substitutes data from another identity.
 
 ## Governance history
 
@@ -216,7 +220,19 @@ clear actions append events instead of deleting earlier decisions.
 indexed lineage into departure/removal packs. It blocks ownership claims for
 ambiguous principals and recommends only resolved internal user successors.
 
-## DAX object lineage
+## Object lineage
+
+Verified object edges are stored beside schema chunks as hidden `ConfigEntry`
+rows. The generic contract identifies item and object, uses stable IDs and
+accepts only `confidence: verified`. It covers physical object-to-ontology
+bindings, entity relationships, Graph Model mappings and selected source
+objects feeding Data Agents. Historical impact loads the edges from the
+selected snapshot.
+
+Atlas does not read Ontology or Graph Model instances. Those are business data,
+not workspace metadata.
+
+### DAX object lineage
 
 `src/atlas/dax-refs.ts` strips strings and comments before extracting qualified
 columns and measures. `src/atlas/schema-lineage.ts` emits dependencies only
@@ -236,6 +252,16 @@ resolves.
 - Warehouse and SQL Database objects use scanner metadata, with a clearly
   labelled downstream model subset when complete SQL catalog access is not
   available.
+- KQL Database tables and columns come from one database-wide read-only schema
+  command. Function and materialized-view bodies are not retained.
+- SQL Database tables, views and columns come from one constant `sys.*`
+  metadata query. Atlas does not select table rows or retain module definitions.
+- Ontology definitions are reduced to entities, properties, source bindings,
+  relationships and contextualizations.
+- Graph Model definitions are reduced to node/edge types and source/property
+  mappings; filter values and instances are discarded.
+- Data Agent definitions retain publication state, source references and
+  selected element trees. Instructions, few-shots and answers are discarded.
 - Semantic Models include tables, columns, measures, descriptions, hidden
   flags and measure expressions. Dataset expressions are requested only because
   the scanner requires that option for measure DAX.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ Rayfin Data API (Data API Builder)  ──  Fabric SQL database (mssql)
 
 ## Data model
 
-Twelve entities capture the workspace, team context and personal review state.
+Fifteen entities capture the workspace, team context and personal review state.
 See [data-model.md](data-model.md) for fields.
 
 | Entity | Holds |
@@ -44,8 +44,11 @@ See [data-model.md](data-model.md) for fields.
 | `Comment` | Team notes on the workspace or an item |
 | `SyncRun` | Audit of each Sync |
 | `SavedView` | User-scoped filter and navigation presets |
-| `AccessReview` | User-scoped access-review decisions and notes |
+| `AccessReview` | Legacy user-scoped access-review decisions and notes |
+| `AccessReviewEvent` | Personal append-only review history bound to permission evidence |
 | `FindingAck` | User-scoped Governance Radar acknowledgements and mutes |
+| `GovernancePolicy` | Shared workspace targets for the six posture pillars |
+| `GovernanceException` | Shared, justified exceptions with an expiry |
 
 ## Authorization and collaboration scope
 
@@ -64,6 +67,10 @@ Atlas resolves `authorName` from one unique synchronized principal email when
 possible, then falls back to the authenticated session label. `authorEmail`
 remains the authoritative identity and is displayed beside a distinct label so
 readers can verify the author.
+
+`AccessReviewEvent` uses the same personal subject boundary but exposes only
+create and read. Shared `GovernancePolicy` and `GovernanceException` records are
+readable by the app audience and writable only by the configured synchronizer.
 
 Comments are append-only in v1.x: authenticated app users can read them and
 their authenticated author can create them, but the entity exposes no update
@@ -143,6 +150,11 @@ the current and previous detailed catalogs. Selecting another Change Center
 snapshot lazily loads and validates that catalog through a snapshot-scoped
 query; in-flight loads are discarded when a newer sync starts.
 
+Change details retain full values and DAX rather than only ledger previews.
+Historical impact uses the explicitly selected before or after catalog. A
+removed object is inspected in its earlier snapshot; unavailable historical
+evidence never falls back to the current graph.
+
 ## Personal governance state
 
 Saved views and access-review decisions are separate from synchronized
@@ -154,6 +166,12 @@ coverage. Access Review uses the same additive effective-access engine as the
 Asset Catalog and lineage inspector.
 
 ## Navigation state
+
+Display preferences are separate from shareable navigation. Density, Catalog
+layout and lineage inspector width are stored in browser local storage, keyed
+by the authenticated user and configured workspace. They are not cloud-synced
+and are not included in copied URLs. A storage failure leaves a visible warning.
+Compact mode adjusts spacing and control height rather than reducing font size.
 
 `src/atlas/routing.ts` parses and serializes Atlas-owned URL parameters while
 preserving unrelated Fabric host parameters. Catalog, Asset Catalog,
@@ -182,6 +200,17 @@ personalization failure never hides the underlying Radar alerts.
 lineage and operations. Non-applicable evidence is excluded rather than scored
 as zero. Current and previous loaded catalogs provide Overview deltas; opening
 Posture lazily hydrates older catalogs for a consistent trend.
+
+`GovernancePolicy` supplies workspace targets, all defaulting to 70%. Current
+targets apply consistently to current and historical scores; earlier policy
+versions are not retained. `GovernanceException` attaches an administrator's
+reason and expiry to a finding without suppressing the finding or changing
+its score.
+
+Access-review events include a canonical permission fingerprint. A changed
+grant or principal resolution requires revalidation even when the strongest
+access level is unchanged. Legacy decisions remain visible as history, and
+clear actions append events instead of deleting earlier decisions.
 
 `src/atlas/offboarding.ts` composes existing metadata, effective access and
 indexed lineage into departure/removal packs. It blocks ownership claims for

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -96,12 +96,21 @@ A refresh, pipeline or notebook run.
 
 ## ConfigEntry
 
-A configuration fact or a chunk of serialized object schema.
+A configuration fact or a chunk of serialized object metadata.
 
 `workspace_id`, `snapshotId`, `writerEmail?`, `itemFabricId`, `section`, `label`, `value?`
 
 Schema chunks use the private `__schema__` section. Chunking preserves complete
-column and measure lists within the bounded SQL text field.
+object lists within the bounded SQL text field. A hidden metadata envelope
+retains safe KQL, Ontology, Graph Model and Data Agent structures after reload.
+
+Verified object-lineage edges use the private `__object_edges__` section. Each
+edge stores source and target item, object kind, stable ID, readable name,
+optional parent/table context, relation and `confidence: verified`. The parser
+rejects inferred, malformed, self-referential or oversized edge sets.
+
+No extra Rayfin entity is required, so this metadata follows the same immutable
+snapshot publication and retention boundary as the catalog.
 
 ## Comment
 
@@ -192,8 +201,9 @@ removed.
 
 History does not require another table. Atlas uses trusted `Workspace`
 manifests as the index and loads older child rows by `workspace_id` and
-`snapshotId`. Comments, saved views and access-review decisions are not part of
-snapshot comparisons.
+`snapshotId`. Schema metadata and verified object edges come from the selected
+historical snapshot. Comments, saved views and access-review decisions are not
+part of snapshot comparisons.
 
 The configured retention window keeps 12 snapshots by default. Retention runs
 after publication, removes child entities before their manifest, and leaves a

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -27,6 +27,11 @@ update and delete policies require the authenticated subject claim to match
 workspace, user and stable finding ID so different users can acknowledge the
 same governance signal independently.
 
+`AccessReviewEvent` allows only personal create and read operations under the
+same subject policy. `GovernancePolicy` and `GovernanceException` allow shared
+authenticated reads; only the configured synchronization administrator can
+write them.
+
 ## Workspace
 
 The manifest for a complete synchronized snapshot.
@@ -128,12 +133,50 @@ A personal named view over Atlas navigation and filters.
 
 ## AccessReview
 
-A personal decision for one effective principal and item pair.
+A legacy personal decision for one effective principal and item pair.
 
 `workspace_id`, `user_id`, `recordKey`, `rowKey`, `itemFabricId`,
 `principalRef`, `status`, `note?`, `reviewedAt`, `updatedAt`
 
 The status is `reviewed`, `accepted` or `needsAction`.
+
+Legacy rows remain available as history. They require revalidation because they
+do not carry the permission evidence needed to confirm a current decision.
+
+## AccessReviewEvent
+
+An append-only personal decision or clear event.
+
+`workspace_id`, `user_id`, `rowKey`, `itemFabricId`, `principalRef`, `status`,
+`evidenceKey`, `eventOrder`, `note?`, `occurredAt`
+
+The status is `reviewed`, `accepted`, `needsAction` or `cleared`. The evidence
+fingerprint includes the resolved principal and underlying grants, independently
+of grant order or display names. The newest event determines the current
+decision. Clearing appends an event and retains all earlier records.
+
+## GovernancePolicy
+
+Shared targets for one configured workspace.
+
+`workspace_id`, `recordKey`, `writerEmail`, `documentationTarget`,
+`ownershipTarget`, `sensitivityTarget`, `accessTarget`, `lineageTarget`,
+`operationsTarget`, `updatedById`, `updatedByName`, `updatedByEmail`, `updatedAt`
+
+Targets are whole percentages from 0 to 100. When no policy row exists, all six
+default to 70. An unavailable or invalid persisted policy is reported as an
+error rather than treated as an absent policy.
+
+## GovernanceException
+
+A shared, expiring annotation for one stable finding.
+
+`workspace_id`, `recordKey`, `writerEmail`, `findingId`, `reason`, `expiresAt`,
+`authorId`, `authorName`, `authorEmail`, `createdAt`, `updatedAt`
+
+The administrator supplies a justification and future expiry. The UI retains
+the raw finding and score and distinguishes active, expired and invalid
+exceptions. This entity is separate from personal `FindingAck` records.
 
 ## FindingAck
 

--- a/docs/fabric-metadata-coverage-audit.md
+++ b/docs/fabric-metadata-coverage-audit.md
@@ -1,0 +1,525 @@
+# Fabric metadata coverage audit
+
+**As of:** 2026-09-05
+**Scope:** Current, public, first-party Microsoft documentation and APIs, plus the
+operator-supplied FGI-MAIN observations below. This audit does not rely on
+application source code and does not include business-data rows.
+
+## Executive assessment
+
+Fabric Atlas can add useful metadata coverage for all four areas, but the safe
+integration path differs by workload:
+
+- **Eventhouse/KQL Database:** strong support. Discover items through Fabric
+  REST, then use read-only Kusto management commands for tables, columns,
+  functions, materialized views, and selected policies. This avoids the
+  write-capable permission required by `getDefinition`.
+- **Fabric SQL Database (OLTP):** strong support. The item API returns the OLTP
+  TDS address and database name. Standard `sys.*` catalog views can provide
+  schema metadata with `VIEW DEFINITION`, without granting permission to read
+  business rows. Do not confuse this endpoint with the separate SQL analytics
+  endpoint.
+- **Fabric IQ Ontology/GraphModel:** useful but preview and permission-sensitive.
+  Public definitions expose type systems, bindings, contextualizations, and
+  graph mappings. The separate GQL query API can enumerate graph instances and
+  therefore crosses Atlas's metadata-only boundary.
+- **Fabric Data Agent:** the item and definition management APIs are public and
+  the product is GA. Definition files reveal configured source artifacts and
+  selected schema elements, but also contain AI instructions and few-shot
+  queries that Atlas should discard. There is no direct chat operation in the
+  Fabric DataAgent REST operation group; programmatic Q&A is available through
+  first-party Foundry integration, currently using a preview Fabric tool, and
+  returns business answers rather than catalog metadata.
+
+The central security constraint is confirmed across the public APIs:
+`getDefinition` requires **read and write permission on the item** and
+`Item.ReadWrite.All` for Ontology, GraphModel, and DataAgent. KQL Database and
+SQL Database also accept their type-specific `*.ReadWrite.All` scopes. Atlas's
+documented `Item.Read.All` scope is therefore insufficient for these definition
+calls. The recommended design is not to broaden the default crawler token:
+prefer schema-native read-only access for KQL and SQL, and place preview
+definition ingestion behind a separately consented, tightly allowlisted
+connector.
+
+## Live tenant evidence supplied for this audit
+
+The following observations are evidence that the documented surfaces work in
+FGI-MAIN; they are not a substitute for Microsoft API contracts.
+
+| Item or check | Observed result |
+|---|---|
+| Workspace inventory | 5 `KQLDatabase`, 4 `SQLDatabase`, 1 `Ontology`, 1 `GraphModel`, 1 `DataAgent` |
+| KQL metadata | Read-only checks succeeded; 7 tables, 56 columns, and 6 functions across nonempty databases |
+| SQL metadata | Read-only `sys.*` checks succeeded; 36 tables, 455 columns, and 4 views across four databases |
+| Ontology definition | 12 entity types, 95 properties including time-series properties, 16 source bindings, 14 relationship types, and 14 contextualizations |
+| GraphModel definition | 12 node types, 14 edge types, and source mappings; no instance graph was read |
+| DataAgent definition | Draft and published configurations for a semantic model, KQL source, and ontology, with selected element trees |
+
+No raw business rows or graph instances are included in this report.
+
+## 1. Eventhouse and KQL Database
+
+### Supported discovery surfaces
+
+The type-specific list operations are:
+
+```http
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/eventhouses
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/kqlDatabases
+```
+
+Both list APIs require a Viewer workspace role and
+`Workspace.Read.All` or `Workspace.ReadWrite.All`. Per-item reads use:
+
+```http
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/eventhouses/{eventhouseId}
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/kqlDatabases/{kqlDatabaseId}
+```
+
+The per-item endpoints accept `Item.Read.All` or the corresponding
+type-specific read scope. Eventhouse properties include `queryServiceUri`,
+`ingestionServiceUri`, and `databasesItemIds`; KQL Database properties include
+`parentEventhouseItemId`, both service URIs, and `databaseType`.
+([List Eventhouses](https://learn.microsoft.com/en-us/rest/api/fabric/eventhouse/items/list-eventhouses),
+[Get Eventhouse](https://learn.microsoft.com/en-us/rest/api/fabric/eventhouse/items/get-eventhouse),
+[List KQL Databases](https://learn.microsoft.com/en-us/rest/api/fabric/kqldatabase/items/list-kql-databases),
+[Get KQL Database](https://learn.microsoft.com/en-us/rest/api/fabric/kqldatabase/items/get-kql-database))
+
+### Definition API
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/kqlDatabases/{kqlDatabaseId}/getDefinition
+```
+
+This long-running API requires read-write item permission and
+`KQLDatabase.ReadWrite.All` or `Item.ReadWrite.All`. It returns Base64 parts
+including `DatabaseProperties.json`, `DatabaseSchema.kql`, and `.platform`.
+Microsoft describes `DatabaseSchema.kql` as a KQL script defining tables,
+functions, materialized views, and more. The definition format currently
+supports `ReadWrite` databases; behavior for shortcut/follower `ReadOnly`
+databases should be treated as unsupported until documented or tested.
+([Get KQL Database Definition](https://learn.microsoft.com/en-us/rest/api/fabric/kqldatabase/items/get-kql-database-definition),
+[KQL Database definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/kql-database-definition))
+
+### Preferred read-only schema mechanism
+
+Use the returned `queryServiceUri` as the Kusto service endpoint and send
+control commands to the management route, not the query route:
+
+```http
+POST {queryServiceUri}/v1/rest/mgmt
+Authorization: Bearer <Kusto access token>
+Content-Type: application/json; charset=utf-8
+x-ms-readonly: true
+
+{
+  "db": "<database-name>",
+  "csl": ".show database <database-name> schema as json with(Tables=True, Functions=True, MaterializedViews=True)"
+}
+```
+
+Kusto documents `/v1/rest/mgmt` for management commands and the
+`x-ms-readonly` header for preventing requests from changing data. Kusto client
+libraries support user identities, service principals, and managed identities;
+the identity must also hold an appropriate Kusto database role.
+([Kusto query/management HTTP request](https://learn.microsoft.com/en-us/kusto/api/rest/request?view=microsoft-fabric),
+[Kusto authentication methods](https://learn.microsoft.com/en-us/kusto/api/get-started/app-authentication-methods?view=microsoft-fabric))
+
+Recommended allowlisted commands:
+
+| Metadata | Read-only command | Documented minimum role |
+|---|---|---|
+| Tables and columns | `.show database <db> schema as json` | Database User, Viewer, or Monitor |
+| Functions | Include `Functions=True` in the schema command; use function show commands only if bodies are required | Database User, Viewer, or Monitor |
+| Materialized views | Include `MaterializedViews=True`, or `.show materialized-views` | Database User, Viewer, or Monitor |
+| Retention policy | `.show table <table> policy retention` | Database User, Viewer, or Monitor |
+| Update policy | `.show table <table> policy update` | Database User, Viewer, or Monitor |
+| Row-level security policy | `.show table <table> policy row_level_security` | Database User, Viewer, or Monitor |
+| Restricted-view policy | `.show table * policy restricted_view_access` | Database User, Viewer, or Monitor |
+
+Sources:
+[database schema](https://learn.microsoft.com/en-us/kusto/management/show-schema-database?view=microsoft-fabric),
+[tables](https://learn.microsoft.com/en-us/kusto/management/show-tables-command?view=microsoft-fabric),
+[materialized views](https://learn.microsoft.com/en-us/kusto/management/materialized-views/materialized-view-show-command?view=microsoft-fabric),
+[retention](https://learn.microsoft.com/en-us/kusto/management/show-table-retention-policy-command?view=microsoft-fabric),
+[update policy](https://learn.microsoft.com/en-us/kusto/management/show-table-update-policy-command?view=microsoft-fabric),
+[row-level security](https://learn.microsoft.com/en-us/kusto/management/show-table-row-level-security-policy-command?view=microsoft-fabric),
+[restricted-view access](https://learn.microsoft.com/en-us/kusto/management/show-table-restricted-view-access-policy-command?view=microsoft-fabric),
+[Kusto roles](https://learn.microsoft.com/en-us/kusto/management/security-roles?view=microsoft-fabric).
+Kusto documents additional policy families, but Atlas should add them only
+through an explicit command allowlist.
+([Policies overview](https://learn.microsoft.com/en-us/kusto/management/policies?view=microsoft-fabric))
+
+**Boundary:** function bodies, materialized-view queries, update-policy queries,
+RLS expressions, and documentation strings are metadata/code rather than rows,
+but can contain literals or business logic. Store them only if Atlas explicitly
+classifies source expressions as catalog metadata; otherwise retain names,
+types, dependencies, and policy presence while dropping bodies and literals.
+
+### Scanner and lineage
+
+Microsoft Purview's Fabric inventory explicitly lists KQL Database, and states
+that non-Power BI Fabric items have item-level metadata and lineage only.
+Sub-item metadata is documented for Power BI semantic models and, in preview,
+Lakehouse tables/files; sub-item lineage remains unsupported. Therefore KQL
+table/column/function lineage must not be inferred from scanner results.
+([Fabric metadata scanning](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview),
+[Fabric lineage in Purview](https://learn.microsoft.com/en-us/purview/data-map-lineage-fabric))
+
+## 2. Fabric SQL Database (OLTP)
+
+### Item metadata and endpoint distinction
+
+```http
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/sqlDatabases/{sqlDatabaseId}
+```
+
+The endpoint requires read permission and accepts `SQLDatabase.Read.All` or
+`Item.Read.All`. Its properties include `connectionString`, `databaseName`,
+`serverFqdn`, restore points, retention days, and collation.
+([Get SQL Database](https://learn.microsoft.com/en-us/rest/api/fabric/sqldatabase/items/get-sql-database))
+
+This is the OLTP SQL Database TDS endpoint. It is distinct from the SQL
+analytics endpoint automatically associated with the item. Microsoft documents
+the OLTP endpoint as Azure-SQL-like and shows
+`*.database.fabric.microsoft.com,1433` in current examples, while the analytics
+endpoint uses a `*.fabric.microsoft.com` warehouse-style address. The same
+connection article also contains an older `*.database.windows.net` description,
+so Atlas should trust `serverFqdn`/`connectionString` returned by the REST API
+rather than construct a hostname.
+([Connect to SQL Database in Fabric](https://learn.microsoft.com/en-us/fabric/database/sql/connect))
+
+The type-specific list route
+`GET /v1/workspaces/{workspaceId}/sqlDatabases` requires a Viewer workspace role
+and `Workspace.Read.All` or `Workspace.ReadWrite.All`.
+([List SQL Databases](https://learn.microsoft.com/en-us/rest/api/fabric/sqldatabase/items/list-sql-databases))
+
+### Preferred read-only catalog mechanism
+
+Connect over TDS with Microsoft Entra authentication and query standard catalog
+views such as `sys.schemas`, `sys.tables`, `sys.columns`, `sys.types`,
+`sys.views`, `sys.indexes`, `sys.foreign_keys`, and `sys.objects`.
+SQL Database in Fabric supports the Azure SQL Database catalog-view surface.
+([SQL Database catalog views](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/azure-sql-database-catalog-views?view=fabric-sqldb),
+[Connect to SQL Database in Fabric](https://learn.microsoft.com/en-us/fabric/database/sql/connect))
+
+For a strict metadata-only principal:
+
+1. Grant Fabric **Read** so the identity can connect.
+2. Grant SQL `VIEW DEFINITION` at database scope, or narrower object/schema
+   permissions, so catalog rows are visible.
+3. Do not grant `ReadData`, `SELECT`, or `db_datareader` solely for cataloging.
+
+Fabric documents that item `Read` permits connection while `ReadData` permits
+reading data and metadata. SQL metadata visibility is limited to securables the
+principal owns or can access; `VIEW DEFINITION` expands metadata visibility
+without itself granting row reads.
+([SQL Database authorization](https://learn.microsoft.com/en-us/fabric/database/sql/authorization),
+[SQL metadata visibility](https://learn.microsoft.com/en-us/sql/relational-databases/security/metadata-visibility-configuration?view=fabric-sqldb))
+
+Avoid collecting `sys.sql_modules.definition`, computed/default/check
+expressions, or shared query text unless Atlas deliberately catalogs source
+code. These fields can contain literals even though they are not result rows.
+
+### Definition API
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/sqlDatabases/{sqlDatabaseId}/getDefinition?format=sqlproj
+```
+
+The API requires read-write item permission and
+`SQLDatabase.ReadWrite.All` or `Item.ReadWrite.All`. Supported formats are
+`dacpac` and `sqlproj`; the latter can include object DDL and
+`.sharedqueries/*.sql`. For Atlas, `sys.*` plus `VIEW DEFINITION` is easier to
+constrain and does not require a write-capable Fabric scope. If definitions are
+ever enabled, exclude `.sharedqueries` and apply a DDL allowlist.
+([Get SQL Database Definition](https://learn.microsoft.com/en-us/rest/api/fabric/sqldatabase/items/get-sql-database-definition),
+[SQL Database definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/sql-database-definition))
+
+### Scanner and lineage
+
+The current Purview inventory table names **SQL analytics endpoint** but does
+not list the newer OLTP `SQLDatabase` item. The general scanner documentation
+only promises internal-object metadata for Power BI semantic models, with
+Lakehouse sub-item metadata separately described as preview. Therefore:
+
+- item/sub-item scanner support for the OLTP `SQLDatabase` should be marked
+  **undocumented/uncertain**;
+- support for an associated `SQLEndpoint` must not be reported as coverage of
+  the OLTP database;
+- no public Fabric SQLDatabase REST endpoint was found for table- or
+  column-level lineage.
+
+([Fabric metadata scanning](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview),
+[Fabric lineage in Purview](https://learn.microsoft.com/en-us/purview/data-map-lineage-fabric),
+[Connect to SQL Database in Fabric](https://learn.microsoft.com/en-us/fabric/database/sql/connect))
+
+## 3. Fabric IQ Ontology and GraphModel
+
+### Ontology definition metadata
+
+Ontology and GraphModel item APIs are explicitly **Preview**. Listing either
+type requires a Viewer workspace role and `Workspace.Read.All` or
+`Workspace.ReadWrite.All`.
+([List Ontologies](https://learn.microsoft.com/en-us/rest/api/fabric/ontology/items/list-ontologies),
+[List Graph Models](https://learn.microsoft.com/en-us/rest/api/fabric/graphmodel/items/list-graph-models))
+
+Per-item metadata is available without definition access:
+
+```http
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/ontologies/{ontologyId}
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/graphModels/{graphModelId}
+```
+
+These reads require item read permission and accept `Item.Read.All` or
+`Item.ReadWrite.All`.
+([Get Ontology](https://learn.microsoft.com/en-us/rest/api/fabric/ontology/items/get-ontology),
+[Get Graph Model](https://learn.microsoft.com/en-us/rest/api/fabric/graphmodel/items/get-graph-model))
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/ontologies/{ontologyId}/getDefinition
+```
+
+This API requires read-write permission and `Item.ReadWrite.All`, supports
+long-running operations, omits the sensitivity label from the definition, and
+is blocked for ontologies with encrypted sensitivity labels.
+([Get Ontology Definition](https://learn.microsoft.com/en-us/rest/api/fabric/ontology/items/get-ontology-definition))
+
+The documented definition parts contain:
+
+- entity types with IDs, names, identity/display properties, normal,
+  time-series, and untyped properties, value types, and optional semantic
+  enrichment;
+- data bindings mapping source workspace/item/table/schema/columns to ontology
+  properties;
+- relationship types linking source and target entity types;
+- contextualizations mapping relationship source/target keys to source
+  columns;
+- optional documents, overviews, and resource links.
+
+These structures provide **definition metadata and grounding/lineage mappings**,
+not entity instances.
+([Ontology definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/ontology-definition))
+
+For Atlas, retain an allowlist of entity/relationship identifiers, names,
+property types, binding source identifiers, table/column mappings, and
+contextualization key mappings. Exclude:
+
+- `EntityTypes/*/Documents/*`;
+- `EntityTypes/*/ResourceLinks/*`;
+- arbitrary resource URLs;
+- any literal filter values if future or tenant-specific payloads surface them;
+- unreviewed free-form/custom attribute bags.
+
+### GraphModel definition and instance graph
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/graphModels/{graphModelId}/getDefinition
+```
+
+The Preview API requires read-write item permission and `Item.ReadWrite.All`.
+It returns `graphType`, `graphDefinition`, `dataSources`, and
+`stylingConfiguration`. The schemas describe node types, edge types, property
+types, source mappings, key columns, and property mappings. Graph mapping
+filters can contain literal values, so Atlas should strip each filter's
+`value` field or omit filters entirely.
+([Get Graph Model Definition](https://learn.microsoft.com/en-us/rest/api/fabric/graphmodel/items/get-graph-model-definition),
+[Graph Model definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/graph-model-definition))
+
+Definition metadata is separate from the instance graph. Microsoft now
+documents a public GQL execution endpoint:
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/GraphModels/{graphModelId}/executeQuery?preview=true
+Content-Type: application/json
+
+{ "query": "MATCH (n) RETURN n LIMIT 100" }
+```
+
+The API accepts user-delegated or application bearer tokens and returns typed
+query results, including node and edge references and projected property
+values. It is therefore capable of enumerating business entities and
+relationships. Atlas should **not call this endpoint**: there is no general
+instance-enumeration mode that guarantees metadata-only output.
+([GQL Query HTTP API](https://learn.microsoft.com/en-us/fabric/graph/gql-query-api))
+
+The FGI-MAIN GraphModel counts (12 node types and 14 edge types) came from the
+definition only. No instance graph was read.
+
+### Scanner and lineage
+
+Current Purview inventory documentation does not list Ontology or GraphModel.
+Treat scanner/lineage support for these item types as
+**undocumented/uncertain**. Atlas can derive reliable configuration lineage
+from Ontology bindings and GraphModel source/property mappings, but should label
+it as definition-derived rather than scanner-derived operational lineage.
+([Fabric lineage in Purview](https://learn.microsoft.com/en-us/purview/data-map-lineage-fabric))
+
+## 4. Fabric Data Agent
+
+### Item type and management APIs
+
+`DataAgent` is a first-class Fabric item type. The public v1 operation group
+currently exposes create, delete, get, get definition, list, publish, update,
+and update definition operations.
+([DataAgent REST operations](https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items))
+
+```http
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/dataAgents
+GET https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/dataAgents/{dataAgentId}
+```
+
+List requires a Viewer workspace role plus `Workspace.Read.All` or
+`Workspace.ReadWrite.All`; Get requires item read permission plus
+`Item.Read.All` or `Item.ReadWrite.All`. Get can return
+`properties.publishedDescription`.
+([List Data Agents](https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items/list-data-agents),
+[Get Data Agent](https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items/get-data-agent))
+
+Microsoft describes the Fabric data agent product as **generally available**,
+with an F2/P1-or-higher capacity prerequisite. Individual integrations can
+still be preview.
+([Fabric data agent overview](https://learn.microsoft.com/en-us/fabric/data-science/concept-data-agent))
+
+### Definition metadata
+
+```http
+POST https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/dataAgents/{dataAgentId}/getDefinition
+```
+
+The API requires read-write item permission and `Item.ReadWrite.All`.
+([Get Data Agent Definition](https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items/get-data-agent-definition))
+
+The documented JSON definition contains:
+
+| Part | Catalog treatment |
+|---|---|
+| `Files/Config/data_agent.json` | Keep schema version |
+| `draft|published/stage_config.json` | Exclude `aiInstructions` and experimental bags |
+| `draft|published/{source}/datasource.json` | Keep `artifactId`, `workspaceId`, display name, documented source type, and selected structural `elements` |
+| `draft|published/{source}/fewshots.json` | Exclude all questions and queries |
+| `publish_info.json` | Published description is ordinary item metadata; retain only if existing description policy allows it |
+
+The current public schema names the selected tree `elements`; the supplied
+tenant evidence described it as a selected-element tree. The schema also
+contains `dataSourceInstructions`, `userDescription`, and an open-ended
+`metadata` bag. Exclude `dataSourceInstructions`; treat `userDescription` and
+the open-ended bag as opt-in fields rather than safe structural metadata.
+([Data Agent definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/data-agent-definition))
+
+Documented source-type values include Lakehouse, Warehouse, Kusto, semantic
+model, graph, mirrored database, and mirrored Azure Databricks. The product
+overview lists Lakehouse, Warehouse, semantic model, KQL Database, mirrored
+database, Ontology, and Microsoft Graph. The current public definition schema
+does **not** explicitly list Fabric SQL Database (OLTP) as a source type; mark
+that capability **unsupported/uncertain** rather than inferring it from
+Warehouse or mirrored-database support.
+([Data Agent definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/data-agent-definition),
+[Fabric data agent overview](https://learn.microsoft.com/en-us/fabric/data-science/concept-data-agent))
+
+### Lineage and query/chat surfaces
+
+The source `workspaceId`, `artifactId`, type, and selected `elements` support
+configuration lineage from DataAgent to its configured sources and schema
+elements. No dedicated DataAgent lineage REST operation is listed, and current
+Purview inventory documentation does not list DataAgent, so scanner-derived
+lineage is **undocumented/uncertain**.
+([DataAgent REST operations](https://learn.microsoft.com/en-us/rest/api/fabric/dataagent/items),
+[Fabric lineage in Purview](https://learn.microsoft.com/en-us/purview/data-map-lineage-fabric))
+
+The Fabric DataAgent REST operation group does not expose a direct chat or
+execute-query operation. However, Microsoft documents two first-party
+consumption routes:
+
+- Copilot Studio can add a published Fabric data agent through the Fabric IQ
+  Data MCP tool, using user or maker credentials.
+  ([Copilot Studio integration](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-microsoft-copilot-studio-tool))
+- Microsoft Foundry Agent Service can call a published Fabric data agent through
+  `MicrosoftFabricPreviewTool`; the integration supports SDKs and Foundry REST,
+  uses end-user identity passthrough, requires the same tenant and region, and
+  does not support service-principal authentication for the Fabric data-agent
+  call.
+  ([Foundry integration](https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/tools/fabric))
+
+These routes execute questions against governed data and return business
+answers. They are not metadata discovery mechanisms and should remain outside
+Atlas's crawler.
+
+Fabric data-agent execution is read-only and uses the requesting user's
+effective permissions; RLS/CLS and supported Purview controls continue to
+apply. That protects query execution but does not make returned answers
+metadata-only.
+([Data Agent sharing and permissions](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-sharing),
+[Fabric data agent overview](https://learn.microsoft.com/en-us/fabric/data-science/concept-data-agent))
+
+## Cross-cutting permission result
+
+| Surface | Public permission requirement | Atlas implication |
+|---|---|---|
+| Type-specific workspace list APIs | Viewer workspace role + `Workspace.Read.All` or `Workspace.ReadWrite.All` | Use existing workspace inventory permission/path; `Item.Read.All` alone is not the documented scope for these list routes |
+| Per-item Get for KQL, SQL, DataAgent | Item read + `Item.Read.All` or type-specific read where offered | Compatible with the stated Atlas read-only item scope |
+| KQL Database `getDefinition` | Read-write item + `KQLDatabase.ReadWrite.All` or `Item.ReadWrite.All` | Do not use by default; prefer Kusto management endpoint |
+| SQL Database `getDefinition` | Read-write item + `SQLDatabase.ReadWrite.All` or `Item.ReadWrite.All` | Do not use by default; prefer TDS `sys.*` |
+| Ontology `getDefinition` | Read-write item + `Item.ReadWrite.All`; Preview; blocked by encrypted sensitivity label | Separate opt-in connector only |
+| GraphModel `getDefinition` | Read-write item + `Item.ReadWrite.All`; Preview | Separate opt-in connector only |
+| DataAgent `getDefinition` | Read-write item + `Item.ReadWrite.All` | Separate opt-in connector with strict field allowlist |
+| GraphModel GQL query | Fabric bearer token; user and application access documented; endpoint uses `preview=true` | Exclude because results can contain graph instances and property values |
+
+## Prioritized feasibility
+
+| Priority | Capability | Support status | Difficulty | Recommended Atlas scope |
+|---|---|---|---|---|
+| P0 | Eventhouse/KQL Database item properties | Public v1 REST | Low | Add IDs, parent/child links, database type, query endpoint; never store ingestion credentials |
+| P0 | KQL tables, columns, functions, materialized views | Public Kusto management API | Medium | Add through `/v1/rest/mgmt`, `x-ms-readonly: true`, a command allowlist, and a Viewer/Monitor identity |
+| P0 | SQL Database item and connection metadata | Public v1 REST | Low | Add OLTP item metadata; identify it separately from `SQLEndpoint` |
+| P0 | SQL tables, columns, views, keys/indexes | Public TDS `sys.*` | Medium | Add with Fabric Read + SQL `VIEW DEFINITION`; do not grant `ReadData`/`db_datareader` solely for cataloging |
+| P1 | KQL selected policy metadata | Public Kusto management API | Medium | Add policy presence/settings; omit expressions/literals unless explicitly approved |
+| P1 | DataAgent source and selected-element configuration | Public v1 definition API; product GA | Medium-High | Opt-in only because of `Item.ReadWrite.All`; retain structural allowlist and discard instructions/few-shots |
+| P1 | Ontology types, properties, bindings, relationships, contextualizations | Public Preview definition API | Medium-High | Opt-in only; retain structural metadata, exclude documents/resource links and arbitrary values |
+| P1 | GraphModel node/edge types and mappings | Public Preview definition API | Medium-High | Opt-in only; strip filter literals and never query instances |
+| P2 | Purview/scanner item-level lineage for KQL Database | Documented item-level support | Medium | Import as coarse lineage; do not imply table/column lineage |
+| P2 | Scanner lineage for SQLDatabase, Ontology, GraphModel, DataAgent | Not documented in current inventory | Unknown | Do not promise; probe only after Microsoft documents the item type |
+| Defer | KQL/SQL `getDefinition` | Public but write-scoped | Medium-High | Redundant with safer native metadata paths |
+| Exclude | Ontology documents/resource links, GraphModel filter literal values | Present in definitions | Low | Drop before persistence |
+| Exclude | DataAgent AI/data-source instructions and few-shot content | Present in definitions | Low | Drop before persistence |
+| Exclude | Graph instances and GQL results | Public Preview query API, contains entity data | High risk | Never ingest |
+| Exclude | DataAgent chat/Foundry/Copilot answers | First-party consumption APIs/tools, contains business answers | High risk | Never ingest |
+
+## Recommended implementation boundary
+
+1. Keep Atlas's default Fabric crawler read-only. Add KQL metadata through
+   `queryServiceUri` plus `/v1/rest/mgmt` and add SQL metadata through TDS plus
+   `VIEW DEFINITION`.
+2. Do not replace `Item.Read.All` with broad `Item.ReadWrite.All` for the
+   default sync. If Ontology, GraphModel, or DataAgent definitions are required,
+   use separate consent, credentials, feature flags, audit logging, and a
+   hardcoded set of GET/list/getDefinition routes.
+3. Parse definition payloads through positive field allowlists. Never persist
+   unknown JSON fields automatically as these preview schemas evolve.
+4. Exclude AI instructions, data-source instructions, few-shot questions and
+   queries, graph filter literal values, Ontology documents/resource links,
+   shared SQL queries, and every graph/query result.
+5. Label lineage by provenance: `definition-binding`, `definition-mapping`, or
+   `Purview-item-lineage`. Do not present inferred sub-item lineage as scanner
+   lineage.
+6. Recheck Preview status and definition schemas before enabling Ontology or
+   GraphModel support in production.
+
+## Unsupported, private, preview, and uncertain summary
+
+- **Preview:** Ontology item/API, GraphModel item/API, GraphModel GQL execution,
+  and the Foundry `MicrosoftFabricPreviewTool`.
+- **Private APIs:** none are used or recommended in this audit. Tenant-observed
+  fields that are absent from the current public schema must not be treated as
+  a stable contract.
+- **Unsupported for Atlas by policy:** all graph instances/GQL results, DataAgent
+  answers, AI instructions, few-shots, Ontology documents/resource links, and
+  literal-valued graph filters.
+- **Not exposed as a direct public Fabric DataAgent API:** chat/query execution;
+  the public DataAgent operation group is management/definition/publish only.
+- **Uncertain/undocumented:** Purview scanner support for OLTP `SQLDatabase`,
+  Ontology, GraphModel, and DataAgent; KQL `getDefinition` behavior for
+  `ReadOnly` databases; direct Fabric SQL Database (OLTP) as a DataAgent source.
+- **Public but unsuitable as the default:** all reviewed `getDefinition`
+  endpoints because they require read-write item permission even when Atlas
+  only reads the response.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,12 +113,17 @@ appId=$(az ad app create --display-name "Fabric Atlas Sync" --sign-in-audience A
 #    UserDataFunction.Execute.All, Workspace.Read.All, Item.Read.All,
 #    Lakehouse.Read.All, Warehouse.Read.All, SQLDatabase.Read.All,
 #    Report.Read.All, Dataset.Read.All, Tenant.Read.All
+#    Optional Ontology, Graph Model and Data Agent definition discovery
+#    additionally requires Item.ReadWrite.All.
 #    (add each with: az ad app permission add --id $appId --api 00000009-0000-0000-c000-000000000000
 #     --api-permissions <scope-id>=Scope), then grant admin consent:
+#
+# 3. Add delegated user_impersonation permissions for Azure Data Explorer
+#    and Azure SQL Database to enable KQL and SQL system-catalog discovery.
 az ad sp create --id $appId
 az ad app permission admin-consent --id $appId
 
-# 3. Register the SPA redirect URIs (your app origin + localhost) via Microsoft Graph:
+# 4. Register the SPA redirect URIs (your app origin + localhost) via Microsoft Graph:
 #    PATCH https://graph.microsoft.com/v1.0/applications/<object-id>
 #    body: { "spa": { "redirectUris": [ "https://<app>.fabricapps.net", "http://localhost:5173" ] } }
 ```
@@ -161,6 +166,17 @@ content after a database configuration failure.
 Only this configured account can run the first synchronization or publish later
 snapshots. Other authenticated users see the account on the guided sync screen
 so they know who to contact.
+
+Deep discovery is capability-based. Without Kusto or Azure SQL delegated
+consent, those items remain visible and Atlas reports their deep schema as
+unavailable. Ontology, Graph Model and Data Agent definitions require
+`Item.ReadWrite.All` and read/write permission on the item because that is the
+current Fabric API contract. Encrypted sensitivity labels can block Ontology
+definition retrieval.
+
+Atlas uses these permissions only for read operations. It never calls
+definition update/delete APIs, never elevates the signed-in user and never
+stores rows, prompts, few-shots or graph instances.
 
 Sensitivity downgrade alerts are tenant-specific. Optionally map Purview label
 IDs or normalized aliases to numeric ranks in

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,8 +72,9 @@ are not supported — see
 Deployment provisions the backend (Fabric SQL database + Rayfin Data API, storage, static hosting,
 Fabric auth), applies the schema, and publishes the app — in one command.
 
-```bash
+```powershell
 npx rayfin login                       # sign in with Entra ID (target the tenant that owns the workspace)
+$env:RAYFIN_PUBLIC_ATLAS_SYNC_ADMIN_EMAIL = "<authorized-sync-user>"
 npx rayfin up --workspace "<workspace-name>"
 ```
 
@@ -150,6 +151,12 @@ it requires another `npx rayfin up`. Snapshot retention defaults to 12 and is
 clamped between 2 and 50. When rotating the synchronizer, list former writer
 emails in `RAYFIN_PUBLIC_ATLAS_PREVIOUS_SYNC_WRITERS` until their retained
 history has been migrated or pruned.
+
+The synchronizer setting must also be available to the CLI process that
+compiles these policies. Keep it in `rayfin/.env` for frontend generation and
+export it in the deployment shell as shown above. Confirm that the database
+configuration phase succeeds: some CLI versions continue publishing static
+content after a database configuration failure.
 
 Only this configured account can run the first synchronization or publish later
 snapshots. Other authenticated users see the account on the guided sync screen

--- a/fabric/udf/atlas_sync_functions/function_app.py
+++ b/fabric/udf/atlas_sync_functions/function_app.py
@@ -937,6 +937,17 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
     edges = []
     seen = set()
     truncated = False
+    containment_parent_types = {
+        "KQL table",
+        "KQL external table",
+        "KQL materialized view",
+        "KQL function",
+        "Ontology entity",
+        "Graph node",
+        "Graph edge",
+        "Data Agent source",
+        "Data Agent selected element",
+    }
 
     def add(source, target, relation):
         nonlocal truncated
@@ -977,7 +988,13 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
     for object_id, value in values_by_id.items():
         current = references[object_id]
         parent_id = _strict_text(value.get("parentObjectId"))
-        if parent_id:
+        parent_value = values_by_id.get(parent_id)
+        if (
+            parent_id
+            and isinstance(parent_value, dict)
+            and parent_value.get("objectType")
+            in containment_parent_types
+        ):
             add(
                 reference_for(parent_id),
                 current,
@@ -1537,11 +1554,9 @@ def _get_definition(token, ws, artifact_type, artifact_id):
     if not operation_id:
         raise DefinitionError("definition operation omitted its identifier")
     operation_id = _workspace_id(operation_id)
-    state_url = (
-        _fabric_url(location)
-        if location
-        else f"{FABRIC}/operations/{operation_id}"
-    )
+    # Ontology-family LROs can return an analysis.windows.net Location.
+    # Poll the canonical Fabric operations endpoint with the Fabric token.
+    state_url = f"{FABRIC}/operations/{operation_id}"
     deadline = _ACTIVE_DEADLINE.get() or _ExecutionDeadline()
     retry_after = _retry_after_seconds(headers) or 1
     for _ in range(30):
@@ -1554,26 +1569,15 @@ def _get_definition(token, ws, artifact_type, artifact_id):
             raise DefinitionError("definition operation state was invalid")
         operation_status = _strict_text(state.get("status"))
         if operation_status == "Succeeded":
-            result_location = _strict_text(
-                _header_value(state_headers, "Location")
+            return _get(
+                token,
+                f"{FABRIC}/operations/{operation_id}/result",
             )
-            result_url = (
-                _fabric_url(result_location)
-                if result_location
-                and result_location.rstrip("/").endswith("/result")
-                else f"{FABRIC}/operations/{operation_id}/result"
-            )
-            return _get(token, result_url)
         if operation_status == "Failed":
             raise DefinitionError("definition operation failed")
         if operation_status not in ("NotStarted", "Running"):
             raise DefinitionError("definition operation status was invalid")
         retry_after = _retry_after_seconds(state_headers) or 1
-        next_location = _strict_text(
-            _header_value(state_headers, "Location")
-        )
-        if next_location and not next_location.rstrip("/").endswith("/result"):
-            state_url = _fabric_url(next_location)
     raise DeadlineExceeded("definition operation did not complete")
 
 

--- a/fabric/udf/atlas_sync_functions/function_app.py
+++ b/fabric/udf/atlas_sync_functions/function_app.py
@@ -2,9 +2,15 @@ import contextlib
 import contextvars
 import datetime
 import email.utils
+import base64
+import binascii
+import hashlib
+import importlib
 import json
 import math
 import numbers
+import re
+import struct
 import time
 import uuid
 import urllib.request
@@ -25,6 +31,91 @@ MAX_BACKOFF_SECONDS = 8
 MAX_RESPONSE_BYTES = 25 * 1024 * 1024
 MAX_UPSTREAM_RESPONSE_BYTES = 25 * 1024 * 1024
 RESPONSE_READ_CHUNK_BYTES = 64 * 1024
+MAX_DEFINITION_PARTS = 500
+MAX_DEFINITION_DECODED_BYTES = 8 * 1024 * 1024
+MAX_DEFINITION_FACTS_PER_ITEM = 1000
+MAX_SCHEMA_OBJECTS_PER_ITEM = 1000
+MAX_SCHEMA_COLUMNS_PER_OBJECT = 500
+MAX_OBJECT_LINEAGE_EDGES = 1000
+MAX_SQL_CATALOG_ROWS = 50000
+MAX_SQL_RELATIONSHIP_ROWS = 5000
+MAX_SQL_TOKEN_CHARACTERS = 65536
+MAX_ARTIFACT_METADATA_ELEMENTS = 2048
+MAX_ARTIFACT_METADATA_COLLECTION = 512
+SQL_COPT_SS_ACCESS_TOKEN = 1256
+
+SQL_OBJECTS_QUERY = """
+SELECT TOP (50001)
+    schemas.name,
+    objects.name,
+    objects.type,
+    columns.name,
+    types.name,
+    columns.column_id
+FROM sys.objects AS objects
+INNER JOIN sys.schemas AS schemas
+    ON schemas.schema_id = objects.schema_id
+LEFT JOIN sys.columns AS columns
+    ON columns.object_id = objects.object_id
+LEFT JOIN sys.types AS types
+    ON types.user_type_id = columns.user_type_id
+WHERE objects.type IN ('U', 'V')
+  AND objects.is_ms_shipped = 0
+ORDER BY schemas.name, objects.name, columns.column_id;
+""".strip()
+
+SQL_PRIMARY_KEYS_QUERY = """
+SELECT TOP (5001)
+    schemas.name,
+    tables.name,
+    key_constraints.name,
+    columns.name,
+    index_columns.key_ordinal
+FROM sys.key_constraints AS key_constraints
+INNER JOIN sys.tables AS tables
+    ON tables.object_id = key_constraints.parent_object_id
+INNER JOIN sys.schemas AS schemas
+    ON schemas.schema_id = tables.schema_id
+INNER JOIN sys.index_columns AS index_columns
+    ON index_columns.object_id = tables.object_id
+   AND index_columns.index_id = key_constraints.unique_index_id
+INNER JOIN sys.columns AS columns
+    ON columns.object_id = index_columns.object_id
+   AND columns.column_id = index_columns.column_id
+WHERE key_constraints.type = 'PK'
+ORDER BY schemas.name, tables.name, key_constraints.name,
+         index_columns.key_ordinal;
+""".strip()
+
+SQL_FOREIGN_KEYS_QUERY = """
+SELECT TOP (5001)
+    foreign_keys.name,
+    source_schemas.name,
+    source_tables.name,
+    source_columns.name,
+    target_schemas.name,
+    target_tables.name,
+    target_columns.name,
+    foreign_key_columns.constraint_column_id
+FROM sys.foreign_keys AS foreign_keys
+INNER JOIN sys.foreign_key_columns AS foreign_key_columns
+    ON foreign_key_columns.constraint_object_id = foreign_keys.object_id
+INNER JOIN sys.tables AS source_tables
+    ON source_tables.object_id = foreign_key_columns.parent_object_id
+INNER JOIN sys.schemas AS source_schemas
+    ON source_schemas.schema_id = source_tables.schema_id
+INNER JOIN sys.columns AS source_columns
+    ON source_columns.object_id = foreign_key_columns.parent_object_id
+   AND source_columns.column_id = foreign_key_columns.parent_column_id
+INNER JOIN sys.tables AS target_tables
+    ON target_tables.object_id = foreign_key_columns.referenced_object_id
+INNER JOIN sys.schemas AS target_schemas
+    ON target_schemas.schema_id = target_tables.schema_id
+INNER JOIN sys.columns AS target_columns
+    ON target_columns.object_id = foreign_key_columns.referenced_object_id
+   AND target_columns.column_id = foreign_key_columns.referenced_column_id
+ORDER BY foreign_keys.name, foreign_key_columns.constraint_column_id;
+""".strip()
 
 
 class DeadlineExceeded(RuntimeError):
@@ -36,6 +127,26 @@ class ResponseSizeExceeded(RuntimeError):
 
 
 class ScannerError(RuntimeError):
+    pass
+
+
+class DefinitionError(RuntimeError):
+    pass
+
+
+class SqlRuntimeUnavailable(RuntimeError):
+    pass
+
+
+class SqlConnectionError(RuntimeError):
+    pass
+
+
+class SqlAuthorizationError(RuntimeError):
+    pass
+
+
+class SqlCatalogQueryError(RuntimeError):
     pass
 
 
@@ -156,11 +267,12 @@ def _read_response_bytes(response, deadline, attempt_expires_at):
     return bytes(payload)
 
 
-def _req(
+def _req_response(
     token,
     url,
     method="GET",
     body=None,
+    headers=None,
     deadline=None,
     per_request_timeout=REQUEST_TIMEOUT_SECONDS,
     max_attempts=MAX_REQUEST_ATTEMPTS,
@@ -172,6 +284,8 @@ def _req(
     req.add_header("Authorization", "Bearer " + token)
     if data is not None:
         req.add_header("Content-Type", "application/json")
+    for name, value in (headers or {}).items():
+        req.add_header(name, value)
     active_deadline = (
         deadline
         or _ACTIVE_DEADLINE.get()
@@ -188,7 +302,17 @@ def _req(
                     attempt_expires_at,
                 )
                 text = payload.decode("utf-8")
-                return json.loads(text) if text else {}
+                status = getattr(
+                    response,
+                    "status",
+                    getattr(response, "code", 200),
+                )
+                response_headers = getattr(response, "headers", {}) or {}
+                return (
+                    int(status),
+                    response_headers,
+                    json.loads(text) if text else {},
+                )
         except urllib.error.HTTPError as error:
             retryable = error.code == 429 or 500 <= error.code <= 599
             if not retryable or attempt + 1 >= max_attempts:
@@ -204,6 +328,32 @@ def _req(
             )
             active_deadline.sleep(delay, sleeper=sleeper)
     raise RuntimeError("request attempts exhausted")
+
+
+def _req(
+    token,
+    url,
+    method="GET",
+    body=None,
+    headers=None,
+    deadline=None,
+    per_request_timeout=REQUEST_TIMEOUT_SECONDS,
+    max_attempts=MAX_REQUEST_ATTEMPTS,
+    sleeper=None,
+    wall_clock=None,
+):
+    return _req_response(
+        token,
+        url,
+        method=method,
+        body=body,
+        headers=headers,
+        deadline=deadline,
+        per_request_timeout=per_request_timeout,
+        max_attempts=max_attempts,
+        sleeper=sleeper,
+        wall_clock=wall_clock,
+    )[2]
 
 
 def _get(token, url):
@@ -315,6 +465,9 @@ ART_KEYS = {
     "sqlDatabases": "SQLDatabase",
     "Eventhouse": "Eventhouse",
     "KQLDatabase": "KQLDatabase",
+    "Ontology": "Ontology",
+    "GraphModel": "GraphModel",
+    "DataAgent": "DataAgent",
     "UserDataFunction": "UserDataFunction",
     "SQLAnalyticsEndpoint": "SQLEndpoint",
     "MirroredDatabase": "MirroredDatabase",
@@ -342,6 +495,524 @@ def _normalized_id(value):
         return str(uuid.UUID(text))
     except ValueError:
         return text
+
+
+def _object_slug(value):
+    text = _strict_text(value)
+    if not text:
+        return None
+    return re.sub(r"[^a-z0-9]+", "-", text.casefold()).strip("-")
+
+
+def _fabric_object_id(item_id, object_kind, identifier):
+    normalized_item_id = _normalized_id(item_id)
+    kind = _object_slug(object_kind)
+    identity = (
+        _strict_text(str(identifier))
+        if identifier is not None
+        else None
+    )
+    if not normalized_item_id or not kind or not identity:
+        return None
+    result = (
+        "fabric-object://"
+        + urllib.parse.quote(normalized_item_id, safe="")
+        + "/"
+        + kind
+        + "/"
+        + urllib.parse.quote(identity, safe="")
+    )
+    if len(result) <= 240:
+        return result
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return (
+        "fabric-object://"
+        + urllib.parse.quote(normalized_item_id, safe="")
+        + "/"
+        + kind
+        + "/sha256-"
+        + digest
+    )
+
+
+def _bounded_text(value, max_length=256):
+    text = _strict_text(value)
+    if not text:
+        return None
+    return text[:max_length]
+
+
+def _schema_object_kind(item_type, object_type):
+    item = _strict_text(item_type) or "item"
+    kind = _strict_text(object_type) or "object"
+    aliases = {
+        ("Lakehouse", "Table"): "lakehouse-table",
+        ("Lakehouse", "Managed"): "lakehouse-table",
+        ("Lakehouse", "External"): "lakehouse-table",
+        ("Warehouse", "Table"): "warehouse-table",
+        ("Warehouse", "View"): "warehouse-view",
+        ("SemanticModel", "Model table"): "semantic-model-table",
+        ("KQLDatabase", "KQL table"): "kql-table",
+        ("KQLDatabase", "KQL external table"): "kql-external-table",
+        ("KQLDatabase", "KQL materialized view"): (
+            "kql-materialized-view"
+        ),
+        ("KQLDatabase", "KQL function"): "kql-function",
+        ("SQLDatabase", "SQL table"): "sql-table",
+        ("SQLDatabase", "SQL view"): "sql-view",
+    }
+    return aliases.get((item, kind)) or _object_slug(kind) or "object"
+
+
+def _metadata_object_kind(object_type, fallback="table"):
+    value = (_strict_text(object_type) or "").casefold()
+    mappings = {
+        "table": "table",
+        "managed": "table",
+        "external": "table",
+        "model table": "table",
+        "kql table": "table",
+        "kql external table": "table",
+        "sql table": "table",
+        "view": "view",
+        "sql view": "view",
+        "column": "column",
+        "measure": "measure",
+        "kql function": "function",
+        "kql materialized view": "materializedView",
+        "ontology entity": "entityType",
+        "ontology property": "property",
+        "ontology time-series property": "timeSeriesProperty",
+        "ontology relationship": "relationshipType",
+        "graph node": "nodeType",
+        "graph edge": "edgeType",
+        "graph property": "property",
+        "data agent source": "dataSource",
+        "data agent selected element": "selectedElement",
+    }
+    return mappings.get(value, fallback)
+
+
+def _metadata_source_kind(value):
+    text = (_strict_text(value) or "").casefold()
+    if text.endswith("-column") or text.endswith("-field"):
+        return "column"
+    if text.endswith("-measure"):
+        return "measure"
+    if "function" in text:
+        return "function"
+    if "materialized-view" in text:
+        return "materializedView"
+    if text == "ontology-entity":
+        return "entityType"
+    if text == "ontology-property":
+        return "property"
+    if text == "ontology-relationship":
+        return "relationshipType"
+    if text == "graph-node":
+        return "nodeType"
+    if text == "graph-edge":
+        return "edgeType"
+    if "view" in text:
+        return "view"
+    return "table"
+
+
+def _finalize_schema_object_ids(item_id, item_type, schema):
+    result = []
+    for table in schema or []:
+        record = dict(table)
+        object_kind = _schema_object_kind(
+            item_type,
+            record.get("objectType"),
+        )
+        object_id = _strict_text(record.get("objectId")) or _fabric_object_id(
+            item_id,
+            object_kind,
+            record.get("name"),
+        )
+        if object_id:
+            record["objectId"] = object_id
+        columns = []
+        for column in record.get("columns") or []:
+            safe_column = dict(column)
+            column_kind = (
+                _object_slug(safe_column.get("objectType"))
+                or f"{object_kind}-column"
+            )
+            column_id = _strict_text(
+                safe_column.get("objectId")
+            ) or _fabric_object_id(
+                item_id,
+                column_kind,
+                f"{record.get('name')}/{safe_column.get('name')}",
+            )
+            if column_id:
+                safe_column["objectId"] = column_id
+            if object_id:
+                safe_column.setdefault("parentObjectId", object_id)
+            columns.append(safe_column)
+        record["columns"] = columns
+        measures = []
+        for measure in record.get("measures") or []:
+            safe_measure = dict(measure)
+            measure_id = _strict_text(
+                safe_measure.get("objectId")
+            ) or _fabric_object_id(
+                item_id,
+                "semantic-model-measure",
+                f"{record.get('name')}/{safe_measure.get('name')}",
+            )
+            if measure_id:
+                safe_measure["objectId"] = measure_id
+            if object_id:
+                safe_measure.setdefault("parentObjectId", object_id)
+            measures.append(safe_measure)
+        record["measures"] = measures
+        result.append(record)
+    return result
+
+
+def _object_edge_id(source_object_id, relation, target_object_id):
+    source = _strict_text(source_object_id)
+    label = _object_slug(relation)
+    target = _strict_text(target_object_id)
+    if not source or not label or not target:
+        return None
+    return (
+        "fabric-edge://"
+        + urllib.parse.quote(source, safe="")
+        + "/"
+        + label
+        + "/"
+        + urllib.parse.quote(target, safe="")
+    )
+
+
+def _metadata_object_ref(
+    item_id,
+    kind,
+    object_id,
+    name,
+    parent_id=None,
+    table_name=None,
+):
+    normalized_item_id = _normalized_id(item_id)
+    safe_kind = _strict_text(kind)
+    safe_id = _strict_text(object_id)
+    safe_name = _bounded_text(name)
+    if not normalized_item_id or not safe_kind or not safe_id or not safe_name:
+        return None
+    reference = {
+        "itemId": normalized_item_id,
+        "kind": safe_kind,
+        "id": safe_id,
+        "name": safe_name,
+    }
+    if _strict_text(parent_id):
+        reference["parentId"] = parent_id
+    if _bounded_text(table_name):
+        reference["tableName"] = _bounded_text(table_name)
+    return reference
+
+
+def _add_artifact_object_edge(artifact, source, target, relation):
+    relation = _bounded_text(relation)
+    if not source or not target or not relation:
+        return
+    edges = artifact.setdefault("_objectEdges", [])
+    if len(edges) >= MAX_OBJECT_LINEAGE_EDGES:
+        artifact["_objectEdgesTruncated"] = True
+        return
+    edges.append({
+        "source": source,
+        "target": target,
+        "relation": relation,
+        "confidence": "verified",
+    })
+
+
+def _schema_object_references(item_id, schema):
+    references = []
+    for table in schema or []:
+        for value in (
+            [table]
+            + list(table.get("columns") or [])
+            + list(table.get("measures") or [])
+        ):
+            object_id = _strict_text(value.get("objectId"))
+            name = _bounded_text(value.get("name"))
+            if not object_id or not name:
+                continue
+            reference = {
+                "id": object_id,
+                "itemId": _normalized_id(item_id),
+                "name": name,
+                "kind": _metadata_object_kind(
+                    value.get("objectType"),
+                    (
+                        "column"
+                        if value is not table
+                        else "table"
+                    ),
+                ),
+            }
+            parent_id = _strict_text(value.get("parentObjectId"))
+            if parent_id:
+                reference["parentId"] = parent_id
+            if value is not table:
+                reference["tableName"] = _strict_text(table.get("name"))
+            references.append(reference)
+    return references
+
+
+def _schema_object_edges(schema):
+    edges = []
+    seen = set()
+    for table in schema or []:
+        values = (
+            [table]
+            + list(table.get("columns") or [])
+            + list(table.get("measures") or [])
+        )
+        for value in values:
+            object_id = _strict_text(value.get("objectId"))
+            parent_id = _strict_text(value.get("parentObjectId"))
+            candidates = []
+            if parent_id and object_id:
+                candidates.append((parent_id, object_id, "contains", None))
+            source_id = _strict_text(value.get("sourceObjectId"))
+            target_id = _strict_text(value.get("targetObjectId"))
+            relation = _strict_text(value.get("relation"))
+            if source_id and target_id and relation:
+                candidates.append((
+                    source_id,
+                    target_id,
+                    relation,
+                    (
+                        object_id
+                        if value.get("objectType")
+                        == "Ontology relationship"
+                        else None
+                    ),
+                ))
+            for source, target, label, relation_object_id in candidates:
+                key = (source, target, label, relation_object_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                edge = {
+                    "id": _object_edge_id(source, label, target),
+                    "source": source,
+                    "target": target,
+                    "relation": label,
+                }
+                if relation_object_id:
+                    edge["relationObjectId"] = relation_object_id
+                edges.append(edge)
+    return edges
+
+
+def _public_schema(schema):
+    result = []
+    for table in schema or []:
+        public_table = {
+            key: value
+            for key, value in table.items()
+            if key not in ("columns", "measures")
+        }
+        public_table["columns"] = [
+            dict(column)
+            for column in table.get("columns") or []
+        ]
+        public_table["measures"] = [
+            dict(measure)
+            for measure in table.get("measures") or []
+        ]
+        result.append(public_table)
+    return result
+
+
+def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
+    references = {}
+    values_by_id = {}
+    table_by_object_id = {}
+    for item_id, schema in schema_by_item.items():
+        for table in schema or []:
+            table_id = _strict_text(table.get("objectId"))
+            if table_id:
+                table_by_object_id[table_id] = table
+            for value in (
+                [table]
+                + list(table.get("columns") or [])
+                + list(table.get("measures") or [])
+            ):
+                object_id = _strict_text(value.get("objectId"))
+                name = _strict_text(value.get("name"))
+                if not object_id or not name:
+                    continue
+                parent_id = _strict_text(value.get("parentObjectId"))
+                parent = table_by_object_id.get(parent_id)
+                fallback_kind = (
+                    "measure"
+                    if any(
+                        value is measure
+                        for measure in table.get("measures") or []
+                    )
+                    else (
+                        "column"
+                        if value is not table
+                        else "table"
+                    )
+                )
+                reference = {
+                    "itemId": _normalized_id(item_id),
+                    "kind": _metadata_object_kind(
+                        value.get("objectType"),
+                        fallback_kind,
+                    ),
+                    "id": object_id,
+                    "name": name,
+                }
+                if parent_id:
+                    reference["parentId"] = parent_id
+                parent_path = value.get("parentPath")
+                if isinstance(parent_path, list) and parent_path:
+                    reference["parentPath"] = [
+                        name
+                        for candidate in parent_path[:16]
+                        if (name := _bounded_text(candidate))
+                    ]
+                table_name = _bounded_text(
+                    value.get("tableName")
+                    or (
+                        (parent or table).get("name")
+                        if parent_id
+                        or reference["kind"]
+                        in ("table", "view", "materializedView")
+                        else None
+                    )
+                )
+                if table_name:
+                    reference["tableName"] = table_name
+                references[object_id] = reference
+                values_by_id[object_id] = value
+
+    def reference_for(object_id, value=None, source=False):
+        existing = references.get(object_id)
+        if existing:
+            return dict(existing)
+        if not value:
+            return None
+        item_id = _normalized_id(value.get("sourceItemId"))
+        name = _bounded_text(value.get("sourceObjectName"))
+        source_type = _strict_text(value.get("sourceObjectType"))
+        if not item_id or not object_id or not name:
+            return None
+        reference = {
+            "itemId": item_id,
+            "kind": (
+                _metadata_source_kind(source_type)
+                if source
+                else "selectedElement"
+            ),
+            "id": object_id,
+            "name": name,
+        }
+        parent_id = _strict_text(value.get("sourceParentObjectId"))
+        if parent_id:
+            reference["parentId"] = parent_id
+        parent_path = value.get("sourceParentPath")
+        if isinstance(parent_path, list) and parent_path:
+            reference["parentPath"] = [
+                name
+                for candidate in parent_path[:16]
+                if (name := _bounded_text(candidate))
+            ]
+        table_name = _bounded_text(value.get("sourceTableName"))
+        if table_name:
+            reference["tableName"] = table_name
+        return reference
+
+    edges = []
+    seen = set()
+    truncated = False
+
+    def add(source, target, relation):
+        nonlocal truncated
+        relation = _bounded_text(relation)
+        if not source or not target or not relation:
+            return
+        key = (
+            source["itemId"],
+            source["kind"],
+            source["id"],
+            target["itemId"],
+            target["kind"],
+            target["id"],
+            relation,
+        )
+        if key in seen:
+            return
+        if len(edges) >= MAX_OBJECT_LINEAGE_EDGES:
+            truncated = True
+            return
+        seen.add(key)
+        edges.append({
+            "source": source,
+            "target": target,
+            "relation": relation,
+            "confidence": "verified",
+        })
+
+    for edge in extra_edges or []:
+        if not isinstance(edge, dict):
+            continue
+        add(
+            edge.get("source"),
+            edge.get("target"),
+            edge.get("relation"),
+        )
+
+    for object_id, value in values_by_id.items():
+        current = references[object_id]
+        parent_id = _strict_text(value.get("parentObjectId"))
+        if parent_id:
+            add(
+                reference_for(parent_id),
+                current,
+                "contains",
+            )
+        source_id = _strict_text(value.get("sourceObjectId"))
+        target_id = _strict_text(value.get("targetObjectId"))
+        relation = _strict_text(value.get("relation"))
+        if not source_id or not target_id or not relation:
+            continue
+        if value.get("objectType") == "Ontology relationship":
+            add(
+                reference_for(source_id),
+                current,
+                "relationship source",
+            )
+            add(
+                current,
+                reference_for(target_id),
+                "relationship target",
+            )
+        else:
+            add(
+                reference_for(source_id, value, source=True),
+                reference_for(target_id, value),
+                relation,
+            )
+    return edges, truncated
+
+
+def _atlas_object_edges(schema_by_item, extra_edges=None):
+    return _collect_atlas_object_edges(
+        schema_by_item,
+        extra_edges=extra_edges,
+    )[0]
 
 
 def _artifact_id(value):
@@ -511,29 +1182,29 @@ def _metadata_for_item(artifact, scanner_matched):
     {labelId, displayName}, and tags [{id, displayName}] when supplied.
     """
     metadata = {"scannerMatched": scanner_matched}
-    if not scanner_matched:
-        return metadata
-    configured_by = _safe_text(artifact.get("configuredBy"))
-    modified_by = _safe_text(artifact.get("modifiedBy"))
-    modified = _safe_text(
-        artifact.get("modifiedDateTime")
-        or artifact.get("lastUpdatedDate")
-        or artifact.get("lastUpdatedTime")
-    )
-    if configured_by:
-        metadata["configuredBy"] = configured_by
-    if modified_by:
-        metadata["modifiedBy"] = modified_by
-    if modified:
-        metadata["modifiedDateTime"] = _normalize_timestamp(modified)
+    if scanner_matched:
+        configured_by = _safe_text(artifact.get("configuredBy"))
+        modified_by = _safe_text(artifact.get("modifiedBy"))
+        modified = _safe_text(
+            artifact.get("modifiedDateTime")
+            or artifact.get("lastUpdatedDate")
+            or artifact.get("lastUpdatedTime")
+        )
+        if configured_by:
+            metadata["configuredBy"] = configured_by
+        if modified_by:
+            metadata["modifiedBy"] = modified_by
+        if modified:
+            metadata["modifiedDateTime"] = _normalize_timestamp(modified)
 
     artifact_type = artifact.get("_type")
-    owner_available = artifact_type in (
+    owner_available = scanner_matched and artifact_type in (
         "SemanticModel",
         "Dataflow",
         "Datamart",
     ) or (
-        artifact_type == "Report"
+        scanner_matched
+        and artifact_type == "Report"
         and ("createdBy" in artifact or "createdById" in artifact)
     )
     metadata["ownerAvailable"] = owner_available
@@ -616,6 +1287,8 @@ def _safe_error_code(error, optional=False):
     if isinstance(error, DeadlineExceeded):
         return "deadline-exhausted"
     if isinstance(error, urllib.error.HTTPError):
+        if error.code == 423:
+            return "encrypted-label-blocked"
         if optional and error.code in (400, 404):
             return "endpoint-unsupported"
         if error.code in (401, 403):
@@ -629,7 +1302,33 @@ def _safe_error_code(error, optional=False):
         return "invalid-response"
     if isinstance(error, ScannerError):
         return "scanner-failed"
+    if isinstance(error, DefinitionError):
+        return "invalid-definition"
+    if isinstance(error, SqlRuntimeUnavailable):
+        return "tds-runtime-unavailable"
+    if isinstance(error, SqlConnectionError):
+        return "sql-connection-failed"
+    if isinstance(error, SqlAuthorizationError):
+        return "authorization-failed"
+    if isinstance(error, SqlCatalogQueryError):
+        return "sql-catalog-query-failed"
     return "upstream-failure"
+
+
+def _definition_error_code(error):
+    if isinstance(error, DeadlineExceeded):
+        return "deadline-exhausted"
+    if isinstance(error, urllib.error.HTTPError):
+        if error.code in (401, 403):
+            return "read-write-permission-required"
+        if error.code == 423:
+            return "encrypted-label-blocked"
+        if error.code in (400, 404):
+            return "endpoint-unsupported"
+        return _safe_error_code(error, optional=True)
+    if isinstance(error, (DefinitionError, ValueError, json.JSONDecodeError)):
+        return "invalid-definition"
+    return _safe_error_code(error, optional=True)
 
 
 def _set_section(out, name, status, code=None):
@@ -674,7 +1373,11 @@ def _finish_optional_section(out, name, tracker):
             out,
             name,
             "complete",
-            "partial-unsupported" if tracker["unsupported"] else None,
+            (
+                "partial-unsupported"
+                if tracker["unsupported"]
+                else (tracker["codes"][0] if tracker["codes"] else None)
+            ),
         )
     elif tracker["unsupported"]:
         _set_section(
@@ -714,6 +1417,17 @@ def _set_metadata_capabilities(out):
         "tags": tags,
         "ownership": ownership,
     }
+
+
+def _set_optional_capabilities(out):
+    for section_name, capability_name in (
+        ("definitions", "definitionEnrichment"),
+        ("kqlSchema", "kqlSchema"),
+        ("sqlSchema", "sqlSchema"),
+    ):
+        section = out["sections"].get(section_name)
+        if section:
+            out["capabilities"][capability_name] = dict(section)
 
 
 def _access_right(user):
@@ -758,10 +1472,2569 @@ DETAIL_PATHS = {
     "Lakehouse": "lakehouses",
     "Warehouse": "warehouses",
     "SQLDatabase": "sqlDatabases",
+    "Eventhouse": "eventhouses",
+    "KQLDatabase": "kqlDatabases",
+    "Ontology": "ontologies",
+    "GraphModel": "graphModels",
+    "DataAgent": "dataAgents",
+}
+
+DEFINITION_PATHS = {
+    "Ontology": "ontologies",
+    "GraphModel": "graphModels",
+    "DataAgent": "dataAgents",
 }
 
 
-def _enrich_artifact(token, ws, artifact, trackers, errors):
+def _merge_detail_metadata(artifact, detail):
+    if not isinstance(detail, dict):
+        raise ValueError("item properties response was not an object")
+    for key in (
+        "displayName",
+        "description",
+        "workspaceId",
+        "folderId",
+        "sensitivityLabel",
+        "tags",
+    ):
+        if key in detail and detail[key] is not None:
+            artifact[key] = detail[key]
+
+
+def _header_value(headers, name):
+    if not headers:
+        return None
+    value = headers.get(name)
+    if value is not None:
+        return value
+    expected = name.casefold()
+    for key, candidate in headers.items():
+        if str(key).casefold() == expected:
+            return candidate
+    return None
+
+
+def _get_definition(token, ws, artifact_type, artifact_id):
+    path = DEFINITION_PATHS[artifact_type]
+    status, headers, data = _req_response(
+        token,
+        f"{FABRIC}/workspaces/{ws}/{path}/{artifact_id}/getDefinition",
+        method="POST",
+    )
+    if status == 200:
+        return data
+    if status != 202:
+        raise DefinitionError("definition request returned an invalid status")
+
+    operation_id = _strict_text(
+        _header_value(headers, "x-ms-operation-id")
+    )
+    location = _strict_text(_header_value(headers, "Location"))
+    if not operation_id and location:
+        operation_id = _strict_text(
+            urllib.parse.urlparse(location).path.rstrip("/").rsplit("/", 1)[-1]
+        )
+    if not operation_id:
+        raise DefinitionError("definition operation omitted its identifier")
+    operation_id = _workspace_id(operation_id)
+    state_url = (
+        _fabric_url(location)
+        if location
+        else f"{FABRIC}/operations/{operation_id}"
+    )
+    deadline = _ACTIVE_DEADLINE.get() or _ExecutionDeadline()
+    retry_after = _retry_after_seconds(headers) or 1
+    for _ in range(30):
+        deadline.sleep(retry_after)
+        state_status, state_headers, state = _req_response(
+            token,
+            state_url,
+        )
+        if state_status != 200 or not isinstance(state, dict):
+            raise DefinitionError("definition operation state was invalid")
+        operation_status = _strict_text(state.get("status"))
+        if operation_status == "Succeeded":
+            result_location = _strict_text(
+                _header_value(state_headers, "Location")
+            )
+            result_url = (
+                _fabric_url(result_location)
+                if result_location
+                and result_location.rstrip("/").endswith("/result")
+                else f"{FABRIC}/operations/{operation_id}/result"
+            )
+            return _get(token, result_url)
+        if operation_status == "Failed":
+            raise DefinitionError("definition operation failed")
+        if operation_status not in ("NotStarted", "Running"):
+            raise DefinitionError("definition operation status was invalid")
+        retry_after = _retry_after_seconds(state_headers) or 1
+        next_location = _strict_text(
+            _header_value(state_headers, "Location")
+        )
+        if next_location and not next_location.rstrip("/").endswith("/result"):
+            state_url = _fabric_url(next_location)
+    raise DeadlineExceeded("definition operation did not complete")
+
+
+def _definition_parts(response):
+    if not isinstance(response, dict):
+        raise DefinitionError("definition response was not an object")
+    definition = response.get("definition")
+    if not isinstance(definition, dict):
+        raise DefinitionError("definition response omitted the definition")
+    parts = definition.get("parts")
+    if not isinstance(parts, list) or len(parts) > MAX_DEFINITION_PARTS:
+        raise DefinitionError("definition parts were invalid")
+    return parts
+
+
+def _decode_definition_json(part, decoded_total):
+    if not isinstance(part, dict):
+        raise DefinitionError("definition part was invalid")
+    path = _strict_text(part.get("path"))
+    payload = _strict_text(part.get("payload"))
+    if (
+        not path
+        or not payload
+        or part.get("payloadType") != "InlineBase64"
+    ):
+        raise DefinitionError("definition part metadata was invalid")
+    try:
+        decoded = base64.b64decode(payload, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise DefinitionError("definition part payload was malformed") from error
+    decoded_total[0] += len(decoded)
+    if decoded_total[0] > MAX_DEFINITION_DECODED_BYTES:
+        raise ResponseSizeExceeded(
+            "definition payload exceeded the safe decoded size limit"
+        )
+    try:
+        value = json.loads(decoded.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DefinitionError("definition part was not valid JSON") from error
+    if not isinstance(value, dict):
+        raise DefinitionError("definition JSON part was not an object")
+    return path, value
+
+
+def _explicit_ids(value, field_names):
+    found = set()
+    expected = {name.casefold() for name in field_names}
+
+    def visit(node):
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if str(key).casefold() in expected:
+                    normalized = _normalized_id(child)
+                    if normalized:
+                        found.add(normalized)
+                elif isinstance(child, (dict, list)):
+                    visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                if isinstance(child, (dict, list)):
+                    visit(child)
+
+    visit(value)
+    return found
+
+
+def _exact_scalar_id(value, field_names):
+    if not isinstance(value, dict):
+        return None
+    for name in field_names:
+        candidate = value.get(name)
+        normalized = _normalized_id(
+            str(candidate) if candidate is not None else None
+        )
+        if normalized:
+            return normalized
+    return None
+
+
+def _definition_identifier(value, fallback=None):
+    candidate = value if value is not None else fallback
+    if candidate is None:
+        return None
+    return _normalized_id(str(candidate))
+
+
+def _dedupe_metadata(values, key):
+    result = []
+    seen = set()
+    for value in values:
+        identity = key(value)
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        result.append(value)
+        if len(result) >= MAX_ARTIFACT_METADATA_COLLECTION:
+            break
+    return result
+
+
+def _add_definition_fact(artifact, section, label, value):
+    facts = artifact.setdefault("_definitionFacts", [])
+    if len(facts) >= MAX_DEFINITION_FACTS_PER_ITEM:
+        artifact["_definitionTruncated"] = True
+        return
+    if (
+        _strict_text(section)
+        and _strict_text(label)
+        and isinstance(value, (str, int, float, bool))
+        and str(value).strip()
+    ):
+        facts.append((str(section), str(label), str(value)))
+
+
+def _safe_property_records(values):
+    result = []
+    for value in (values or [])[:MAX_SCHEMA_COLUMNS_PER_OBJECT]:
+        if not isinstance(value, dict):
+            continue
+        name = _strict_text(value.get("name"))
+        if not name:
+            continue
+        record = {"name": name}
+        property_id = _definition_identifier(value.get("id"))
+        value_type = _strict_text(value.get("valueType") or value.get("type"))
+        if property_id:
+            record["id"] = property_id
+        if value_type:
+            record["valueType"] = value_type
+        result.append(record)
+    return result
+
+
+def _source_metadata(value):
+    if not isinstance(value, dict):
+        return None
+    item_id = _normalized_id(
+        value.get("itemId")
+        or value.get("artifactId")
+        or value.get("sourceItemId")
+    )
+    workspace_id = _normalized_id(
+        value.get("workspaceId") or value.get("sourceWorkspaceId")
+    )
+    source_object_id = _normalized_id(
+        value.get("sourceObjectId")
+        or value.get("tableId")
+        or value.get("objectId")
+    )
+    source_type = _strict_text(
+        value.get("sourceType") or value.get("type")
+    )
+    table_name = _strict_text(
+        value.get("sourceTableName")
+        or value.get("tableName")
+        or value.get("displayName")
+    )
+    schema_name = _strict_text(
+        value.get("sourceSchema") or value.get("schemaName")
+    )
+    if not any((item_id, source_type, table_name, schema_name)):
+        return None
+    return {
+        key: field
+        for key, field in {
+            "itemId": item_id,
+            "workspaceId": workspace_id,
+            "sourceType": source_type,
+            "schema": schema_name,
+            "table": table_name,
+            "sourceObjectId": source_object_id,
+        }.items()
+        if field
+    }
+
+
+def _source_summary(source):
+    values = [
+        source.get("sourceType"),
+        source.get("itemId"),
+        ".".join(
+            value
+            for value in (source.get("schema"), source.get("table"))
+            if value
+        ),
+    ]
+    return " | ".join(value for value in values if value)
+
+
+def _source_object_kind(source_type):
+    value = (_strict_text(source_type) or "").casefold()
+    if "warehouse" in value:
+        return "warehouse-table"
+    if "kusto" in value or "kql" in value:
+        return "kql-table"
+    if "semantic" in value or "dataset" in value:
+        return "semantic-model-table"
+    if "sql" in value:
+        return "sql-table"
+    return "table"
+
+
+def _source_object_identity(source):
+    if not isinstance(source, dict):
+        return None
+    return ".".join(
+        value
+        for value in (source.get("schema"), source.get("table"))
+        if _strict_text(value)
+    ) or _strict_text(source.get("itemId"))
+
+
+def _source_object_reference(source):
+    if not isinstance(source, dict):
+        return None
+    item_id = source.get("itemId")
+    identity = _source_object_identity(source)
+    object_kind = _source_object_kind(source.get("sourceType"))
+    return _metadata_object_ref(
+        item_id,
+        "table",
+        _fabric_object_id(item_id, object_kind, identity),
+        source.get("table") or identity,
+        table_name=source.get("table") or identity,
+    )
+
+
+def _source_column_reference(source, column_name):
+    parent = _source_object_reference(source)
+    name = _strict_text(column_name)
+    if not parent or not name:
+        return None
+    object_kind = _source_object_kind(source.get("sourceType"))
+    return _metadata_object_ref(
+        source.get("itemId"),
+        "column",
+        _fabric_object_id(
+            source.get("itemId"),
+            f"{object_kind}-column",
+            f"{_source_object_identity(source)}/{name}",
+        ),
+        name,
+        parent_id=parent["id"],
+        table_name=source.get("table") or _source_object_identity(source),
+    )
+
+
+def _project_ontology_definition(artifact, response):
+    entity_parts = []
+    binding_parts = []
+    relationship_parts = []
+    contextualization_parts = []
+    decoded_total = [0]
+    unknown = 0
+    for part in _definition_parts(response):
+        path = _strict_text(part.get("path"))
+        if not path:
+            raise DefinitionError("definition part path was invalid")
+        normalized_path = path.replace("\\", "/")
+        if normalized_path in (".platform", "definition.json"):
+            continue
+        if re.fullmatch(
+            r"EntityTypes/[^/]+/(Documents|ResourceLinks)/.+\.json",
+            normalized_path,
+            re.IGNORECASE,
+        ) or re.fullmatch(
+            r"EntityTypes/[^/]+/Overviews/definition\.json",
+            normalized_path,
+            re.IGNORECASE,
+        ):
+            continue
+        match = re.fullmatch(
+            r"EntityTypes/([^/]+)/definition\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if match:
+            _, value = _decode_definition_json(part, decoded_total)
+            entity_parts.append((match.group(1), value))
+            artifact.setdefault("_graphModelItemIds", set()).update(
+                _explicit_ids(
+                    value,
+                    (
+                        "graphModelId",
+                        "graphModelItemId",
+                        "generatedGraphModelId",
+                        "generatedGraphModelItemId",
+                    ),
+                )
+            )
+            continue
+        match = re.fullmatch(
+            r"EntityTypes/([^/]+)/DataBindings/([^/]+)\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if match:
+            _, value = _decode_definition_json(part, decoded_total)
+            binding_parts.append((match.group(1), match.group(2), value))
+            continue
+        match = re.fullmatch(
+            r"RelationshipTypes/([^/]+)/definition\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if match:
+            _, value = _decode_definition_json(part, decoded_total)
+            relationship_parts.append((match.group(1), value))
+            continue
+        match = re.fullmatch(
+            r"RelationshipTypes/([^/]+)/Contextualizations/([^/]+)\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if match:
+            _, value = _decode_definition_json(part, decoded_total)
+            contextualization_parts.append(
+                (match.group(1), match.group(2), value)
+            )
+            continue
+        unknown += 1
+
+    entity_names = {}
+    entity_object_ids = {}
+    entity_refs = {}
+    property_refs = {}
+    definition_schema = []
+    metadata_entities = []
+    metadata_bindings = []
+    metadata_relationships = []
+    metadata_contextualizations = []
+    for path_id, value in entity_parts:
+        entity_id = _definition_identifier(value.get("id"), path_id)
+        name = _strict_text(value.get("name")) or entity_id
+        entity_names[entity_id] = name
+        entity_object_id = _fabric_object_id(
+            artifact.get("id"),
+            "ontology-entity",
+            entity_id,
+        )
+        entity_object_ids[entity_id] = entity_object_id
+        properties = _safe_property_records(value.get("properties"))
+        timeseries = _safe_property_records(
+            value.get("timeseriesProperties")
+        )
+        property_metadata = [
+            {
+                "id": prop["id"],
+                "name": prop["name"],
+                "valueType": prop.get("valueType") or "Object",
+                "timeSeries": False,
+            }
+            for prop in properties
+            if prop.get("id")
+        ] + [
+            {
+                "id": prop["id"],
+                "name": prop["name"],
+                "valueType": prop.get("valueType") or "Object",
+                "timeSeries": True,
+            }
+            for prop in timeseries
+            if prop.get("id")
+        ]
+        property_ids = {
+            prop["id"]
+            for prop in property_metadata
+        }
+        key_property_ids = [
+            normalized
+            for candidate in value.get("entityIdParts") or []
+            if (
+                normalized := _definition_identifier(candidate)
+            ) in property_ids
+        ]
+        display_name_property_id = _definition_identifier(
+            value.get("displayNamePropertyId")
+        )
+        metadata_entity = {
+            "id": entity_id,
+            "name": name,
+            "keyPropertyIds": key_property_ids,
+            "properties": property_metadata,
+        }
+        namespace = _strict_text(value.get("namespace"))
+        if namespace:
+            metadata_entity["namespace"] = namespace
+        if display_name_property_id in property_ids:
+            metadata_entity[
+                "displayNamePropertyId"
+            ] = display_name_property_id
+        metadata_entities.append(metadata_entity)
+        definition_schema.append({
+            "_mergeKey": f"ontology-entity:{entity_id}",
+            "name": name,
+            "objectType": "Ontology entity",
+            "objectId": entity_object_id,
+            "source": "Fabric Ontology definition",
+            "columns": [
+                {
+                    "name": prop["name"],
+                    "dataType": prop.get("valueType") or "property",
+                    "objectType": "Ontology property",
+                    "objectId": _fabric_object_id(
+                        artifact.get("id"),
+                        "ontology-property",
+                        prop.get("id") or f"{entity_id}/{prop['name']}",
+                    ),
+                    "parentObjectId": entity_object_id,
+                }
+                for prop in properties
+            ] + [
+                {
+                    "name": prop["name"],
+                    "dataType": prop.get("valueType") or "property",
+                    "objectType": "Ontology time-series property",
+                    "objectId": _fabric_object_id(
+                        artifact.get("id"),
+                        "ontology-property",
+                        prop.get("id") or f"{entity_id}/{prop['name']}",
+                    ),
+                    "parentObjectId": entity_object_id,
+                }
+                for prop in timeseries
+            ],
+            "measures": [],
+        })
+        entity_refs[entity_id] = _metadata_object_ref(
+            artifact.get("id"),
+            "entityType",
+            entity_object_id,
+            name,
+        )
+        for prop in properties:
+            property_refs[(entity_id, prop.get("id"))] = (
+                _metadata_object_ref(
+                    artifact.get("id"),
+                    "property",
+                    _fabric_object_id(
+                        artifact.get("id"),
+                        "ontology-property",
+                        prop.get("id")
+                        or f"{entity_id}/{prop['name']}",
+                    ),
+                    prop["name"],
+                    parent_id=entity_object_id,
+                    table_name=name,
+                )
+            )
+        for prop in timeseries:
+            property_refs[(entity_id, prop.get("id"))] = (
+                _metadata_object_ref(
+                    artifact.get("id"),
+                    "timeSeriesProperty",
+                    _fabric_object_id(
+                        artifact.get("id"),
+                        "ontology-property",
+                        prop.get("id")
+                        or f"{entity_id}/{prop['name']}",
+                    ),
+                    prop["name"],
+                    parent_id=entity_object_id,
+                    table_name=name,
+                )
+            )
+        _add_definition_fact(
+            artifact,
+            "Ontology entity types",
+            name,
+            f"id {entity_id} | {len(properties)} properties | "
+            f"{len(timeseries)} time-series properties",
+        )
+        for prop in properties:
+            _add_definition_fact(
+                artifact,
+                "Ontology properties",
+                f"{name}.{prop['name']}",
+                prop.get("valueType") or "property",
+            )
+        for prop in timeseries:
+            _add_definition_fact(
+                artifact,
+                "Ontology time-series properties",
+                f"{name}.{prop['name']}",
+                prop.get("valueType") or "property",
+            )
+
+    for entity_id, binding_id, value in binding_parts:
+        entity_id = _definition_identifier(entity_id)
+        binding_id = _definition_identifier(value.get("id"), binding_id)
+        configuration = value.get("dataBindingConfiguration")
+        configuration = configuration if isinstance(configuration, dict) else {}
+        source = _source_metadata(
+            configuration.get("sourceTableProperties")
+        )
+        if source:
+            source_id = source.get("itemId")
+            if source_id:
+                artifact.setdefault("_definitionSourceIds", set()).add(
+                    source_id
+                )
+            property_bindings = configuration.get("propertyBindings")
+            safe_property_bindings = []
+            for property_binding in (
+                property_bindings
+                if isinstance(property_bindings, list)
+                else []
+            ):
+                if not isinstance(property_binding, dict):
+                    continue
+                source_column = _strict_text(
+                    property_binding.get("sourceColumnName")
+                    or property_binding.get("sourceColumn")
+                )
+                target_property_id = _definition_identifier(
+                    property_binding.get("targetPropertyId")
+                    or property_binding.get("propertyId")
+                )
+                if (
+                    source_column
+                    and (entity_id, target_property_id) in property_refs
+                ):
+                    safe_property_bindings.append({
+                        "sourceColumn": source_column,
+                        "targetPropertyId": target_property_id,
+                    })
+            count = (
+                len(safe_property_bindings)
+            )
+            label = f"{entity_names.get(entity_id, entity_id)}:{binding_id}"
+            _add_definition_fact(
+                artifact,
+                "Ontology data bindings",
+                label,
+                f"{_source_summary(source)} | {count} property bindings",
+            )
+            _add_artifact_object_edge(
+                artifact,
+                _source_object_reference(source),
+                entity_refs.get(entity_id),
+                "binds entity",
+            )
+            for property_binding in safe_property_bindings:
+                target_property_id = property_binding["targetPropertyId"]
+                _add_artifact_object_edge(
+                    artifact,
+                    _source_column_reference(
+                        source,
+                        property_binding["sourceColumn"],
+                    ),
+                    property_refs.get(
+                        (entity_id, target_property_id)
+                    ),
+                    "binds property",
+                )
+            if entity_id in entity_names and source.get("itemId") and source.get("table"):
+                metadata_binding = {
+                    "id": binding_id,
+                    "entityId": entity_id,
+                    "bindingType": _strict_text(
+                        configuration.get("dataBindingType")
+                        or configuration.get("bindingType")
+                    ) or "Table",
+                    "sourceItemId": source["itemId"],
+                    "sourceObject": source["table"],
+                    "propertyBindings": safe_property_bindings,
+                }
+                for target_key, source_key in (
+                    ("sourceWorkspaceId", "workspaceId"),
+                    ("sourceType", "sourceType"),
+                    ("sourceSchema", "schema"),
+                    ("sourceObjectId", "sourceObjectId"),
+                ):
+                    if source.get(source_key):
+                        metadata_binding[target_key] = source[source_key]
+                timestamp_column = _strict_text(
+                    configuration.get("timestampColumn")
+                    or configuration.get("timestampColumnName")
+                )
+                if timestamp_column:
+                    metadata_binding["timestampColumn"] = timestamp_column
+                metadata_bindings.append(metadata_binding)
+
+    relationship_names = {}
+    for relationship_id, value in relationship_parts:
+        relationship_id = _definition_identifier(
+            value.get("id"),
+            relationship_id,
+        )
+        name = _strict_text(value.get("name")) or relationship_id
+        relationship_names[relationship_id] = name
+        source = value.get("source")
+        target = value.get("target")
+        source_id = (
+            _definition_identifier(source.get("entityTypeId"))
+            if isinstance(source, dict) and source.get("entityTypeId") is not None
+            else None
+        )
+        target_id = (
+            _definition_identifier(target.get("entityTypeId"))
+            if isinstance(target, dict) and target.get("entityTypeId") is not None
+            else None
+        )
+        _add_definition_fact(
+            artifact,
+            "Ontology relationship types",
+            name,
+            f"{entity_names.get(source_id, source_id) or 'unknown'} -> "
+            f"{entity_names.get(target_id, target_id) or 'unknown'}",
+        )
+        definition_schema.append({
+            "_mergeKey": f"ontology-relationship:{relationship_id}",
+            "name": name,
+            "objectType": "Ontology relationship",
+            "objectId": _fabric_object_id(
+                artifact.get("id"),
+                "ontology-relationship",
+                relationship_id,
+            ),
+            "sourceObjectId": entity_object_ids.get(source_id)
+            or _fabric_object_id(
+                artifact.get("id"),
+                "ontology-entity",
+                source_id,
+            ),
+            "targetObjectId": entity_object_ids.get(target_id)
+            or _fabric_object_id(
+                artifact.get("id"),
+                "ontology-entity",
+                target_id,
+            ),
+            "relation": "ontology relationship",
+            "source": "Fabric Ontology definition",
+            "description": (
+                f"{entity_names.get(source_id, source_id) or 'unknown'} -> "
+                f"{entity_names.get(target_id, target_id) or 'unknown'}"
+            ),
+            "columns": [],
+            "measures": [],
+        })
+        if source_id in entity_names and target_id in entity_names:
+            metadata_relationships.append({
+                "id": relationship_id,
+                "name": name,
+                "sourceEntityId": source_id,
+                "targetEntityId": target_id,
+            })
+
+    for relationship_id, contextualization_id, value in contextualization_parts:
+        relationship_id = _definition_identifier(relationship_id)
+        contextualization_id = _definition_identifier(
+            value.get("id"),
+            contextualization_id,
+        )
+        source = _source_metadata(value.get("dataBindingTable"))
+        if source:
+            source_id = source.get("itemId")
+            if source_id:
+                artifact.setdefault("_definitionSourceIds", set()).add(
+                    source_id
+                )
+            _add_definition_fact(
+                artifact,
+                "Ontology contextualizations",
+                f"{relationship_id}:{contextualization_id}",
+                _source_summary(source),
+            )
+            relationship_ref = _metadata_object_ref(
+                artifact.get("id"),
+                "relationshipType",
+                _fabric_object_id(
+                    artifact.get("id"),
+                    "ontology-relationship",
+                    relationship_id,
+                ),
+                relationship_names.get(relationship_id)
+                or relationship_id,
+            )
+            _add_artifact_object_edge(
+                artifact,
+                _source_object_reference(source),
+                relationship_ref,
+                "contextualizes relationship",
+            )
+            relationship = next(
+                (
+                    candidate
+                    for candidate in metadata_relationships
+                    if candidate["id"] == relationship_id
+                ),
+                None,
+            )
+            if (
+                relationship
+                and source.get("itemId")
+                and source.get("table")
+            ):
+                source_key_bindings = []
+                target_key_bindings = []
+                for raw_values, output, entity_key in (
+                    (
+                        value.get("sourceKeyRefBindings")
+                        or value.get("sourceKeyBindings"),
+                        source_key_bindings,
+                        "sourceEntityId",
+                    ),
+                    (
+                        value.get("targetKeyRefBindings")
+                        or value.get("targetKeyBindings"),
+                        target_key_bindings,
+                        "targetEntityId",
+                    ),
+                ):
+                    for binding in (
+                        raw_values
+                        if isinstance(raw_values, list)
+                        else []
+                    ):
+                        if not isinstance(binding, dict):
+                            continue
+                        source_column = _strict_text(
+                            binding.get("sourceColumnName")
+                            or binding.get("sourceColumn")
+                        )
+                        target_property_id = _definition_identifier(
+                            binding.get("targetPropertyId")
+                            or binding.get("propertyId")
+                        )
+                        if (
+                            source_column
+                            and (
+                                relationship[entity_key],
+                                target_property_id,
+                            ) in property_refs
+                        ):
+                            output.append({
+                                "sourceColumn": source_column,
+                                "targetPropertyId": target_property_id,
+                            })
+                metadata_contextualization = {
+                    "id": contextualization_id,
+                    "relationshipId": relationship_id,
+                    "sourceItemId": source["itemId"],
+                    "sourceObject": source["table"],
+                    "sourceKeyBindings": source_key_bindings,
+                    "targetKeyBindings": target_key_bindings,
+                }
+                for target_key, source_key in (
+                    ("sourceWorkspaceId", "workspaceId"),
+                    ("sourceType", "sourceType"),
+                    ("sourceSchema", "schema"),
+                    ("sourceObjectId", "sourceObjectId"),
+                ):
+                    if source.get(source_key):
+                        metadata_contextualization[target_key] = source[
+                            source_key
+                        ]
+                metadata_contextualizations.append(
+                    metadata_contextualization
+                )
+    artifact["_definitionSchema"] = _merge_schema_tables(
+        definition_schema
+    )
+    metadata_entities = _dedupe_metadata(
+        metadata_entities,
+        lambda value: value.get("id"),
+    )
+    metadata_relationships = _dedupe_metadata(
+        metadata_relationships,
+        lambda value: value.get("id"),
+    )
+    metadata_bindings = _dedupe_metadata(
+        metadata_bindings,
+        lambda value: value.get("id"),
+    )
+    metadata_contextualizations = _dedupe_metadata(
+        metadata_contextualizations,
+        lambda value: value.get("id"),
+    )
+    artifact["_artifactMetadata"] = {
+        "kind": "ontology",
+        "entities": metadata_entities,
+        "relationships": metadata_relationships,
+        "bindings": metadata_bindings,
+        "contextualizations": metadata_contextualizations,
+    }
+    artifact["_definitionUnknownParts"] = unknown
+
+
+def _onelake_source(value):
+    if not isinstance(value, dict):
+        return None
+    source = _source_metadata(value)
+    properties = value.get("properties")
+    properties = properties if isinstance(properties, dict) else {}
+    path = _strict_text(properties.get("path"))
+    if path:
+        match = re.search(
+            r"abfss://([0-9a-f-]{36})@onelake\.dfs\.fabric\.microsoft\.com/"
+            r"([0-9a-f-]{36})/(Tables|Files)/(.*)$",
+            path,
+            re.IGNORECASE,
+        )
+        if match:
+            source = source or {}
+            source["workspaceId"] = _normalized_id(match.group(1))
+            source["itemId"] = _normalized_id(match.group(2))
+            source["sourceType"] = _strict_text(value.get("type"))
+            source["table"] = _strict_text(match.group(4))
+    return source
+
+
+def _safe_graph_properties(values):
+    result = []
+    for value in (values or [])[:MAX_SCHEMA_COLUMNS_PER_OBJECT]:
+        if not isinstance(value, dict):
+            continue
+        name = _strict_text(value.get("name"))
+        data_type = _strict_text(value.get("type"))
+        if name:
+            result.append((name, data_type or "property"))
+    return result
+
+
+def _project_graph_definition(artifact, response):
+    decoded_total = [0]
+    known = {}
+    unknown = 0
+    known_paths = {
+        "graphtype.json": "graphType",
+        "graphdefinition.json": "graphDefinition",
+        "datasources.json": "dataSources",
+    }
+    for part in _definition_parts(response):
+        path = _strict_text(part.get("path"))
+        if not path:
+            raise DefinitionError("definition part path was invalid")
+        lower_path = path.replace("\\", "/").casefold()
+        if lower_path in (".platform", "stylingconfiguration.json"):
+            continue
+        name = known_paths.get(lower_path)
+        if not name:
+            unknown += 1
+            continue
+        _, value = _decode_definition_json(part, decoded_total)
+        known[name] = value
+        artifact.setdefault("_ontologyItemIds", set()).update(
+            _explicit_ids(
+                value,
+                (
+                    "ontologyId",
+                    "ontologyItemId",
+                    "sourceOntologyId",
+                    "sourceOntologyItemId",
+                    "generatedFromOntologyId",
+                    "generatedFromOntologyItemId",
+                ),
+            )
+        )
+
+    graph_type = known.get("graphType", {})
+    definition_schema = []
+    schema_by_alias = {}
+    metadata_node_types = []
+    metadata_edge_types = []
+    metadata_mappings = []
+    ontology_ids = artifact.get("_ontologyItemIds") or set()
+    ontology_item_id = (
+        next(iter(ontology_ids)) if len(ontology_ids) == 1 else None
+    )
+    for node in graph_type.get("nodeTypes") or []:
+        if not isinstance(node, dict):
+            continue
+        alias = _strict_text(node.get("alias"))
+        if not alias:
+            continue
+        properties = _safe_graph_properties(node.get("properties"))
+        labels = [
+            label
+            for label in node.get("labels") or []
+            if _strict_text(label)
+        ]
+        _add_definition_fact(
+            artifact,
+            "Graph node types",
+            alias,
+            f"{', '.join(labels) or 'unlabeled'} | "
+            f"{len(properties)} properties",
+        )
+        for name, data_type in properties:
+            _add_definition_fact(
+                artifact,
+                "Graph node properties",
+                f"{alias}.{name}",
+                data_type,
+            )
+        schema_record = {
+            "_mergeKey": f"graph-node:{alias}",
+            "name": alias,
+            "objectType": "Graph node",
+            "objectId": _fabric_object_id(
+                artifact.get("id"),
+                "graph-node",
+                alias,
+            ),
+            "source": "Fabric GraphModel definition",
+            "description": ", ".join(labels) if labels else None,
+            "columns": [
+                {
+                    "name": name,
+                    "dataType": data_type,
+                    "objectType": "Graph property",
+                }
+                for name, data_type in properties
+            ],
+            "measures": [],
+        }
+        metadata_node_types.append({
+            "alias": alias,
+            "labels": labels,
+            "primaryKeyProperties": [
+                key
+                for key in node.get("primaryKeyProperties") or []
+                if _strict_text(key)
+            ],
+            "properties": [
+                {"name": name, "dataType": data_type}
+                for name, data_type in properties
+            ],
+        })
+        ontology_entity_id = _exact_scalar_id(
+            node,
+            (
+                "ontologyEntityTypeId",
+                "sourceOntologyEntityTypeId",
+                "entityTypeId",
+            ),
+        )
+        if ontology_item_id and ontology_entity_id:
+            schema_record.update({
+                "sourceObjectId": _fabric_object_id(
+                    ontology_item_id,
+                    "ontology-entity",
+                    ontology_entity_id,
+                ),
+                "targetObjectId": schema_record["objectId"],
+                "relation": "generated graph node",
+                "sourceItemId": ontology_item_id,
+                "sourceObjectName": ontology_entity_id,
+                "sourceObjectType": "ontology-entity",
+            })
+        definition_schema.append(schema_record)
+        schema_by_alias[("node", alias)] = schema_record
+    for edge in graph_type.get("edgeTypes") or []:
+        if not isinstance(edge, dict):
+            continue
+        alias = _strict_text(edge.get("alias"))
+        if not alias:
+            continue
+        source = edge.get("sourceNodeType")
+        target = edge.get("destinationNodeType")
+        source_alias = (
+            _strict_text(source.get("alias"))
+            if isinstance(source, dict)
+            else None
+        )
+        target_alias = (
+            _strict_text(target.get("alias"))
+            if isinstance(target, dict)
+            else None
+        )
+        _add_definition_fact(
+            artifact,
+            "Graph edge types",
+            alias,
+            f"{source_alias or 'unknown'} -> {target_alias or 'unknown'} | "
+            f"{len(_safe_graph_properties(edge.get('properties')))} properties",
+        )
+        properties = _safe_graph_properties(edge.get("properties"))
+        schema_record = {
+            "_mergeKey": f"graph-edge:{alias}",
+            "name": alias,
+            "objectType": "Graph edge",
+            "objectId": _fabric_object_id(
+                artifact.get("id"),
+                "graph-edge",
+                alias,
+            ),
+            "source": "Fabric GraphModel definition",
+            "description": (
+                f"{source_alias or 'unknown'} -> "
+                f"{target_alias or 'unknown'}"
+            ),
+            "columns": [
+                {
+                    "name": name,
+                    "dataType": data_type,
+                    "objectType": "Graph property",
+                }
+                for name, data_type in properties
+            ],
+            "measures": [],
+        }
+        if source_alias and target_alias:
+            metadata_edge_types.append({
+                "alias": alias,
+                "labels": [
+                    label
+                    for label in edge.get("labels") or []
+                    if _strict_text(label)
+                ],
+                "sourceNodeType": source_alias,
+                "destinationNodeType": target_alias,
+                "properties": [
+                    {"name": name, "dataType": data_type}
+                    for name, data_type in properties
+                ],
+            })
+        ontology_relationship_id = _exact_scalar_id(
+            edge,
+            (
+                "ontologyRelationshipTypeId",
+                "sourceOntologyRelationshipTypeId",
+                "relationshipTypeId",
+            ),
+        )
+        if ontology_item_id and ontology_relationship_id:
+            schema_record.update({
+                "sourceObjectId": _fabric_object_id(
+                    ontology_item_id,
+                    "ontology-relationship",
+                    ontology_relationship_id,
+                ),
+                "targetObjectId": schema_record["objectId"],
+                "relation": "generated graph edge",
+                "sourceItemId": ontology_item_id,
+                "sourceObjectName": ontology_relationship_id,
+                "sourceObjectType": "ontology-relationship",
+            })
+        definition_schema.append(schema_record)
+        schema_by_alias[("edge", alias)] = schema_record
+
+    source_names = {}
+    metadata_data_sources = []
+    for source_value in known.get("dataSources", {}).get("dataSources") or []:
+        if not isinstance(source_value, dict):
+            continue
+        name = _strict_text(source_value.get("name"))
+        source = _onelake_source(source_value)
+        if not name or not source:
+            continue
+        source_names[name] = source
+        source_id = source.get("itemId")
+        if source_id:
+            artifact.setdefault("_definitionSourceIds", set()).add(source_id)
+        _add_definition_fact(
+            artifact,
+            "Graph data sources",
+            name,
+            _source_summary(source),
+        )
+        if source.get("itemId") and source.get("table"):
+            metadata_source = {
+                "name": name,
+                "sourceItemId": source["itemId"],
+                "sourceObject": source["table"],
+            }
+            for target_key, source_key in (
+                ("sourceWorkspaceId", "workspaceId"),
+                ("sourceObjectId", "sourceObjectId"),
+                ("sourceType", "sourceType"),
+            ):
+                if source.get(source_key):
+                    metadata_source[target_key] = source[source_key]
+            metadata_data_sources.append(metadata_source)
+
+    graph_definition = known.get("graphDefinition", {})
+    for collection, section, alias_field in (
+        ("nodeTables", "Graph node mappings", "nodeTypeAlias"),
+        ("edgeTables", "Graph edge mappings", "edgeTypeAlias"),
+    ):
+        for mapping in graph_definition.get(collection) or []:
+            if not isinstance(mapping, dict):
+                continue
+            alias = _strict_text(mapping.get(alias_field))
+            data_source_name = _strict_text(mapping.get("dataSourceName"))
+            if not alias or not data_source_name:
+                continue
+            property_mappings = mapping.get("propertyMappings")
+            count = (
+                len(property_mappings)
+                if isinstance(property_mappings, list)
+                else 0
+            )
+            _add_definition_fact(
+                artifact,
+                section,
+                alias,
+                f"{data_source_name} | {count} property mappings",
+            )
+            kind = "node" if collection == "nodeTables" else "edge"
+            schema_record = schema_by_alias.get((kind, alias))
+            if schema_record:
+                schema_record["source"] = (
+                    "Fabric GraphModel definition | "
+                    f"{data_source_name}"
+                )
+                source = source_names.get(data_source_name)
+                target_kind = (
+                    "nodeType" if kind == "node" else "edgeType"
+                )
+                target_object_kind = (
+                    "graph-node" if kind == "node" else "graph-edge"
+                )
+                target_ref = _metadata_object_ref(
+                    artifact.get("id"),
+                    target_kind,
+                    schema_record.get("objectId")
+                    or _fabric_object_id(
+                        artifact.get("id"),
+                        target_object_kind,
+                        alias,
+                    ),
+                    alias,
+                )
+                _add_artifact_object_edge(
+                    artifact,
+                    _source_object_reference(source),
+                    target_ref,
+                    "maps node" if kind == "node" else "maps edge",
+                )
+                for property_mapping in (
+                    property_mappings
+                    if isinstance(property_mappings, list)
+                    else []
+                ):
+                    if not isinstance(property_mapping, dict):
+                        continue
+                    property_name = _strict_text(
+                        property_mapping.get("propertyName")
+                    )
+                    if not property_name:
+                        continue
+                    _add_artifact_object_edge(
+                        artifact,
+                        _source_column_reference(
+                            source,
+                            property_mapping.get("sourceColumn"),
+                        ),
+                        _metadata_object_ref(
+                            artifact.get("id"),
+                            "property",
+                            _fabric_object_id(
+                                artifact.get("id"),
+                                "graph-property",
+                                f"{alias}/{property_name}",
+                            ),
+                            property_name,
+                            parent_id=target_ref["id"]
+                            if target_ref
+                            else None,
+                            table_name=alias,
+                        ),
+                        "maps property",
+                    )
+                source = source_names.get(data_source_name)
+                property_names = {
+                    name
+                    for name, _ in _safe_graph_properties(
+                        next(
+                            (
+                                candidate.get("properties")
+                                for candidate in (
+                                    graph_type.get("nodeTypes")
+                                    if kind == "node"
+                                    else graph_type.get("edgeTypes")
+                                ) or []
+                                if isinstance(candidate, dict)
+                                and _strict_text(candidate.get("alias"))
+                                == alias
+                            ),
+                            [],
+                        )
+                    )
+                }
+                safe_mappings = []
+                for property_mapping in (
+                    property_mappings
+                    if isinstance(property_mappings, list)
+                    else []
+                ):
+                    if not isinstance(property_mapping, dict):
+                        continue
+                    property_name = _strict_text(
+                        property_mapping.get("propertyName")
+                    )
+                    source_column = _strict_text(
+                        property_mapping.get("sourceColumn")
+                    )
+                    if (
+                        property_name in property_names
+                        and source_column
+                    ):
+                        safe_mappings.append({
+                            "propertyName": property_name,
+                            "sourceColumn": source_column,
+                        })
+                mapping_id = _definition_identifier(
+                    mapping.get("id"),
+                    f"{kind}:{alias}",
+                )
+                if (
+                    mapping_id
+                    and source
+                    and source.get("itemId")
+                    and source.get("table")
+                ):
+                    metadata_mapping = {
+                        "id": mapping_id,
+                        "kind": kind,
+                        "typeAlias": alias,
+                        "dataSourceName": data_source_name,
+                        "sourceItemId": source["itemId"],
+                        "sourceObject": source["table"],
+                        "propertyMappings": safe_mappings,
+                    }
+                    for target_key, source_key in (
+                        ("sourceWorkspaceId", "workspaceId"),
+                        ("sourceObjectId", "sourceObjectId"),
+                    ):
+                        if source.get(source_key):
+                            metadata_mapping[target_key] = source[source_key]
+                    if kind == "edge":
+                        metadata_mapping["sourceNodeKeyColumns"] = [
+                            value
+                            for value in mapping.get(
+                                "sourceNodeKeyColumns"
+                            ) or []
+                            if _strict_text(value)
+                        ]
+                        metadata_mapping[
+                            "destinationNodeKeyColumns"
+                        ] = [
+                            value
+                            for value in mapping.get(
+                                "destinationNodeKeyColumns"
+                            ) or []
+                            if _strict_text(value)
+                        ]
+                    metadata_mappings.append(metadata_mapping)
+    artifact["_definitionSchema"] = _merge_schema_tables(
+        definition_schema
+    )
+    metadata_data_sources = _dedupe_metadata(
+        metadata_data_sources,
+        lambda value: value.get("name"),
+    )
+    metadata_node_types = _dedupe_metadata(
+        metadata_node_types,
+        lambda value: value.get("alias"),
+    )
+    metadata_edge_types = _dedupe_metadata(
+        metadata_edge_types,
+        lambda value: value.get("alias"),
+    )
+    metadata_mappings = _dedupe_metadata(
+        metadata_mappings,
+        lambda value: value.get("id"),
+    )
+    node_aliases = {
+        node["alias"]
+        for node in metadata_node_types
+    }
+    metadata_edge_types = [
+        edge
+        for edge in metadata_edge_types
+        if edge["sourceNodeType"] in node_aliases
+        and edge["destinationNodeType"] in node_aliases
+    ]
+    edge_aliases = {
+        edge["alias"]
+        for edge in metadata_edge_types
+    }
+    metadata_mappings = [
+        mapping
+        for mapping in metadata_mappings
+        if (
+            mapping["kind"] == "node"
+            and mapping["typeAlias"] in node_aliases
+        )
+        or (
+            mapping["kind"] == "edge"
+            and mapping["typeAlias"] in edge_aliases
+        )
+    ]
+    artifact["_artifactMetadata"] = {
+        "kind": "graphModel",
+        "dataSources": metadata_data_sources,
+        "nodeTypes": metadata_node_types,
+        "edgeTypes": metadata_edge_types,
+        "mappings": metadata_mappings,
+    }
+    artifact["_definitionUnknownParts"] = unknown
+
+
+def _data_agent_source_object_kind(source_type, element_type):
+    source = (_strict_text(source_type) or "").casefold()
+    element = (_strict_text(element_type) or "").casefold()
+    if source == "ontology":
+        if element in ("ontology.entity", "graph.nodetype"):
+            return "ontology-entity"
+        if element in ("ontology.relationship", "graph.edgetype"):
+            return "ontology-relationship"
+        if element in (
+            "ontology.property",
+            "ontology.timeseriesproperty",
+            "graph.property",
+        ):
+            return "ontology-property"
+    if source == "graph":
+        if element == "graph.nodetype":
+            return "graph-node"
+        if element == "graph.edgetype":
+            return "graph-edge"
+        if element == "graph.property":
+            return "graph-property"
+    mappings = {
+        "lakehouse_tables.table": "lakehouse-table",
+        "lakehouse_tables.column": "lakehouse-table-column",
+        "warehouse_tables.table": "warehouse-table",
+        "warehouse_tables.column": "warehouse-table-column",
+        "kusto.table": "kql-table",
+        "kusto.column": "kql-table-column",
+        "kusto.function": "kql-function",
+        "kusto.materializedview": "kql-materialized-view",
+        "semantic_model.table": "semantic-model-table",
+        "semantic_model.column": "semantic-model-table-column",
+        "semantic_model.measure": "semantic-model-measure",
+        "mirrored_database.table": "table",
+        "mirrored_database.column": "table-column",
+        "graph.nodetype": "graph-node",
+        "graph.edgetype": "graph-edge",
+        "graph.property": "graph-property",
+    }
+    return mappings.get(element)
+
+
+def _source_element_identity(
+    source_type,
+    element_type,
+    element_id,
+    display_name,
+    parent_identity,
+):
+    source = (_strict_text(source_type) or "").casefold()
+    element = (_strict_text(element_type) or "").casefold()
+    if source in ("ontology", "graph") and element_id:
+        return element_id
+    if element.endswith(".table"):
+        return (
+            f"{parent_identity}.{display_name}"
+            if parent_identity
+            else display_name
+        )
+    if (
+        element.endswith(".column")
+        or element.endswith(".measure")
+    ) and parent_identity:
+        return f"{parent_identity}/{display_name}"
+    return "/".join(
+        value for value in (parent_identity, display_name) if value
+    )
+
+
+def _data_agent_group_identity(element_type, display_name, parent_identity):
+    element = (_strict_text(element_type) or "").casefold()
+    if element.endswith(".schema"):
+        return ".".join(
+            value for value in (parent_identity, display_name) if value
+        )
+    return parent_identity
+
+
+def _selected_element_facts(
+    artifact,
+    source_name,
+    elements,
+    source_id=None,
+    source_type=None,
+    target_object_id=None,
+    parent_display="",
+    parent_identity="",
+    parent_source_kind=None,
+    parent_source_object_id=None,
+    parent_target_object_id=None,
+    table_name=None,
+    parent_path=None,
+    selected_elements=None,
+    metadata_elements=None,
+    metadata_parent_id=None,
+    metadata_parent_name=None,
+    metadata_budget=None,
+    state=None,
+):
+    for element in elements or []:
+        if not isinstance(element, dict):
+            continue
+        display_name = _bounded_text(
+            element.get("display_name") or element.get("displayName")
+        )
+        element_type = _strict_text(element.get("type"))
+        element_data_type = _strict_text(
+            element.get("data_type") or element.get("dataType")
+        )
+        selected = element.get("is_selected")
+        if display_name:
+            display_path = " / ".join(
+                value for value in (parent_display, display_name) if value
+            )
+            element_id = _definition_identifier(element.get("id"))
+            source_identity = _source_element_identity(
+                source_type,
+                element_type,
+                element_id,
+                display_name,
+                parent_identity,
+            )
+            source_object_type = _data_agent_source_object_kind(
+                source_type,
+                element_type,
+            )
+            _add_definition_fact(
+                artifact,
+                "Data agent selected elements",
+                f"{source_name}:{display_path}",
+                f"{element_type or 'element'} | selected "
+                f"{'yes' if selected is True else 'no'}",
+            )
+            next_parent_identity = source_identity
+            next_parent_source_kind = source_object_type
+            next_parent_source_object_id = (
+                _fabric_object_id(
+                    source_id,
+                    source_object_type,
+                    source_identity,
+                )
+                if source_object_type
+                else parent_source_object_id
+            )
+            next_table_name = table_name
+            if (
+                source_object_type
+                and _metadata_source_kind(source_object_type)
+                in ("table", "view", "materializedView")
+            ):
+                next_table_name = source_identity
+            next_parent_target_id = parent_target_object_id
+            next_parent_path = list(parent_path or [])
+            next_metadata_elements = metadata_elements
+            next_metadata_parent_id = metadata_parent_id
+            next_metadata_parent_name = metadata_parent_name
+            if (
+                selected is True
+                and source_object_type
+                and selected_elements is not None
+            ):
+                if metadata_budget is not None:
+                    metadata_budget["count"] += 1
+                    if (
+                        metadata_budget["count"]
+                        > MAX_ARTIFACT_METADATA_ELEMENTS
+                    ):
+                        artifact["_artifactMetadataTruncated"] = True
+                        return
+                selected_object_id = _fabric_object_id(
+                    artifact.get("id"),
+                    "data-agent-selected-element",
+                    (
+                        f"{source_id or source_name}/"
+                        f"{element_id or source_identity}"
+                    ),
+                )
+                selected_elements.append({
+                    "name": display_name,
+                    "dataType": element_data_type
+                    or element_type
+                    or "element",
+                    "objectType": "Data Agent selected element",
+                    "objectId": selected_object_id,
+                    "parentObjectId": (
+                        parent_target_object_id or target_object_id
+                    ),
+                    "parentPath": list(next_parent_path),
+                    "tableName": next_table_name,
+                    "sourceObjectId": _fabric_object_id(
+                        source_id,
+                        source_object_type,
+                        source_identity,
+                    ),
+                    "sourceParentObjectId": parent_source_object_id,
+                    "sourceParentPath": list(next_parent_path),
+                    "sourceTableName": next_table_name,
+                    "targetObjectId": selected_object_id,
+                    "relation": "selected by data agent",
+                    "sourceItemId": source_id,
+                    "sourceObjectName": display_name,
+                    "sourceObjectType": source_object_type,
+                })
+                if metadata_elements is not None and element_id:
+                    metadata_element = {
+                        "id": element_id,
+                        "displayName": display_name,
+                        "elementType": element_type,
+                        "selected": True,
+                        "sourceArtifactId": source_id,
+                        "parentPath": list(next_parent_path),
+                        "children": [],
+                    }
+                    if element_data_type:
+                        metadata_element["dataType"] = element_data_type
+                    if metadata_parent_id:
+                        metadata_element["parentId"] = metadata_parent_id
+                    if metadata_parent_name:
+                        metadata_element["parentName"] = metadata_parent_name
+                    index_state = _strict_text(
+                        element.get("index_state")
+                        or element.get("indexState")
+                    )
+                    if index_state:
+                        metadata_element["indexState"] = index_state
+                    if state:
+                        metadata_element["state"] = state
+                    metadata_elements.append(metadata_element)
+                    next_metadata_elements = metadata_element["children"]
+                    next_metadata_parent_id = element_id
+                    next_metadata_parent_name = display_name
+                next_parent_target_id = selected_object_id
+                next_parent_path.append(display_name)
+            elif not source_object_type:
+                next_parent_identity = _data_agent_group_identity(
+                    element_type,
+                    display_name,
+                    parent_identity,
+                )
+                next_parent_source_kind = parent_source_kind
+                next_parent_source_object_id = parent_source_object_id
+            children = element.get("children")
+            if isinstance(children, list):
+                _selected_element_facts(
+                    artifact,
+                    source_name,
+                    children,
+                    source_id=source_id,
+                    source_type=source_type,
+                    target_object_id=target_object_id,
+                    parent_display=display_path,
+                    parent_identity=next_parent_identity,
+                    parent_source_kind=next_parent_source_kind,
+                    parent_source_object_id=next_parent_source_object_id,
+                    parent_target_object_id=next_parent_target_id,
+                    table_name=next_table_name,
+                    parent_path=next_parent_path,
+                    selected_elements=selected_elements,
+                    metadata_elements=next_metadata_elements,
+                    metadata_parent_id=next_metadata_parent_id,
+                    metadata_parent_name=next_metadata_parent_name,
+                    metadata_budget=metadata_budget,
+                    state=state,
+                )
+
+
+def _flatten_data_agent_elements(elements):
+    flattened = []
+    for element in elements or []:
+        if not isinstance(element, dict):
+            continue
+        flattened.append(element)
+        flattened.extend(
+            _flatten_data_agent_elements(element.get("children"))
+        )
+    return flattened
+
+
+def _project_data_agent_definition(artifact, response):
+    decoded_total = [0]
+    unknown = 0
+    stages = set()
+    published_description = None
+    definition_schema = []
+    metadata_sources = {}
+    metadata_source_order = []
+    for part in _definition_parts(response):
+        path = _strict_text(part.get("path"))
+        if not path:
+            raise DefinitionError("definition part path was invalid")
+        normalized_path = path.replace("\\", "/")
+        lower_path = normalized_path.casefold()
+        if lower_path in (
+            ".platform",
+            "dataagentv1.json",
+            "files/config/data_agent.json",
+        ):
+            continue
+        if lower_path.endswith("/fewshots.json"):
+            continue
+        if lower_path == "files/config/publish_info.json":
+            _, value = _decode_definition_json(part, decoded_total)
+            published_description = _strict_text(value.get("description"))
+            continue
+        stage_match = re.fullmatch(
+            r"Files/Config/(draft|published)/stage_config\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if stage_match:
+            stages.add(stage_match.group(1).casefold())
+            continue
+        source_match = re.fullmatch(
+            r"Files/Config/(draft|published)/[^/]+/datasource\.json",
+            normalized_path,
+            re.IGNORECASE,
+        )
+        if source_match:
+            stage = source_match.group(1).casefold()
+            stages.add(stage)
+            _, value = _decode_definition_json(part, decoded_total)
+            source_id = _normalized_id(value.get("artifactId"))
+            source_name = _bounded_text(value.get("displayName")) or (
+                source_id or "source"
+            )
+            source_type = _strict_text(value.get("type")) or "unknown"
+            if source_id:
+                artifact.setdefault("_definitionSourceIds", set()).add(
+                    source_id
+                )
+            _add_definition_fact(
+                artifact,
+                "Data agent sources",
+                f"{stage}:{source_name}",
+                f"{source_type} | {source_id or 'external source'}",
+            )
+            agent_source_object_id = _fabric_object_id(
+                artifact.get("id"),
+                "data-agent-source",
+                f"{stage}/{source_id or source_name}",
+            )
+            elements = value.get("elements")
+            selected_elements = []
+            metadata_elements = []
+            metadata_budget = {"count": 0}
+            if isinstance(elements, list):
+                _selected_element_facts(
+                    artifact,
+                    f"{stage}:{source_name}",
+                    elements,
+                    source_id=source_id,
+                    source_type=source_type,
+                    target_object_id=agent_source_object_id,
+                    selected_elements=selected_elements,
+                    metadata_elements=metadata_elements,
+                    metadata_budget=metadata_budget,
+                    state=stage,
+                )
+            definition_schema.append({
+                "_mergeKey": (
+                    f"data-agent-source:{stage}:"
+                    f"{source_id or source_name}"
+                ),
+                "name": f"{stage}:{source_name}",
+                "objectType": "Data Agent source",
+                "objectId": agent_source_object_id,
+                "source": "Fabric DataAgent definition",
+                "description": (
+                    f"{source_type} | {source_id or 'external source'}"
+                ),
+                "columns": selected_elements,
+                "measures": [],
+            })
+            if source_id:
+                metadata_source = {
+                    "artifactId": source_id,
+                    "displayName": source_name,
+                    "sourceType": source_type,
+                    "elements": metadata_elements,
+                    "selectedElements": [
+                        {
+                            key: field
+                            for key, field in {
+                                "id": element.get("id"),
+                                "displayName": element.get("displayName"),
+                                "elementType": element.get("elementType"),
+                                "sourceArtifactId": element.get(
+                                    "sourceArtifactId"
+                                ),
+                                "dataType": element.get("dataType"),
+                                "parentId": element.get("parentId"),
+                                "parentName": element.get("parentName"),
+                                "parentPath": element.get("parentPath"),
+                                "state": element.get("state"),
+                                "indexState": element.get("indexState"),
+                            }.items()
+                            if field is not None
+                        }
+                        for element in _flatten_data_agent_elements(
+                            metadata_elements
+                        )
+                    ],
+                    "_stage": stage,
+                }
+                workspace_id = _normalized_id(value.get("workspaceId"))
+                if workspace_id:
+                    metadata_source["workspaceId"] = workspace_id
+                existing = metadata_sources.get(source_id)
+                if existing is None:
+                    metadata_source_order.append(source_id)
+                if (
+                    existing is None
+                    or existing.get("_stage") != "published"
+                    and stage == "published"
+                ):
+                    metadata_sources[source_id] = metadata_source
+            continue
+        unknown += 1
+    _add_definition_fact(
+        artifact,
+        "Data agent",
+        "State",
+        "published" if "published" in stages else "draft",
+    )
+    if published_description:
+        _add_definition_fact(
+            artifact,
+            "Data agent",
+            "Published description",
+            published_description,
+        )
+    artifact["_definitionSchema"] = _merge_schema_tables(
+        definition_schema
+    )
+    artifact["_artifactMetadata"] = {
+        "kind": "dataAgent",
+        "sources": [
+            {
+                key: value
+                for key, value in metadata_sources[source_id].items()
+                if key != "_stage"
+            }
+            for source_id in metadata_source_order
+        ],
+    }
+    artifact["_definitionUnknownParts"] = unknown
+
+
+def _project_definition(artifact, response):
+    artifact_type = artifact.get("_type")
+    if artifact_type == "Ontology":
+        _project_ontology_definition(artifact, response)
+    elif artifact_type == "GraphModel":
+        _project_graph_definition(artifact, response)
+    elif artifact_type == "DataAgent":
+        _project_data_agent_definition(artifact, response)
+    else:
+        raise DefinitionError("definition type was unsupported")
+
+
+def _kusto_url(value):
+    text = _strict_text(value)
+    if not text:
+        raise ValueError("KQL query service URI was missing")
+    parsed = urllib.parse.urlparse(text)
+    host = (parsed.hostname or "").casefold()
+    if (
+        parsed.scheme != "https"
+        or (
+            not host.endswith(".kusto.fabric.microsoft.com")
+            and not host.endswith(".kusto.windows.net")
+        )
+    ):
+        raise ValueError("KQL query service URI used an unexpected origin")
+    return text.rstrip("/") + "/v1/rest/mgmt"
+
+
+def _json_documents(value):
+    documents = []
+    if isinstance(value, dict):
+        if isinstance(value.get("Databases"), dict):
+            documents.append(value)
+        for table in value.get("Tables") or []:
+            if not isinstance(table, dict):
+                continue
+            for row in table.get("Rows") or []:
+                if not isinstance(row, list):
+                    continue
+                for cell in row:
+                    if not isinstance(cell, str):
+                        continue
+                    try:
+                        parsed = json.loads(cell)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(parsed, dict):
+                        documents.extend(_json_documents(parsed))
+    return documents
+
+
+def _kusto_entities(database, name):
+    values = database.get(name)
+    if isinstance(values, dict):
+        return [
+            (key, value)
+            for key, value in values.items()
+            if isinstance(value, dict)
+        ]
+    if isinstance(values, list):
+        return [
+            (_strict_text(value.get("Name")) or "", value)
+            for value in values
+            if isinstance(value, dict)
+        ]
+    return []
+
+
+def _kusto_schema(response, database_name):
+    documents = _json_documents(response)
+    if not documents:
+        raise ValueError("KQL schema response omitted database metadata")
+    databases = documents[0]["Databases"]
+    database = next(
+        (
+            value
+            for key, value in databases.items()
+            if str(key).casefold() == database_name.casefold()
+            and isinstance(value, dict)
+        ),
+        None,
+    )
+    if database is None and len(databases) == 1:
+        database = next(iter(databases.values()))
+    if not isinstance(database, dict):
+        raise ValueError("KQL schema response omitted the requested database")
+
+    tables = []
+    for collection, object_type in (
+        ("Tables", "KQL table"),
+        ("ExternalTables", "KQL external table"),
+        ("MaterializedViews", "KQL materialized view"),
+    ):
+        for key, value in _kusto_entities(database, collection):
+            if len(tables) >= MAX_SCHEMA_OBJECTS_PER_ITEM:
+                break
+            name = _strict_text(value.get("Name")) or _strict_text(key)
+            schema = value.get("Schema")
+            schema = schema if isinstance(schema, dict) else value
+            ordered_columns = schema.get("OrderedColumns")
+            columns = []
+            for column in (
+                ordered_columns if isinstance(ordered_columns, list) else []
+            )[:MAX_SCHEMA_COLUMNS_PER_OBJECT]:
+                if not isinstance(column, dict):
+                    continue
+                column_name = _strict_text(column.get("Name"))
+                if not column_name:
+                    continue
+                columns.append({
+                    "name": column_name,
+                    "dataType": _strict_text(
+                        column.get("CslType") or column.get("Type")
+                    ) or "column",
+                })
+            if name:
+                tables.append({
+                    "_mergeKey": f"{collection}:{name}",
+                    "name": name,
+                    "objectType": object_type,
+                    "source": "Kusto read-only management API",
+                    "columns": columns,
+                    "measures": [],
+                })
+    functions = []
+    for key, value in _kusto_entities(
+        database,
+        "Functions",
+    )[:MAX_SCHEMA_OBJECTS_PER_ITEM]:
+        name = _strict_text(value.get("Name")) or _strict_text(key)
+        if not name:
+            continue
+        parameters = []
+        raw_parameters = (
+            value.get("Parameters")
+            or value.get("InputParameters")
+            or []
+        )
+        for parameter in (
+            raw_parameters if isinstance(raw_parameters, list) else []
+        )[:MAX_ARTIFACT_METADATA_COLLECTION]:
+            if not isinstance(parameter, dict):
+                continue
+            parameter_name = _strict_text(
+                parameter.get("Name") or parameter.get("name")
+            )
+            data_type = _strict_text(
+                parameter.get("CslType")
+                or parameter.get("Type")
+                or parameter.get("dataType")
+            )
+            if parameter_name and data_type:
+                parameters.append({
+                    "name": parameter_name,
+                    "dataType": data_type,
+                })
+        metadata = {"name": name, "parameters": parameters}
+        for output_key, source_keys in (
+            ("folder", ("Folder", "folder")),
+            ("description", ("DocString", "Description", "description")),
+            ("returnType", ("ReturnType", "returnType")),
+        ):
+            candidate = next(
+                (
+                    _bounded_text(
+                        value.get(source_key),
+                        512 if output_key == "description" else 256,
+                    )
+                    for source_key in source_keys
+                    if _strict_text(value.get(source_key))
+                ),
+                None,
+            )
+            if candidate:
+                metadata[output_key] = candidate
+        functions.append(metadata)
+
+    materialized_views = []
+    for key, value in _kusto_entities(
+        database,
+        "MaterializedViews",
+    )[:MAX_SCHEMA_OBJECTS_PER_ITEM]:
+        name = _strict_text(value.get("Name")) or _strict_text(key)
+        if not name:
+            continue
+        schema = value.get("Schema")
+        schema = schema if isinstance(schema, dict) else value
+        columns = []
+        for column in (
+            schema.get("OrderedColumns")
+            if isinstance(schema.get("OrderedColumns"), list)
+            else []
+        )[:MAX_SCHEMA_COLUMNS_PER_OBJECT]:
+            if not isinstance(column, dict):
+                continue
+            column_name = _strict_text(column.get("Name"))
+            data_type = _strict_text(
+                column.get("CslType") or column.get("Type")
+            )
+            if column_name and data_type:
+                columns.append({
+                    "name": column_name,
+                    "dataType": data_type,
+                })
+        metadata = {"name": name, "columns": columns}
+        source_table = _strict_text(
+            value.get("SourceTable")
+            or value.get("SourceTableName")
+        )
+        description = _bounded_text(
+            value.get("DocString")
+            or value.get("Description"),
+            512,
+        )
+        if source_table:
+            metadata["sourceTable"] = source_table
+        if description:
+            metadata["description"] = description
+        materialized_views.append(metadata)
+
+    for function in functions:
+        if len(tables) >= MAX_SCHEMA_OBJECTS_PER_ITEM:
+            break
+        tables.append({
+                "_mergeKey": f"Functions:{function['name']}",
+                "name": function["name"],
+                "objectType": "KQL function",
+                "source": "Kusto read-only management API",
+                "columns": [],
+                "measures": [],
+            })
+    functions = _dedupe_metadata(
+        functions,
+        lambda value: value.get("name"),
+    )
+    materialized_views = _dedupe_metadata(
+        materialized_views,
+        lambda value: value.get("name"),
+    )
+    return (
+        _merge_schema_tables(tables),
+        sorted(functions, key=lambda value: value["name"].casefold()),
+        sorted(
+            materialized_views,
+            key=lambda value: value["name"].casefold(),
+        ),
+    )
+
+
+def _collect_kql_schema(token, artifact):
+    detail = artifact.get("_detail")
+    detail = detail if isinstance(detail, dict) else {}
+    properties = detail.get("properties")
+    properties = properties if isinstance(properties, dict) else {}
+    database_name = (
+        _strict_text(properties.get("databaseName"))
+        or _strict_text(detail.get("displayName"))
+        or _strict_text(artifact.get("displayName"))
+    )
+    query_service_uri = _strict_text(properties.get("queryServiceUri"))
+    if not database_name or not query_service_uri:
+        raise ValueError("KQL database identity was incomplete")
+    escaped_name = database_name.replace("'", "''")
+    response = _req(
+        token,
+        _kusto_url(query_service_uri),
+        method="POST",
+        body={
+            "db": database_name,
+            "csl": (
+                f".show database ['{escaped_name}'] schema as json "
+                "with(Tables=True,ExternalTables=True,"
+                "MaterializedViews=True,Functions=True)"
+            ),
+        },
+        headers={
+            "Accept": "application/json",
+            "x-ms-readonly": "true",
+            "x-ms-app": "Fabric Atlas",
+        },
+    )
+    schema, functions, materialized_views = _kusto_schema(
+        response,
+        database_name,
+    )
+    artifact["_kqlSchema"] = schema
+    artifact["_kqlFunctions"] = functions
+    artifact["_kqlMaterializedViews"] = materialized_views
+    artifact["_artifactMetadata"] = {
+        "kind": "kql",
+        "functions": functions,
+        "materializedViews": materialized_views,
+    }
+
+
+def _sql_endpoint(value):
+    text = _strict_text(value)
+    if not text or any(
+        character in text
+        for character in ("\x00", "\r", "\n", ";", "{", "}")
+    ):
+        raise ValueError("SQL server endpoint was invalid")
+    if "://" in text:
+        parsed = urllib.parse.urlparse(text)
+        if (
+            parsed.scheme.casefold() != "https"
+            or parsed.username
+            or parsed.password
+            or parsed.path not in ("", "/")
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("SQL server endpoint was invalid")
+        host = parsed.hostname
+        try:
+            port = parsed.port or 1433
+        except ValueError as error:
+            raise ValueError("SQL server endpoint port was invalid") from error
+    else:
+        endpoint = text[4:] if text.casefold().startswith("tcp:") else text
+        if endpoint.count(",") > 1:
+            raise ValueError("SQL server endpoint was invalid")
+        host, separator, raw_port = endpoint.rpartition(",")
+        if not separator:
+            host = endpoint
+            raw_port = "1433"
+        try:
+            port = int(raw_port)
+        except ValueError as error:
+            raise ValueError("SQL server endpoint port was invalid") from error
+    host = _strict_text(host)
+    labels = host.casefold().split(".") if host else []
+    if (
+        not host
+        or not re.fullmatch(r"[A-Za-z0-9.-]+", host)
+        or any(
+            not re.fullmatch(
+                r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?",
+                label,
+            )
+            for label in labels
+        )
+        or not host.casefold().endswith(".database.fabric.microsoft.com")
+        or host.casefold() == "database.fabric.microsoft.com"
+        or port != 1433
+    ):
+        raise ValueError("SQL server endpoint used an unexpected origin")
+    return host.casefold(), port
+
+
+def _sql_database_name(value):
+    text = _strict_text(value)
+    if (
+        not text
+        or len(text) > 128
+        or any(
+            character in text
+            for character in ("\x00", "\r", "\n", ";", "{", "}")
+        )
+    ):
+        raise ValueError("SQL database name was invalid")
+    return text
+
+
+def _pack_sql_access_token(token):
+    text = _strict_text(token)
+    if (
+        not text
+        or len(text) < 32
+        or len(text) > MAX_SQL_TOKEN_CHARACTERS
+        or any(ord(character) < 32 for character in text)
+    ):
+        raise ValueError("SQL access token was invalid")
+    token_bytes = text.encode("utf-16le")
+    return struct.pack(
+        f"<I{len(token_bytes)}s",
+        len(token_bytes),
+        token_bytes,
+    )
+
+
+def _sql_timeout_seconds(deadline):
+    remaining = deadline.remaining()
+    if remaining < 1:
+        raise DeadlineExceeded("execution deadline exhausted")
+    return max(
+        1,
+        min(REQUEST_TIMEOUT_SECONDS, int(math.floor(remaining))),
+    )
+
+
+def _load_mssql_driver():
+    try:
+        return importlib.import_module("mssql_python")
+    except (ImportError, ModuleNotFoundError, OSError) as error:
+        raise SqlRuntimeUnavailable(
+            "mssql-python runtime was unavailable"
+        ) from error
+
+
+def _sql_connect(driver, connection_string, token, timeout):
+    try:
+        return driver.connect(
+            connection_string,
+            autocommit=True,
+            attrs_before={
+                SQL_COPT_SS_ACCESS_TOKEN: _pack_sql_access_token(token),
+            },
+            timeout=timeout,
+        )
+    except (ImportError, ModuleNotFoundError, OSError) as error:
+        raise SqlRuntimeUnavailable(
+            "mssql-python native runtime was unavailable"
+        ) from error
+    except Exception as error:
+        message = str(error).casefold()
+        if (
+            "28000" in message
+            or "18456" in message
+            or "login failed" in message
+            or "authentication" in message
+        ):
+            raise SqlAuthorizationError(
+                "SQL authentication failed"
+            ) from error
+        raise SqlConnectionError("SQL connection failed") from error
+
+
+def _sql_fetch_rows(connection, query, limit, deadline):
+    cursor = None
+    active_error = None
+    try:
+        connection.timeout = _sql_timeout_seconds(deadline)
+        cursor = connection.cursor()
+        cursor.execute(query)
+        rows = list(cursor.fetchmany(limit + 1))
+        if len(rows) > limit:
+            raise ResponseSizeExceeded(
+                "SQL catalog response exceeded the safe row limit"
+            )
+        return rows
+    except (DeadlineExceeded, ResponseSizeExceeded) as error:
+        active_error = error
+        raise
+    except Exception as error:
+        active_error = error
+        raise SqlCatalogQueryError(
+            "SQL catalog query failed"
+        ) from error
+    finally:
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception as error:
+                if active_error is None:
+                    raise SqlCatalogQueryError(
+                        "SQL catalog cursor cleanup failed"
+                    ) from error
+
+
+def _sql_catalog_projection(object_rows, primary_key_rows, foreign_key_rows):
+    def row_values(row, minimum):
+        if isinstance(row, (str, bytes, bytearray, dict)):
+            raise ValueError("SQL catalog row was invalid")
+        try:
+            if len(row) < minimum:
+                raise ValueError("SQL catalog row was invalid")
+            return [row[index] for index in range(minimum)]
+        except (TypeError, IndexError) as error:
+            raise ValueError("SQL catalog row was invalid") from error
+
+    def ordinal(value):
+        return (
+            int(value)
+            if isinstance(value, numbers.Integral)
+            and not isinstance(value, bool)
+            else 0
+        )
+
+    objects = {}
+    order = []
+    for row in object_rows:
+        values = row_values(row, 6)
+        schema_name = _strict_text(values[0])
+        object_name = _strict_text(values[1])
+        object_code = _strict_text(values[2])
+        if (
+            not schema_name
+            or not object_name
+            or object_code not in ("U", "V")
+        ):
+            raise ValueError("SQL catalog object identity was invalid")
+        key = (schema_name.casefold(), object_name.casefold(), object_code)
+        if key not in objects:
+            if len(objects) >= MAX_SCHEMA_OBJECTS_PER_ITEM:
+                raise ResponseSizeExceeded(
+                    "SQL catalog exceeded the safe object limit"
+                )
+            objects[key] = {
+                "schema": schema_name,
+                "name": object_name,
+                "objectType": (
+                    "SQL table" if object_code == "U" else "SQL view"
+                ),
+                "columns": [],
+            }
+            order.append(key)
+        column_name = _strict_text(values[3])
+        if column_name:
+            columns = objects[key]["columns"]
+            if len(columns) >= MAX_SCHEMA_COLUMNS_PER_OBJECT:
+                raise ResponseSizeExceeded(
+                    "SQL catalog exceeded the safe column limit"
+                )
+            columns.append({
+                "name": column_name,
+                "dataType": _strict_text(values[4]) or "column",
+            })
+
+    primary_keys = {}
+    for row in primary_key_rows:
+        values = row_values(row, 5)
+        schema_name = _strict_text(values[0])
+        table_name = _strict_text(values[1])
+        key_name = _strict_text(values[2])
+        column_name = _strict_text(values[3])
+        if all((schema_name, table_name, key_name, column_name)):
+            key = (schema_name, table_name, key_name)
+            primary_keys.setdefault(key, []).append(
+                (ordinal(values[4]), column_name)
+            )
+
+    foreign_keys = {}
+    for row in foreign_key_rows:
+        raw_values = row_values(row, 8)
+        values = [_strict_text(value) for value in raw_values[:7]]
+        if all(values):
+            key = tuple(values[:3] + values[4:6])
+            foreign_keys.setdefault(key, []).append(
+                (ordinal(raw_values[7]), values[3], values[6])
+            )
+
+    facts = []
+    for (schema_name, table_name, key_name), columns in primary_keys.items():
+        ordered = [
+            name
+            for _, name in sorted(columns, key=lambda value: value[0])
+        ]
+        facts.append((
+            "Primary key",
+            f"{schema_name}.{table_name}",
+            f"{key_name}: {', '.join(ordered)}",
+        ))
+    for key, columns in foreign_keys.items():
+        key_name, source_schema, source_table, target_schema, target_table = key
+        ordered = sorted(columns, key=lambda value: value[0])
+        source_columns = ", ".join(value[1] for value in ordered)
+        target_columns = ", ".join(value[2] for value in ordered)
+        facts.append((
+            "Foreign key",
+            key_name,
+            (
+                f"{source_schema}.{source_table}({source_columns}) -> "
+                f"{target_schema}.{target_table}({target_columns})"
+            ),
+        ))
+
+    schema = _schema_objects(
+        [objects[key] for key in order],
+        "SQL table",
+        "Fabric SQL system catalog",
+    )
+    return schema, facts
+
+
+def _collect_sql_schema(token, artifact):
+    detail = artifact.get("_detail")
+    detail = detail if isinstance(detail, dict) else {}
+    properties = detail.get("properties")
+    properties = properties if isinstance(properties, dict) else {}
+    host, port = _sql_endpoint(properties.get("serverFqdn"))
+    database_name = _sql_database_name(properties.get("databaseName"))
+    deadline = _ACTIVE_DEADLINE.get() or _ExecutionDeadline()
+    timeout = _sql_timeout_seconds(deadline)
+    connection_string = (
+        f"Server=tcp:{host},{port};"
+        f"Database={database_name};"
+        "Encrypt=yes;"
+        "TrustServerCertificate=no;"
+        "ApplicationIntent=ReadOnly;"
+    )
+    driver = _load_mssql_driver()
+    connection = _sql_connect(
+        driver,
+        connection_string,
+        token,
+        timeout,
+    )
+    active_error = None
+    try:
+        object_rows = _sql_fetch_rows(
+            connection,
+            SQL_OBJECTS_QUERY,
+            MAX_SQL_CATALOG_ROWS,
+            deadline,
+        )
+        primary_key_rows = _sql_fetch_rows(
+            connection,
+            SQL_PRIMARY_KEYS_QUERY,
+            MAX_SQL_RELATIONSHIP_ROWS,
+            deadline,
+        )
+        foreign_key_rows = _sql_fetch_rows(
+            connection,
+            SQL_FOREIGN_KEYS_QUERY,
+            MAX_SQL_RELATIONSHIP_ROWS,
+            deadline,
+        )
+    except Exception as error:
+        active_error = error
+        raise
+    finally:
+        try:
+            connection.close()
+        except Exception as error:
+            if active_error is None:
+                raise SqlConnectionError(
+                    "SQL connection cleanup failed"
+                ) from error
+    schema, facts = _sql_catalog_projection(
+        object_rows,
+        primary_key_rows,
+        foreign_key_rows,
+    )
+    artifact["_sqlSchema"] = schema
+    artifact["_sqlMetadataFacts"] = facts
+
+
+def _sql_metadata_for_item(sql_metadata, item_id):
+    if sql_metadata is None:
+        return None
+    if not isinstance(sql_metadata, dict):
+        raise ValueError("sqlMetadata must be an object")
+    value = sql_metadata.get(item_id)
+    if value is None:
+        for key, candidate in sql_metadata.items():
+            if _normalized_id(key) == item_id:
+                value = candidate
+                break
+    return value
+
+
+def _sql_metadata_projection(value):
+    if not isinstance(value, dict):
+        raise ValueError("SQL metadata item was not an object")
+    tables = _schema_objects(
+        value.get("tables") if isinstance(value.get("tables"), list) else [],
+        "SQL table",
+        "Pre-collected SQL system catalog metadata",
+    )
+    views = _schema_objects(
+        value.get("views") if isinstance(value.get("views"), list) else [],
+        "SQL view",
+        "Pre-collected SQL system catalog metadata",
+    )
+    facts = []
+    for collection, label in (
+        (value.get("tables"), "Primary key"),
+        (value.get("foreignKeys"), "Foreign key"),
+    ):
+        if not isinstance(collection, list):
+            continue
+        for entry in collection[:MAX_DEFINITION_FACTS_PER_ITEM]:
+            if not isinstance(entry, dict):
+                continue
+            name = _qualified_object_name(entry)
+            if label == "Primary key":
+                columns = entry.get("primaryKey")
+                if not isinstance(columns, list):
+                    continue
+                safe_columns = [
+                    column for column in columns if _strict_text(column)
+                ]
+                if name and safe_columns:
+                    facts.append((label, name, ", ".join(safe_columns)))
+            else:
+                source = _strict_text(entry.get("sourceTable"))
+                target = _strict_text(entry.get("targetTable"))
+                if source and target:
+                    facts.append((
+                        label,
+                        _strict_text(entry.get("name")) or f"{source}->{target}",
+                        f"{source} -> {target}",
+                    ))
+    return _merge_schema_tables(tables, views), facts
+
+
+def _enrich_artifact(
+    token,
+    ws,
+    artifact,
+    trackers,
+    errors,
+    kusto_token="",
+    sql_token="",
+    sql_metadata=None,
+):
     artifact_type = artifact.get("_type")
     artifact_id = artifact.get("id")
     detail_path = DETAIL_PATHS.get(artifact_type)
@@ -772,6 +4045,7 @@ def _enrich_artifact(token, ws, artifact, trackers, errors):
                 token,
                 f"{FABRIC}/workspaces/{ws}/{detail_path}/{artifact_id}",
             )
+            _merge_detail_metadata(artifact, artifact["_detail"])
             _track_optional(trackers["itemDetails"], "success")
         except urllib.error.HTTPError as error:
             code = _safe_error_code(error, optional=True)
@@ -880,6 +4154,112 @@ def _enrich_artifact(token, ws, artifact, trackers, errors):
                 _track_optional(trackers["reportPages"], "failed", code)
                 errors.append(f"reportPages: {code}")
 
+    if artifact_type in DEFINITION_PATHS and artifact_id:
+        try:
+            definition = _get_definition(
+                token,
+                ws,
+                artifact_type,
+                artifact_id,
+            )
+            _project_definition(artifact, definition)
+            code = (
+                "forward-compatible-parts-skipped"
+                if artifact.get("_definitionUnknownParts")
+                else (
+                    "artifact-metadata-truncated"
+                    if artifact.get("_artifactMetadataTruncated")
+                    else (
+                        "projection-truncated"
+                        if artifact.get("_definitionTruncated")
+                        else None
+                    )
+                )
+            )
+            artifact["_definitionStatus"] = code or "complete"
+            _track_optional(trackers["definitions"], "success", code)
+        except Exception as error:
+            code = _definition_error_code(error)
+            artifact["_definitionStatus"] = code
+            if code in (
+                "endpoint-unsupported",
+                "read-write-permission-required",
+                "encrypted-label-blocked",
+            ):
+                _track_optional(
+                    trackers["definitions"],
+                    "unsupported",
+                    code,
+                )
+            else:
+                _track_optional(trackers["definitions"], "failed", code)
+                errors.append(f"definitions:{artifact_id}: {code}")
+
+    if artifact_type == "KQLDatabase" and artifact_id:
+        if not _strict_text(kusto_token):
+            artifact["_kqlSchemaStatus"] = "token-unavailable"
+            _track_optional(
+                trackers["kqlSchema"],
+                "unsupported",
+                "token-unavailable",
+            )
+        else:
+            try:
+                _collect_kql_schema(kusto_token, artifact)
+                artifact["_kqlSchemaStatus"] = "complete"
+                _track_optional(trackers["kqlSchema"], "success")
+            except Exception as error:
+                code = _safe_error_code(error, optional=True)
+                artifact["_kqlSchemaStatus"] = code
+                if code in (
+                    "authorization-failed",
+                    "endpoint-unsupported",
+                ):
+                    _track_optional(
+                        trackers["kqlSchema"],
+                        "unsupported",
+                        code,
+                    )
+                else:
+                    _track_optional(trackers["kqlSchema"], "failed", code)
+                    errors.append(f"kqlSchema:{artifact_id}: {code}")
+
+    if artifact_type == "SQLDatabase" and artifact_id:
+        try:
+            supplied = _sql_metadata_for_item(sql_metadata, artifact_id)
+            if _strict_text(sql_token):
+                _collect_sql_schema(sql_token, artifact)
+                artifact["_sqlSchemaStatus"] = "complete"
+                _track_optional(trackers["sqlSchema"], "success")
+            elif supplied is not None:
+                schema, facts = _sql_metadata_projection(supplied)
+                artifact["_sqlSchema"] = schema
+                artifact["_sqlMetadataFacts"] = facts
+                artifact["_sqlSchemaStatus"] = "complete"
+                _track_optional(trackers["sqlSchema"], "success")
+            else:
+                artifact["_sqlSchemaStatus"] = "token-unavailable"
+                _track_optional(
+                    trackers["sqlSchema"],
+                    "unsupported",
+                    "token-unavailable",
+                )
+        except Exception as error:
+            code = _safe_error_code(error, optional=True)
+            artifact["_sqlSchemaStatus"] = code
+            if code in (
+                "authorization-failed",
+                "tds-runtime-unavailable",
+            ):
+                _track_optional(
+                    trackers["sqlSchema"],
+                    "unsupported",
+                    code,
+                )
+            else:
+                _track_optional(trackers["sqlSchema"], "failed", code)
+                errors.append(f"sqlSchema:{artifact_id}: {code}")
+
 
 def _merge_schema_tables(*groups):
     """Deduplicate table names case-insensitively and retain all real columns."""
@@ -890,12 +4270,18 @@ def _merge_schema_tables(*groups):
             name = _strict_text(table.get("name"))
             if not name:
                 continue
-            key = name.casefold()
-            if key not in merged:
+            explicit_key = _strict_text(table.get("_mergeKey"))
+            key = (
+                f"@{explicit_key.casefold()}"
+                if explicit_key
+                else name.casefold()
+            )
+            if key not in merged and not explicit_key:
                 leaf = key.rsplit(".", 1)[-1]
                 leaf_matches = [
                     existing
                     for existing in order
+                    if not existing.startswith("@")
                     if existing.rsplit(".", 1)[-1] == leaf
                     and ("." not in key or "." not in existing)
                 ]
@@ -905,6 +4291,26 @@ def _merge_schema_tables(*groups):
                 merged[key] = {
                     "name": name,
                     "objectType": _strict_text(table.get("objectType")),
+                    "objectId": _strict_text(table.get("objectId")),
+                    "parentObjectId": _strict_text(
+                        table.get("parentObjectId")
+                    ),
+                    "sourceObjectId": _strict_text(
+                        table.get("sourceObjectId")
+                    ),
+                    "targetObjectId": _strict_text(
+                        table.get("targetObjectId")
+                    ),
+                    "relation": _strict_text(table.get("relation")),
+                    "sourceItemId": _normalized_id(
+                        table.get("sourceItemId")
+                    ),
+                    "sourceObjectName": _strict_text(
+                        table.get("sourceObjectName")
+                    ),
+                    "sourceObjectType": _strict_text(
+                        table.get("sourceObjectType")
+                    ),
                     "source": _strict_text(table.get("source")),
                     "description": _strict_text(table.get("description")),
                     "isHidden": (
@@ -922,6 +4328,18 @@ def _merge_schema_tables(*groups):
             target = merged[key]
             if not target.get("objectType") and table.get("objectType"):
                 target["objectType"] = table.get("objectType")
+            for field in (
+                "objectId",
+                "parentObjectId",
+                "sourceObjectId",
+                "targetObjectId",
+                "relation",
+                "sourceItemId",
+                "sourceObjectName",
+                "sourceObjectType",
+            ):
+                if not target.get(field) and table.get(field):
+                    target[field] = table.get(field)
             if table.get("source"):
                 sources = [
                     value.strip()
@@ -947,6 +4365,55 @@ def _merge_schema_tables(*groups):
                         "dataType": _strict_text(
                             column.get("dataType") or column.get("type")
                         ) or "column",
+                        "objectType": _strict_text(
+                            column.get("objectType")
+                        ),
+                        "objectId": _strict_text(
+                            column.get("objectId")
+                        ),
+                        "parentObjectId": _strict_text(
+                            column.get("parentObjectId")
+                        ),
+                        "sourceObjectId": _strict_text(
+                            column.get("sourceObjectId")
+                        ),
+                        "targetObjectId": _strict_text(
+                            column.get("targetObjectId")
+                        ),
+                        "relation": _strict_text(
+                            column.get("relation")
+                        ),
+                        "sourceItemId": _normalized_id(
+                            column.get("sourceItemId")
+                        ),
+                        "sourceObjectName": _strict_text(
+                            column.get("sourceObjectName")
+                        ),
+                        "sourceObjectType": _strict_text(
+                            column.get("sourceObjectType")
+                        ),
+                        "sourceParentObjectId": _strict_text(
+                            column.get("sourceParentObjectId")
+                        ),
+                        "sourceParentPath": (
+                            list(column.get("sourceParentPath"))
+                            if isinstance(
+                                column.get("sourceParentPath"),
+                                list,
+                            )
+                            else None
+                        ),
+                        "sourceTableName": _strict_text(
+                            column.get("sourceTableName")
+                        ),
+                        "parentPath": (
+                            list(column.get("parentPath"))
+                            if isinstance(column.get("parentPath"), list)
+                            else None
+                        ),
+                        "tableName": _strict_text(
+                            column.get("tableName")
+                        ),
                         "description": _strict_text(
                             column.get("description")
                         ),
@@ -968,6 +4435,15 @@ def _merge_schema_tables(*groups):
                         "name": measure_name,
                         "expression": _strict_text(
                             measure.get("expression")
+                        ),
+                        "objectType": _strict_text(
+                            measure.get("objectType")
+                        ),
+                        "objectId": _strict_text(
+                            measure.get("objectId")
+                        ),
+                        "parentObjectId": _strict_text(
+                            measure.get("parentObjectId")
                         ),
                         "description": _strict_text(
                             measure.get("description")
@@ -1163,6 +4639,7 @@ def _schema_objects(values, object_type, source, include_measures=False):
                 "dataType": _strict_text(
                     column.get("dataType") or column.get("type")
                 ) or "column",
+                "objectType": _strict_text(column.get("objectType")),
                 "description": _strict_text(column.get("description")),
                 "isHidden": (
                     column.get("isHidden")
@@ -1182,6 +4659,9 @@ def _schema_objects(values, object_type, source, include_measures=False):
                     "name": measure_name,
                     "expression": _strict_text(
                         measure.get("expression")
+                    ),
+                    "objectType": _strict_text(
+                        measure.get("objectType")
                     ),
                     "description": _strict_text(
                         measure.get("description")
@@ -1332,12 +4812,69 @@ def _item_config(token, ws, a, typ, item_schema=None):
         )
     elif typ == "SQLDatabase":
         add("SQL database", "Database name", properties.get("databaseName"))
+        add("SQL database", "Server", properties.get("serverFqdn"))
         add("SQL database", "Collation", properties.get("collation"))
         add(
             "SQL database",
             "Backup retention days",
             properties.get("backupRetentionDays"),
         )
+        add(
+            "Metadata capability",
+            "SQL schema",
+            a.get("_sqlSchemaStatus"),
+        )
+        for section, label, value in a.get("_sqlMetadataFacts") or []:
+            add(f"SQL {section}s", label, value)
+    elif typ == "Eventhouse":
+        add(
+            "Eventhouse",
+            "Query service URI",
+            properties.get("queryServiceUri"),
+        )
+        database_ids = properties.get("databasesItemIds")
+        if isinstance(database_ids, list):
+            add("Eventhouse", "KQL databases", len(database_ids))
+    elif typ == "KQLDatabase":
+        add(
+            "KQL database",
+            "Parent Eventhouse item ID",
+            properties.get("parentEventhouseItemId"),
+        )
+        add(
+            "KQL database",
+            "Query service URI",
+            properties.get("queryServiceUri"),
+        )
+        add(
+            "KQL database",
+            "Database identity",
+            properties.get("databaseName")
+            or detail.get("displayName")
+            or a.get("displayName"),
+        )
+        add(
+            "KQL database",
+            "Database type",
+            properties.get("databaseType"),
+        )
+        add(
+            "Metadata capability",
+            "KQL schema",
+            a.get("_kqlSchemaStatus"),
+        )
+        for function in a.get("_kqlFunctions") or []:
+            add(
+                "KQL stored functions",
+                function.get("name"),
+                "Stored function",
+            )
+        for view in a.get("_kqlMaterializedViews") or []:
+            add(
+                "KQL materialized views",
+                view.get("name"),
+                "Materialized view",
+            )
     elif typ == "Report":
         add("Report", "Type", a.get("reportType"))
         add("Report", "Semantic model", a.get("datasetId"))
@@ -1366,14 +4903,24 @@ def _item_config(token, ws, a, typ, item_schema=None):
 
     if typ in ("Warehouse", "SQLDatabase"):
         native_inventory = any(
-            "admin scanner" in str(table.get("source") or "").lower()
+            (
+                "admin scanner" in str(table.get("source") or "").lower()
+                or "system catalog" in str(table.get("source") or "").lower()
+            )
             for table in (item_schema or [])
         )
         if native_inventory:
+            sources = " + ".join(
+                sorted({
+                    str(table.get("source"))
+                    for table in (item_schema or [])
+                    if table.get("source")
+                })
+            )
             add(
                 "Inventory",
                 "Coverage",
-                "Tables/views and columns returned by the Power BI admin scanner.",
+                f"Tables/views and columns returned by {sources}.",
             )
         elif item_schema:
             add(
@@ -1387,6 +4934,33 @@ def _item_config(token, ws, a, typ, item_schema=None):
                 "Coverage",
                 "Fabric REST exposes item properties only; complete tables, views and columns require SQL connectivity.",
             )
+
+    if typ in DEFINITION_PATHS:
+        add(
+            "Metadata capability",
+            "Definition enrichment",
+            a.get("_definitionStatus"),
+        )
+        if a.get("_definitionUnknownParts"):
+            add(
+                "Metadata capability",
+                "Forward-compatible definition parts skipped",
+                a.get("_definitionUnknownParts"),
+            )
+        if a.get("_definitionTruncated"):
+            add(
+                "Metadata capability",
+                "Definition projection",
+                "Truncated at the safe metadata fact limit",
+            )
+        if a.get("_artifactMetadataTruncated"):
+            add(
+                "Metadata capability",
+                "Artifact metadata projection",
+                "Truncated at the safe selected-element limit",
+            )
+        for section, label, value in a.get("_definitionFacts") or []:
+            add(section, label, value)
 
     for table in item_schema or []:
         add(
@@ -1427,15 +5001,23 @@ def _item_schema(token, ws, a, typ):
     elif typ in ("Warehouse", "SQLDatabase"):
         tables = _schema_objects(
             a.get("tables"),
-            "Table",
+            "SQL table" if typ == "SQLDatabase" else "Table",
             "Power BI admin scanner",
         )
         views = _schema_objects(
             a.get("views"),
-            "View",
+            "SQL view" if typ == "SQLDatabase" else "View",
             "Power BI admin scanner",
         )
-        return _merge_schema_tables(tables, views)
+        return _merge_schema_tables(
+            tables,
+            views,
+            a.get("_sqlSchema") if typ == "SQLDatabase" else [],
+        )
+    elif typ == "KQLDatabase":
+        return _merge_schema_tables(a.get("_kqlSchema"))
+    elif typ in DEFINITION_PATHS:
+        return _merge_schema_tables(a.get("_definitionSchema"))
     return []
 
 
@@ -1454,6 +5036,11 @@ def _official_lineage(artifacts, workspace_item_ids, workspace_id):
     edges = []
     seen = set()
     normalized_workspace_id = _normalized_id(workspace_id)
+    item_types = {
+        _artifact_id(artifact): artifact.get("_type")
+        for artifact in artifacts
+        if _artifact_id(artifact)
+    }
 
     def add(source, target, relation):
         source_id = _normalized_id(source)
@@ -1532,6 +5119,33 @@ def _official_lineage(artifacts, workspace_item_ids, workspace_id):
             for tile in _lineage_collection(artifact, "tiles"):
                 add(tile.get("reportId"), artifact_id, "dashboard report")
                 add(tile.get("datasetId"), artifact_id, "dashboard dataset")
+        if artifact.get("_type") == "KQLDatabase":
+            detail = artifact.get("_detail")
+            detail = detail if isinstance(detail, dict) else {}
+            properties = detail.get("properties")
+            properties = properties if isinstance(properties, dict) else {}
+            add(
+                properties.get("parentEventhouseItemId"),
+                artifact_id,
+                "KQL database",
+            )
+        for source_id in artifact.get("_definitionSourceIds") or set():
+            relation = {
+                "Ontology": "ontology binding",
+                "GraphModel": "graph source",
+                "DataAgent": (
+                    "ontology"
+                    if item_types.get(_normalized_id(source_id)) == "Ontology"
+                    else "data agent source"
+                ),
+            }.get(artifact.get("_type"), "metadata source")
+            add(source_id, artifact_id, relation)
+        if artifact.get("_type") == "GraphModel":
+            for ontology_id in artifact.get("_ontologyItemIds") or set():
+                add(ontology_id, artifact_id, "generated graph")
+        if artifact.get("_type") == "Ontology":
+            for graph_model_id in artifact.get("_graphModelItemIds") or set():
+                add(artifact_id, graph_model_id, "generated graph")
     return edges
 
 
@@ -1557,7 +5171,14 @@ def _guard_response_size(value, max_bytes=MAX_RESPONSE_BYTES):
 
 
 @udf.function()
-def sync_all(fabricToken: str, workspaceId: str) -> dict:
+def sync_all(
+    fabricToken: str,
+    workspaceId: str,
+    kustoToken: str = "",
+    sqlToken: str = "",
+    storageToken: str = "",
+    sqlMetadata: dict = None,
+) -> dict:
     """Return the v2 metadata-only Fabric Atlas synchronization envelope."""
     ws = _workspace_id(workspaceId)
     out = {
@@ -1567,10 +5188,12 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
         "roleAssignments": [],
         "access": [],
         "lineage": [],
+        "objectEdges": [],
         "config": [],
         "schema": {},
         "jobs": [],
         "itemMetadata": {},
+        "artifactMetadata": {},
         "capabilities": {},
         "sections": {
             name: {"status": "failed", "code": "not-run"}
@@ -1593,6 +5216,9 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
         "lakehouseTables": _new_optional_tracker(),
         "reportPages": _new_optional_tracker(),
         "jobs": _new_optional_tracker(),
+        "definitions": _new_optional_tracker(),
+        "kqlSchema": _new_optional_tracker(),
+        "sqlSchema": _new_optional_tracker(),
     }
 
     with _deadline_scope(deadline):
@@ -1740,6 +5366,13 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
                         artifact,
                         trackers,
                         out["errors"],
+                        kusto_token=kustoToken,
+                        sql_token=sqlToken,
+                        sql_metadata=sqlMetadata,
+                    )
+                    out["itemMetadata"][artifact_id] = _metadata_for_item(
+                        artifact,
+                        artifact_id in scanner_by_id,
                     )
                     users = artifact.get("users") or []
                     if not isinstance(users, list):
@@ -1804,6 +5437,18 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
                 _set_section(out, "access", "failed", "invalid-response")
             else:
                 _set_section(out, "access", "complete")
+            out["artifactMetadata"] = {
+                artifact_id: artifact["_artifactMetadata"]
+                for artifact in artifacts
+                if (
+                    (artifact_id := _artifact_id(artifact))
+                    in workspace_item_ids
+                    and isinstance(
+                        artifact.get("_artifactMetadata"),
+                        dict,
+                    )
+                )
+            }
             try:
                 out["lineage"] = _official_lineage(
                     artifacts,
@@ -1849,10 +5494,55 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
                 out["errors"].append(
                     f"schema: {_safe_error_code(error)}"
                 )
-            out["schema"] = {
+            artifact_types = {
+                _artifact_id(artifact): artifact.get("_type")
+                for artifact in artifacts
+                if _artifact_id(artifact)
+            }
+            all_schema = {
+                item_id: _finalize_schema_object_ids(
+                    item_id,
+                    artifact_types.get(item_id),
+                    tables,
+                )
+                for item_id, tables in all_schema.items()
+            }
+            workspace_schema = {
                 item_id: tables
                 for item_id, tables in all_schema.items()
                 if item_id in workspace_item_ids
+            }
+            extra_object_edges = [
+                edge
+                for artifact in artifacts
+                if _artifact_id(artifact) in workspace_item_ids
+                for edge in artifact.get("_objectEdges") or []
+            ]
+            object_edges, object_edges_truncated = (
+                _collect_atlas_object_edges(
+                    workspace_schema,
+                    extra_edges=extra_object_edges,
+                )
+            )
+            object_edges_truncated = (
+                object_edges_truncated
+                or any(
+                    artifact.get("_objectEdgesTruncated")
+                    for artifact in artifacts
+                )
+            )
+            out["objectEdges"] = object_edges
+            out["capabilities"]["objectLineage"] = {
+                "status": "complete",
+                **(
+                    {"code": "truncated"}
+                    if object_edges_truncated
+                    else {}
+                ),
+            }
+            out["schema"] = {
+                item_id: _public_schema(tables)
+                for item_id, tables in workspace_schema.items()
             }
             if schema_failed:
                 _set_section(
@@ -1897,6 +5587,10 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
                 "code",
                 "scanner-failed",
             )
+            out["capabilities"]["objectLineage"] = {
+                "status": "failed",
+                "code": scanner_code,
+            }
             for name in ("access", "lineage", "schema", "config"):
                 _set_section(out, name, "failed", scanner_code)
                 out["errors"].append(f"{name}: {scanner_code}")
@@ -1933,6 +5627,7 @@ def sync_all(fabricToken: str, workspaceId: str) -> dict:
 
     for name, tracker in trackers.items():
         _finish_optional_section(out, name, tracker)
+    _set_optional_capabilities(out)
     out["syncedAt"] = (
         datetime.datetime.now(datetime.timezone.utc)
         .isoformat(timespec="milliseconds")

--- a/fabric/udf/atlas_sync_functions/function_app.py
+++ b/fabric/udf/atlas_sync_functions/function_app.py
@@ -3966,32 +3966,19 @@ def _collect_sql_schema(token, artifact):
     artifact["_sqlMetadataFacts"] = facts
 
 
-def _sql_metadata_for_item(sql_metadata, item_id):
-    if sql_metadata is None:
-        return None
-    if not isinstance(sql_metadata, dict):
-        raise ValueError("sqlMetadata must be an object")
-    value = sql_metadata.get(item_id)
-    if value is None:
-        for key, candidate in sql_metadata.items():
-            if _normalized_id(key) == item_id:
-                value = candidate
-                break
-    return value
-
-
 def _sql_metadata_projection(value):
+    """Sanitize SQL catalog fixtures used by tests and offline diagnostics."""
     if not isinstance(value, dict):
         raise ValueError("SQL metadata item was not an object")
     tables = _schema_objects(
         value.get("tables") if isinstance(value.get("tables"), list) else [],
         "SQL table",
-        "Pre-collected SQL system catalog metadata",
+        "Sanitized SQL system catalog metadata",
     )
     views = _schema_objects(
         value.get("views") if isinstance(value.get("views"), list) else [],
         "SQL view",
-        "Pre-collected SQL system catalog metadata",
+        "Sanitized SQL system catalog metadata",
     )
     facts = []
     for collection, label in (
@@ -4019,7 +4006,8 @@ def _sql_metadata_projection(value):
                 if source and target:
                     facts.append((
                         label,
-                        _strict_text(entry.get("name")) or f"{source}->{target}",
+                        _strict_text(entry.get("name"))
+                        or f"{source}->{target}",
                         f"{source} -> {target}",
                     ))
     return _merge_schema_tables(tables, views), facts
@@ -4033,7 +4021,6 @@ def _enrich_artifact(
     errors,
     kusto_token="",
     sql_token="",
-    sql_metadata=None,
 ):
     artifact_type = artifact.get("_type")
     artifact_id = artifact.get("id")
@@ -4226,15 +4213,8 @@ def _enrich_artifact(
 
     if artifact_type == "SQLDatabase" and artifact_id:
         try:
-            supplied = _sql_metadata_for_item(sql_metadata, artifact_id)
             if _strict_text(sql_token):
                 _collect_sql_schema(sql_token, artifact)
-                artifact["_sqlSchemaStatus"] = "complete"
-                _track_optional(trackers["sqlSchema"], "success")
-            elif supplied is not None:
-                schema, facts = _sql_metadata_projection(supplied)
-                artifact["_sqlSchema"] = schema
-                artifact["_sqlMetadataFacts"] = facts
                 artifact["_sqlSchemaStatus"] = "complete"
                 _track_optional(trackers["sqlSchema"], "success")
             else:
@@ -5177,7 +5157,6 @@ def sync_all(
     kustoToken: str = "",
     sqlToken: str = "",
     storageToken: str = "",
-    sqlMetadata: dict = None,
 ) -> dict:
     """Return the v2 metadata-only Fabric Atlas synchronization envelope."""
     ws = _workspace_id(workspaceId)
@@ -5368,7 +5347,6 @@ def sync_all(
                         out["errors"],
                         kusto_token=kustoToken,
                         sql_token=sqlToken,
-                        sql_metadata=sqlMetadata,
                     )
                     out["itemMetadata"][artifact_id] = _metadata_for_item(
                         artifact,

--- a/fabric/udf/atlas_sync_functions/requirements.txt
+++ b/fabric/udf/atlas_sync_functions/requirements.txt
@@ -1,1 +1,2 @@
 fabric-user-data-functions==1.0.142
+mssql-python==1.14.0

--- a/fabric/udf/atlas_sync_functions/test_function_app.py
+++ b/fabric/udf/atlas_sync_functions/test_function_app.py
@@ -2491,7 +2491,7 @@ class KqlAndSqlMetadataTests(unittest.TestCase):
 
         self.assertTrue(connection.cursors[0].closed)
 
-    def test_sql_token_uses_live_catalog_before_injected_metadata(self):
+    def test_sql_token_uses_live_catalog(self):
         artifact = {"id": self.sql_id, "_type": "SQLDatabase"}
         trackers = {
             "itemDetails": function_app._new_optional_tracker(),
@@ -2538,11 +2538,6 @@ class KqlAndSqlMetadataTests(unittest.TestCase):
                 trackers,
                 [],
                 sql_token="sql-token",
-                sql_metadata={
-                    self.sql_id: {
-                        "tables": [{"name": "Injected"}],
-                    }
-                },
             )
 
         collect_sql.assert_called_once_with("sql-token", artifact)
@@ -2759,7 +2754,7 @@ class KqlAndSqlMetadataTests(unittest.TestCase):
         )
         self.assertEqual(trackers["kqlSchema"]["unsupported"], 1)
 
-    def test_sql_precollected_catalog_is_allowlisted(self):
+    def test_sql_metadata_fixture_projection_is_allowlisted(self):
         value = {
             "tables": [
                 {
@@ -2843,7 +2838,7 @@ class KqlAndSqlMetadataTests(unittest.TestCase):
         ):
             self.assertNotIn(secret, serialized)
 
-    def test_sql_without_token_or_injected_metadata_reports_token_absence(self):
+    def test_sql_without_token_reports_token_absence(self):
         artifact = {"id": self.sql_id, "_type": "SQLDatabase"}
         trackers = {
             "itemDetails": function_app._new_optional_tracker(),

--- a/fabric/udf/atlas_sync_functions/test_function_app.py
+++ b/fabric/udf/atlas_sync_functions/test_function_app.py
@@ -1,8 +1,10 @@
+import base64
 import datetime
 import importlib.util
 import io
 import json
 import pathlib
+import struct
 import sys
 import types
 import unittest
@@ -29,9 +31,11 @@ spec.loader.exec_module(function_app)
 
 
 class _Response:
-    def __init__(self, value):
+    def __init__(self, value, status=200, headers=None):
         self.payload = json.dumps(value).encode("utf-8")
         self.offset = 0
+        self.status = status
+        self.headers = headers or {}
 
     def __enter__(self):
         return self
@@ -64,6 +68,57 @@ class _Clock:
         self.value += seconds
 
 
+class _SqlCursor:
+    def __init__(self, rows, execute_error=None):
+        self.rows = rows
+        self.execute_error = execute_error
+        self.executed = []
+        self.closed = False
+
+    def execute(self, query):
+        self.executed.append(query)
+        if self.execute_error:
+            raise self.execute_error
+        return self
+
+    def fetchmany(self, size):
+        return self.rows[:size]
+
+    def close(self):
+        self.closed = True
+
+
+class _SqlConnection:
+    def __init__(self, row_sets, execute_error=None):
+        self.row_sets = list(row_sets)
+        self.execute_error = execute_error
+        self.cursors = []
+        self.timeout = 0
+        self.closed = False
+
+    def cursor(self):
+        rows = self.row_sets.pop(0) if self.row_sets else []
+        cursor = _SqlCursor(rows, execute_error=self.execute_error)
+        self.cursors.append(cursor)
+        return cursor
+
+    def close(self):
+        self.closed = True
+
+
+class _SqlDriver:
+    def __init__(self, connection=None, connect_error=None):
+        self.connection = connection
+        self.connect_error = connect_error
+        self.calls = []
+
+    def connect(self, connection_string, **kwargs):
+        self.calls.append((connection_string, kwargs))
+        if self.connect_error:
+            raise self.connect_error
+        return self.connection
+
+
 def _http_error(code, retry_after=None):
     headers = {}
     if retry_after is not None:
@@ -75,6 +130,17 @@ def _http_error(code, retry_after=None):
         headers,
         io.BytesIO(),
     )
+
+
+def _definition_part(path, value):
+    payload = base64.b64encode(
+        json.dumps(value).encode("utf-8")
+    ).decode("ascii")
+    return {
+        "path": path,
+        "payload": payload,
+        "payloadType": "InlineBase64",
+    }
 
 
 class LakehouseSchemaTests(unittest.TestCase):
@@ -202,6 +268,161 @@ class LakehouseSchemaTests(unittest.TestCase):
         self.assertEqual(
             [column["name"] for column in merged[0]["columns"]],
             ["order_id", "amount"],
+        )
+
+    def test_schema_discriminators_are_optional_and_preserved(self):
+        legacy = function_app._merge_schema_tables([
+            {
+                "name": "Legacy",
+                "columns": [{"name": "Id", "dataType": "string"}],
+                "measures": [],
+            }
+        ])
+        enriched = function_app._merge_schema_tables([
+            {
+                "_mergeKey": "ontology-entity:101",
+                "name": "Equipment",
+                "objectType": "Ontology entity",
+                "columns": [
+                    {
+                        "name": "Temperature",
+                        "dataType": "Double",
+                        "objectType": "Ontology time-series property",
+                    }
+                ],
+                "measures": [],
+            }
+        ])
+
+        self.assertNotIn("objectType", legacy[0])
+        self.assertNotIn("objectType", legacy[0]["columns"][0])
+        self.assertEqual(
+            enriched[0]["objectType"],
+            "Ontology entity",
+        )
+        self.assertEqual(
+            enriched[0]["columns"][0]["objectType"],
+            "Ontology time-series property",
+        )
+
+    def test_object_reference_helpers_use_stable_source_to_consumer_ids(self):
+        item_id = "11111111-1111-4111-8111-111111111111"
+        schema = function_app._finalize_schema_object_ids(
+            item_id,
+            "KQLDatabase",
+            [
+                {
+                    "name": "Events",
+                    "objectType": "KQL table",
+                    "columns": [
+                        {
+                            "name": "Timestamp",
+                            "dataType": "datetime",
+                        }
+                    ],
+                    "measures": [],
+                }
+            ],
+        )
+
+        references = function_app._schema_object_references(
+            item_id,
+            schema,
+        )
+        edges = function_app._schema_object_edges(schema)
+        atlas_edges = function_app._atlas_object_edges(
+            {item_id: schema}
+        )
+
+        self.assertEqual(
+            references[0]["id"],
+            function_app._fabric_object_id(
+                item_id,
+                "kql-table",
+                "Events",
+            ),
+        )
+        self.assertEqual(references[1]["parentId"], references[0]["id"])
+        self.assertEqual(references[0]["kind"], "table")
+        self.assertEqual(references[1]["kind"], "column")
+        self.assertEqual(
+            edges,
+            [
+                {
+                    "id": function_app._object_edge_id(
+                        references[0]["id"],
+                        "contains",
+                        references[1]["id"],
+                    ),
+                    "source": references[0]["id"],
+                    "target": references[1]["id"],
+                    "relation": "contains",
+                }
+            ],
+        )
+        self.assertEqual(
+            atlas_edges,
+            [
+                {
+                    "source": {
+                        "itemId": item_id,
+                        "kind": "table",
+                        "id": references[0]["id"],
+                        "name": "Events",
+                        "tableName": "Events",
+                    },
+                    "target": {
+                        "itemId": item_id,
+                        "kind": "column",
+                        "id": references[1]["id"],
+                        "name": "Timestamp",
+                        "parentId": references[0]["id"],
+                        "tableName": "Events",
+                    },
+                    "relation": "contains",
+                    "confidence": "verified",
+                }
+            ],
+        )
+        public_schema = function_app._public_schema(schema)
+        self.assertEqual(public_schema[0]["objectId"], references[0]["id"])
+        self.assertEqual(
+            public_schema[0]["columns"][0]["parentObjectId"],
+            references[0]["id"],
+        )
+        self.assertEqual(public_schema[0]["objectType"], "KQL table")
+
+    def test_generalized_object_edges_are_bounded(self):
+        item_id = "11111111-1111-4111-8111-111111111111"
+        schema = function_app._finalize_schema_object_ids(
+            item_id,
+            "SQLDatabase",
+            [
+                {
+                    "name": "dbo.Customers",
+                    "objectType": "SQL table",
+                    "columns": [
+                        {"name": f"Column{index}", "dataType": "nvarchar"}
+                        for index in range(4)
+                    ],
+                    "measures": [],
+                }
+            ],
+        )
+
+        with mock.patch.object(
+            function_app,
+            "MAX_OBJECT_LINEAGE_EDGES",
+            2,
+        ):
+            edges, truncated = function_app._collect_atlas_object_edges(
+                {item_id: schema}
+            )
+
+        self.assertEqual(len(edges), 2)
+        self.assertTrue(truncated)
+        self.assertTrue(
+            all(edge["confidence"] == "verified" for edge in edges)
         )
 
     def test_lakehouse_table_api_paginates(self):
@@ -792,6 +1013,28 @@ class MetadataBoundaryTests(unittest.TestCase):
             },
         )
 
+    def test_type_specific_detail_adds_supported_sensitivity_and_tags(self):
+        artifact = {"id": "kql", "_type": "KQLDatabase"}
+        function_app._merge_detail_metadata(
+            artifact,
+            {
+                "id": "kql",
+                "sensitivityLabel": {"id": "label-id"},
+                "tags": [{"id": "tag-id", "displayName": "telemetry"}],
+            },
+        )
+
+        metadata = function_app._metadata_for_item(artifact, False)
+
+        self.assertEqual(
+            metadata["sensitivity"],
+            {"labelId": "label-id"},
+        )
+        self.assertEqual(
+            metadata["tags"],
+            [{"id": "tag-id", "displayName": "telemetry"}],
+        )
+
     def test_response_size_guard_fails_closed(self):
         with self.assertRaises(function_app.ResponseSizeExceeded):
             function_app._guard_response_size(
@@ -805,6 +1048,1907 @@ class MetadataBoundaryTests(unittest.TestCase):
             function_app._guard_response_size(payload, max_bytes=100),
             payload,
         )
+
+
+class DefinitionMetadataTests(unittest.TestCase):
+    source_id = "11111111-1111-4111-8111-111111111111"
+    ontology_id = "22222222-2222-4222-8222-222222222222"
+    graph_id = "33333333-3333-4333-8333-333333333333"
+    agent_id = "44444444-4444-4444-8444-444444444444"
+
+    def test_ontology_projects_safe_metadata_and_binding_lineage(self):
+        artifact = {"id": self.ontology_id, "_type": "Ontology"}
+        response = {
+            "definition": {
+                "parts": [
+                    _definition_part(
+                        "EntityTypes/101/definition.json",
+                        {
+                            "id": "101",
+                            "name": "Equipment",
+                            "properties": [
+                                {
+                                    "id": "201",
+                                    "name": "Name",
+                                    "valueType": "String",
+                                }
+                            ],
+                            "timeseriesProperties": [
+                                {
+                                    "id": "202",
+                                    "name": "Temperature",
+                                    "valueType": "Double",
+                                }
+                            ],
+                        },
+                    ),
+                    _definition_part(
+                        "EntityTypes/101/DataBindings/binding.json",
+                        {
+                            "dataBindingConfiguration": {
+                                "sourceTableProperties": {
+                                    "sourceType": "LakehouseTable",
+                                    "workspaceId": "workspace",
+                                    "itemId": self.source_id,
+                                    "sourceSchema": "dbo",
+                                    "sourceTableName": "equipment",
+                                    "businessRows": [
+                                        {"customer": "must-not-leak"}
+                                    ],
+                                },
+                                "propertyBindings": [
+                                    {
+                                        "sourceColumnName": "Name",
+                                        "targetPropertyId": "201",
+                                    }
+                                ],
+                            }
+                        },
+                    ),
+                    _definition_part(
+                        "RelationshipTypes/301/definition.json",
+                        {
+                            "id": "301",
+                            "name": "contains",
+                            "source": {"entityTypeId": "101"},
+                            "target": {"entityTypeId": "101"},
+                        },
+                    ),
+                    _definition_part(
+                        "RelationshipTypes/301/Contextualizations/context.json",
+                        {
+                            "dataBindingTable": {
+                                "sourceType": "LakehouseTable",
+                                "itemId": self.source_id,
+                                "sourceSchema": "dbo",
+                                "sourceTableName": "relationships",
+                            },
+                            "sourceKeyRefBindings": [
+                                {"sourceColumnName": "secret-key-value"}
+                            ],
+                        },
+                    ),
+                    _definition_part(
+                        "EntityTypes/101/Documents/document.json",
+                        {
+                            "displayText": "Internal document",
+                            "url": "https://secret.example/document",
+                        },
+                    ),
+                    _definition_part(
+                        "Future/part.json",
+                        {"secret": "future-payload-must-not-leak"},
+                    ),
+                ]
+            }
+        }
+
+        function_app._project_definition(artifact, response)
+        config = function_app._item_config(
+            "token",
+            "workspace",
+            artifact,
+            "Ontology",
+            [],
+        )
+        serialized = json.dumps(config)
+
+        self.assertIn("Ontology entity types", serialized)
+        self.assertIn("Ontology properties", serialized)
+        self.assertIn("Ontology time-series properties", serialized)
+        self.assertIn("Ontology data bindings", serialized)
+        self.assertIn("Ontology relationship types", serialized)
+        self.assertIn("Ontology contextualizations", serialized)
+        self.assertEqual(artifact["_definitionUnknownParts"], 1)
+        self.assertNotIn("must-not-leak", serialized)
+        self.assertNotIn("secret-key-value", serialized)
+        self.assertNotIn("secret.example", serialized)
+        self.assertNotIn("future-payload", serialized)
+        metadata = artifact["_artifactMetadata"]
+        self.assertEqual(metadata["kind"], "ontology")
+        self.assertEqual(metadata["entities"][0]["id"], "101")
+        self.assertEqual(
+            metadata["entities"][0]["properties"],
+            [
+                {
+                    "id": "201",
+                    "name": "Name",
+                    "valueType": "String",
+                    "timeSeries": False,
+                },
+                {
+                    "id": "202",
+                    "name": "Temperature",
+                    "valueType": "Double",
+                    "timeSeries": True,
+                },
+            ],
+        )
+        self.assertEqual(
+            metadata["bindings"][0]["sourceItemId"],
+            self.source_id,
+        )
+        self.assertEqual(
+            metadata["relationships"][0],
+            {
+                "id": "301",
+                "name": "contains",
+                "sourceEntityId": "101",
+                "targetEntityId": "101",
+            },
+        )
+        metadata_serialized = json.dumps(metadata)
+        for secret in (
+            "must-not-leak",
+            "secret-key-value",
+            "secret.example",
+            "future-payload",
+            "Documents",
+            "ResourceLinks",
+        ):
+            self.assertNotIn(secret, metadata_serialized)
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "table"
+                and edge["target"]["kind"] == "entityType"
+                and edge["relation"] == "binds entity"
+                for edge in artifact["_objectEdges"]
+            )
+        )
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "column"
+                and edge["target"]["kind"] == "property"
+                and edge["relation"] == "binds property"
+                for edge in artifact["_objectEdges"]
+            )
+        )
+        schema = artifact["_definitionSchema"]
+        self.assertEqual(
+            [value["objectType"] for value in schema],
+            ["Ontology entity", "Ontology relationship"],
+        )
+        self.assertEqual(
+            [column["objectType"] for column in schema[0]["columns"]],
+            ["Ontology property", "Ontology time-series property"],
+        )
+        self.assertEqual(
+            schema[0]["columns"][0]["parentObjectId"],
+            schema[0]["objectId"],
+        )
+        self.assertEqual(
+            schema[1]["sourceObjectId"],
+            schema[0]["objectId"],
+        )
+        self.assertEqual(
+            schema[1]["targetObjectId"],
+            schema[0]["objectId"],
+        )
+        object_edges = function_app._schema_object_edges(schema)
+        self.assertTrue(
+            any(
+                edge["relation"] == "ontology relationship"
+                and edge["relationObjectId"] == schema[1]["objectId"]
+                for edge in object_edges
+            )
+        )
+        atlas_edges = function_app._atlas_object_edges(
+            {self.ontology_id: schema},
+            extra_edges=artifact["_objectEdges"],
+        )
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "entityType"
+                and edge["target"]["kind"] == "relationshipType"
+                and edge["relation"] == "relationship source"
+                and edge["confidence"] == "verified"
+                for edge in atlas_edges
+            )
+        )
+        self.assertTrue(
+            any(
+                edge["source"]["itemId"] == self.source_id
+                and edge["target"]["itemId"] == self.ontology_id
+                and edge["relation"] == "binds entity"
+                for edge in atlas_edges
+            )
+        )
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "relationshipType"
+                and edge["target"]["kind"] == "entityType"
+                and edge["relation"] == "relationship target"
+                for edge in atlas_edges
+            )
+        )
+
+        lineage = function_app._official_lineage(
+            [
+                {"id": self.source_id, "_type": "Lakehouse"},
+                artifact,
+            ],
+            {self.source_id, self.ontology_id},
+            "workspace",
+        )
+        self.assertIn(
+            {
+                "source": self.source_id,
+                "target": self.ontology_id,
+                "relation": "ontology binding",
+            },
+            lineage,
+        )
+
+    def test_ontology_entity_id_falls_back_to_definition_path(self):
+        artifact = {"id": self.ontology_id, "_type": "Ontology"}
+        function_app._project_definition(
+            artifact,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            "EntityTypes/101/definition.json",
+                            {"name": "Equipment"},
+                        ),
+                        _definition_part(
+                            "EntityTypes/101/DataBindings/binding.json",
+                            {
+                                "dataBindingConfiguration": {
+                                    "sourceTableProperties": {
+                                        "itemId": self.source_id,
+                                    }
+                                }
+                            },
+                        ),
+                    ]
+                }
+            },
+        )
+
+        serialized = json.dumps(artifact["_definitionFacts"])
+        self.assertIn("id 101", serialized)
+        self.assertIn("Equipment:binding", serialized)
+        self.assertNotIn("id None", serialized)
+
+    def test_ontology_ids_are_canonical_across_graph_mappings(self):
+        entity_id = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"
+        ontology = {"id": self.ontology_id, "_type": "Ontology"}
+        graph = {"id": self.graph_id, "_type": "GraphModel"}
+        function_app._project_definition(
+            ontology,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            f"EntityTypes/{entity_id}/definition.json",
+                            {
+                                "id": entity_id,
+                                "name": "Equipment",
+                            },
+                        )
+                    ]
+                }
+            },
+        )
+        function_app._project_definition(
+            graph,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            "graphType.json",
+                            {
+                                "ontologyItemId": self.ontology_id,
+                                "nodeTypes": [
+                                    {
+                                        "alias": "EquipmentNode",
+                                        "ontologyEntityTypeId": entity_id.lower(),
+                                        "properties": [],
+                                    }
+                                ],
+                                "edgeTypes": [],
+                            },
+                        ),
+                        _definition_part(
+                            "dataSources.json",
+                            {"dataSources": []},
+                        ),
+                        _definition_part(
+                            "graphDefinition.json",
+                            {"nodeTables": [], "edgeTables": []},
+                        ),
+                    ]
+                }
+            },
+        )
+
+        ontology_object_id = ontology["_definitionSchema"][0]["objectId"]
+        graph_source_id = graph["_definitionSchema"][0]["sourceObjectId"]
+        self.assertEqual(ontology_object_id, graph_source_id)
+
+    def test_graph_projects_types_and_mappings_without_filter_values(self):
+        artifact = {"id": self.graph_id, "_type": "GraphModel"}
+        one_lake_path = (
+            f"abfss://{self.source_id}@onelake.dfs.fabric.microsoft.com/"
+            "55555555-5555-4555-8555-555555555555/Tables/Customers"
+        )
+        response = {
+            "definition": {
+                "parts": [
+                    _definition_part(
+                        "graphType.json",
+                        {
+                            "ontologyItemId": self.ontology_id,
+                            "nodeTypes": [
+                                {
+                                    "alias": "Customer",
+                                    "ontologyEntityTypeId": "101",
+                                    "labels": ["Customer"],
+                                    "properties": [
+                                        {"name": "Id", "type": "STRING"}
+                                    ],
+                                }
+                            ],
+                            "edgeTypes": [
+                                {
+                                    "alias": "Purchased",
+                                    "ontologyRelationshipTypeId": "301",
+                                    "sourceNodeType": {"alias": "Customer"},
+                                    "destinationNodeType": {"alias": "Customer"},
+                                    "properties": [],
+                                }
+                            ],
+                        },
+                    ),
+                    _definition_part(
+                        "dataSources.json",
+                        {
+                            "dataSources": [
+                                {
+                                    "name": "Customers",
+                                    "type": "DeltaTable",
+                                    "properties": {"path": one_lake_path},
+                                }
+                            ]
+                        },
+                    ),
+                    _definition_part(
+                        "graphDefinition.json",
+                        {
+                            "nodeTables": [
+                                {
+                                    "nodeTypeAlias": "Customer",
+                                    "dataSourceName": "Customers",
+                                    "propertyMappings": [
+                                        {
+                                            "propertyName": "Id",
+                                            "sourceColumn": "CustomerId",
+                                        }
+                                    ],
+                                    "filter": {
+                                        "columnName": "Region",
+                                        "operator": "Equal",
+                                        "value": "secret-filter-literal",
+                                    },
+                                }
+                            ],
+                            "edgeTables": [],
+                        },
+                    ),
+                    _definition_part(
+                        "graphInstances.json",
+                        {"instances": [{"name": "secret-instance"}]},
+                    ),
+                ]
+            }
+        }
+
+        function_app._project_definition(artifact, response)
+        serialized = json.dumps(
+            function_app._item_config(
+                "token",
+                "workspace",
+                artifact,
+                "GraphModel",
+                [],
+            )
+        )
+
+        self.assertIn("Graph node types", serialized)
+        self.assertIn("Graph edge types", serialized)
+        self.assertIn("Graph data sources", serialized)
+        self.assertIn("Graph node mappings", serialized)
+        self.assertNotIn("secret-filter-literal", serialized)
+        self.assertNotIn("secret-instance", serialized)
+        metadata = artifact["_artifactMetadata"]
+        self.assertEqual(metadata["kind"], "graphModel")
+        self.assertEqual(metadata["nodeTypes"][0]["alias"], "Customer")
+        self.assertEqual(metadata["edgeTypes"][0]["alias"], "Purchased")
+        self.assertEqual(
+            metadata["dataSources"][0]["sourceItemId"],
+            "55555555-5555-4555-8555-555555555555",
+        )
+        self.assertEqual(metadata["mappings"][0]["kind"], "node")
+        metadata_serialized = json.dumps(metadata)
+        self.assertNotIn("filter", metadata_serialized.casefold())
+        self.assertNotIn("instances", metadata_serialized.casefold())
+        self.assertNotIn("secret-filter-literal", metadata_serialized)
+        self.assertNotIn("secret-instance", metadata_serialized)
+        self.assertEqual(
+            [
+                (value["name"], value["objectType"])
+                for value in artifact["_definitionSchema"]
+            ],
+            [
+                ("Customer", "Graph node"),
+                ("Purchased", "Graph edge"),
+            ],
+        )
+        self.assertEqual(
+            artifact["_definitionSchema"][0]["columns"][0]["objectType"],
+            "Graph property",
+        )
+        graph_schema = artifact["_definitionSchema"]
+        self.assertEqual(
+            graph_schema[0]["sourceObjectId"],
+            function_app._fabric_object_id(
+                self.ontology_id,
+                "ontology-entity",
+                "101",
+            ),
+        )
+        self.assertEqual(
+            graph_schema[1]["sourceObjectId"],
+            function_app._fabric_object_id(
+                self.ontology_id,
+                "ontology-relationship",
+                "301",
+            ),
+        )
+        self.assertEqual(
+            [edge["relation"] for edge in function_app._schema_object_edges(
+                graph_schema
+            )],
+            ["generated graph node", "generated graph edge"],
+        )
+        atlas_edges = function_app._atlas_object_edges({
+            self.graph_id: graph_schema,
+        }, extra_edges=artifact["_objectEdges"])
+        self.assertEqual(
+            {
+                (
+                    edge["source"]["kind"],
+                    edge["target"]["kind"],
+                    edge["relation"],
+                )
+                for edge in atlas_edges
+            },
+            {
+                ("entityType", "nodeType", "generated graph node"),
+                (
+                    "relationshipType",
+                    "edgeType",
+                    "generated graph edge",
+                ),
+                ("table", "nodeType", "maps node"),
+                ("column", "property", "maps property"),
+            },
+        )
+        self.assertIn(
+            "55555555-5555-4555-8555-555555555555",
+            artifact["_definitionSourceIds"],
+        )
+
+        lineage = function_app._official_lineage(
+            [
+                {"id": self.source_id, "_type": "Lakehouse"},
+                {"id": self.ontology_id, "_type": "Ontology"},
+                {
+                    **artifact,
+                    "_definitionSourceIds": {self.source_id},
+                },
+            ],
+            {self.source_id, self.ontology_id, self.graph_id},
+            "workspace",
+        )
+        self.assertIn(
+            {
+                "source": self.ontology_id,
+                "target": self.graph_id,
+                "relation": "generated graph",
+            },
+            lineage,
+        )
+
+    def test_data_agent_projects_sources_and_selected_tree_without_prompts(self):
+        artifact = {"id": self.agent_id, "_type": "DataAgent"}
+        response = {
+            "definition": {
+                "parts": [
+                    _definition_part(
+                        "Files/Config/draft/stage_config.json",
+                        {"aiInstructions": "secret-agent-prompt"},
+                    ),
+                    _definition_part(
+                        "Files/Config/published/stage_config.json",
+                        {"aiInstructions": "secret-published-prompt"},
+                    ),
+                    _definition_part(
+                        "Files/Config/published/ontology-Sales/datasource.json",
+                        {
+                            "artifactId": self.ontology_id,
+                            "workspaceId": "workspace",
+                            "displayName": "Sales ontology",
+                            "type": "ontology",
+                            "dataSourceInstructions": "secret-source-prompt",
+                            "elements": [
+                                {
+                                    "id": "101",
+                                    "display_name": "Customer",
+                                    "type": "graph.nodeType",
+                                    "is_selected": True,
+                                    "children": [
+                                        {
+                                            "id": "201",
+                                            "display_name": "CustomerId",
+                                            "type": "graph.property",
+                                            "is_selected": True,
+                                            "description": "secret-description",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    ),
+                    _definition_part(
+                        "Files/Config/published/ontology-Sales/fewshots.json",
+                        {
+                            "fewShots": [
+                                {
+                                    "question": "secret-question",
+                                    "query": "secret-query",
+                                }
+                            ]
+                        },
+                    ),
+                    _definition_part(
+                        "Files/Config/publish_info.json",
+                        {"description": "Published catalog assistant"},
+                    ),
+                ]
+            }
+        }
+
+        function_app._project_definition(artifact, response)
+        serialized = json.dumps(
+            function_app._item_config(
+                "token",
+                "workspace",
+                artifact,
+                "DataAgent",
+                [],
+            )
+        )
+
+        self.assertIn("Published catalog assistant", serialized)
+        self.assertIn("published", serialized)
+        self.assertIn("Sales ontology", serialized)
+        self.assertIn("CustomerId", serialized)
+        for secret in (
+            "secret-agent-prompt",
+            "secret-published-prompt",
+            "secret-source-prompt",
+            "secret-description",
+            "secret-question",
+            "secret-query",
+        ):
+            self.assertNotIn(secret, serialized)
+        metadata = artifact["_artifactMetadata"]
+        self.assertEqual(metadata["kind"], "dataAgent")
+        self.assertEqual(len(metadata["sources"]), 1)
+        self.assertEqual(
+            metadata["sources"][0]["artifactId"],
+            self.ontology_id,
+        )
+        self.assertEqual(
+            metadata["sources"][0]["elements"][0]["id"],
+            "101",
+        )
+        self.assertNotIn("instructions", json.dumps(metadata).casefold())
+        self.assertNotIn("fewshot", json.dumps(metadata).casefold())
+        for secret in (
+            "secret-agent-prompt",
+            "secret-published-prompt",
+            "secret-source-prompt",
+            "secret-description",
+            "secret-question",
+            "secret-query",
+        ):
+            self.assertNotIn(secret, json.dumps(metadata))
+        self.assertEqual(
+            artifact["_definitionSchema"][0]["objectType"],
+            "Data Agent source",
+        )
+        self.assertEqual(
+            [
+                column["objectType"]
+                for column in artifact["_definitionSchema"][0]["columns"]
+            ],
+            [
+                "Data Agent selected element",
+                "Data Agent selected element",
+            ],
+        )
+        agent_source = artifact["_definitionSchema"][0]
+        self.assertEqual(
+            agent_source["columns"][0]["sourceObjectId"],
+            function_app._fabric_object_id(
+                self.ontology_id,
+                "ontology-entity",
+                "101",
+            ),
+        )
+        self.assertEqual(
+            agent_source["columns"][0]["targetObjectId"],
+            agent_source["columns"][0]["objectId"],
+        )
+        self.assertEqual(
+            agent_source["columns"][1]["sourceObjectId"],
+            function_app._fabric_object_id(
+                self.ontology_id,
+                "ontology-property",
+                "201",
+            ),
+        )
+        self.assertTrue(
+            any(
+                edge["source"]
+                == agent_source["columns"][0]["sourceObjectId"]
+                and edge["target"]
+                == agent_source["columns"][0]["objectId"]
+                and edge["relation"] == "selected by data agent"
+                for edge in function_app._schema_object_edges(
+                    artifact["_definitionSchema"]
+                )
+            )
+        )
+        atlas_edges = function_app._atlas_object_edges({
+            self.agent_id: artifact["_definitionSchema"],
+        })
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "entityType"
+                and edge["target"]["kind"] == "selectedElement"
+                and edge["relation"] == "selected by data agent"
+                and edge["confidence"] == "verified"
+                for edge in atlas_edges
+            )
+        )
+        self.assertTrue(
+            any(
+                edge["source"]["kind"] == "dataSource"
+                and edge["target"]["kind"] == "selectedElement"
+                and edge["relation"] == "contains"
+                for edge in atlas_edges
+            )
+        )
+
+        lineage = function_app._official_lineage(
+            [
+                {"id": self.ontology_id, "_type": "Ontology"},
+                artifact,
+            ],
+            {self.ontology_id, self.agent_id},
+            "workspace",
+        )
+        self.assertIn(
+            {
+                "source": self.ontology_id,
+                "target": self.agent_id,
+                "relation": "ontology",
+            },
+            lineage,
+        )
+
+    def test_definition_permission_locked_and_malformed_are_item_scoped(self):
+        cases = (
+            (_http_error(403), "read-write-permission-required", "unsupported"),
+            (_http_error(423), "encrypted-label-blocked", "unsupported"),
+            (
+                {
+                    "definition": {
+                        "parts": [
+                            {
+                                "path": "graphType.json",
+                                "payload": "not-base64",
+                                "payloadType": "InlineBase64",
+                            }
+                        ]
+                    }
+                },
+                "invalid-definition",
+                "failed",
+            ),
+        )
+        for result, expected_code, expected_tracker in cases:
+            with self.subTest(expected_code=expected_code):
+                artifact = {"id": self.graph_id, "_type": "GraphModel"}
+                trackers = {
+                    "itemDetails": function_app._new_optional_tracker(),
+                    "definitions": function_app._new_optional_tracker(),
+                }
+                errors = []
+                with (
+                    mock.patch.object(
+                        function_app,
+                        "_get",
+                        return_value={"id": self.graph_id},
+                    ),
+                    mock.patch.object(
+                        function_app,
+                        "_get_definition",
+                        side_effect=(
+                            result if isinstance(result, Exception) else None
+                        ),
+                        return_value=(
+                            result if isinstance(result, dict) else None
+                        ),
+                    ),
+                ):
+                    function_app._enrich_artifact(
+                        "token",
+                        "workspace",
+                        artifact,
+                        trackers,
+                        errors,
+                    )
+
+                self.assertEqual(
+                    artifact["_definitionStatus"],
+                    expected_code,
+                )
+                self.assertEqual(
+                    trackers["definitions"][expected_tracker],
+                    1,
+                )
+                if expected_tracker == "failed":
+                    self.assertEqual(
+                        errors,
+                        [f"definitions:{self.graph_id}: {expected_code}"],
+                    )
+                else:
+                    self.assertEqual(errors, [])
+
+    def test_data_agent_physical_selection_points_to_source_object(self):
+        kql_id = "55555555-5555-4555-8555-555555555555"
+        artifact = {"id": self.agent_id, "_type": "DataAgent"}
+        function_app._project_definition(
+            artifact,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            "Files/Config/draft/kusto-Telemetry/datasource.json",
+                            {
+                                "artifactId": kql_id,
+                                "displayName": "Telemetry",
+                                "type": "kusto",
+                                "elements": [
+                                    {
+                                        "display_name": "Events",
+                                        "type": "kusto.table",
+                                        "is_selected": True,
+                                        "children": [
+                                            {
+                                                "display_name": "Timestamp",
+                                                "type": "kusto.column",
+                                                "is_selected": True,
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        )
+                    ]
+                }
+            },
+        )
+
+        source = artifact["_definitionSchema"][0]
+        table, column = source["columns"]
+        self.assertEqual(
+            table["sourceObjectId"],
+            function_app._fabric_object_id(
+                kql_id,
+                "kql-table",
+                "Events",
+            ),
+        )
+        self.assertEqual(
+            column["sourceObjectId"],
+            function_app._fabric_object_id(
+                kql_id,
+                "kql-table-column",
+                "Events/Timestamp",
+            ),
+        )
+        self.assertEqual(table["targetObjectId"], table["objectId"])
+        self.assertEqual(column["targetObjectId"], column["objectId"])
+        self.assertEqual(table["parentObjectId"], source["objectId"])
+        self.assertEqual(column["parentObjectId"], table["objectId"])
+
+    def test_data_agent_live_element_types_skip_grouping_nodes(self):
+        model_id = "55555555-5555-4555-8555-555555555555"
+        kql_id = "66666666-6666-4666-8666-666666666666"
+        artifact = {"id": self.agent_id, "_type": "DataAgent"}
+        function_app._project_definition(
+            artifact,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            "Files/Config/published/semantic_model-Model/datasource.json",
+                            {
+                                "artifactId": model_id,
+                                "displayName": "Sales model",
+                                "type": "semantic_model",
+                                "elements": [
+                                    {
+                                        "display_name": "Model",
+                                        "type": "semantic_model",
+                                        "is_selected": True,
+                                        "children": [
+                                            {
+                                                "display_name": "Sales",
+                                                "type": "semantic_model.table",
+                                                "is_selected": True,
+                                                "children": [
+                                                    {
+                                                        "display_name": "Amount",
+                                                        "type": "semantic_model.column",
+                                                        "data_type": "Decimal",
+                                                        "is_selected": True,
+                                                    },
+                                                    {
+                                                        "display_name": "Revenue",
+                                                        "type": "semantic_model.measure",
+                                                        "data_type": "Decimal",
+                                                        "is_selected": True,
+                                                    },
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ),
+                        _definition_part(
+                            "Files/Config/published/kusto-Telemetry/datasource.json",
+                            {
+                                "artifactId": kql_id,
+                                "displayName": "Telemetry",
+                                "type": "kusto",
+                                "elements": [
+                                    {
+                                        "display_name": "Tables",
+                                        "type": "kusto",
+                                        "is_selected": True,
+                                        "children": [
+                                            {
+                                                "display_name": "Events",
+                                                "type": "kusto.table",
+                                                "is_selected": True,
+                                                "children": [
+                                                    {
+                                                        "display_name": "Timestamp",
+                                                        "type": "kusto.column",
+                                                        "data_type": "datetime",
+                                                        "is_selected": True,
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ),
+                        _definition_part(
+                            "Files/Config/published/ontology-Sales/datasource.json",
+                            {
+                                "artifactId": self.ontology_id,
+                                "displayName": "Sales ontology",
+                                "type": "ontology",
+                                "elements": [
+                                    {
+                                        "id": "101",
+                                        "display_name": "Customer",
+                                        "type": "ontology.entity",
+                                        "is_selected": True,
+                                    }
+                                ],
+                            },
+                        ),
+                    ]
+                }
+            },
+        )
+
+        schema = artifact["_definitionSchema"]
+        selected = [
+            column
+            for source in schema
+            for column in source["columns"]
+        ]
+        self.assertEqual(
+            [column["name"] for column in selected],
+            [
+                "Sales",
+                "Amount",
+                "Revenue",
+                "Events",
+                "Timestamp",
+                "Customer",
+            ],
+        )
+        self.assertNotIn("Model", [column["name"] for column in selected])
+        self.assertNotIn("Tables", [column["name"] for column in selected])
+        self.assertEqual(
+            next(
+                column["dataType"]
+                for column in selected
+                if column["name"] == "Amount"
+            ),
+            "Decimal",
+        )
+        self.assertEqual(
+            next(
+                column["dataType"]
+                for column in selected
+                if column["name"] == "Timestamp"
+            ),
+            "datetime",
+        )
+
+        edges = function_app._atlas_object_edges({
+            self.agent_id: schema,
+        })
+        source_edges = [
+            edge
+            for edge in edges
+            if edge["relation"] == "selected by data agent"
+        ]
+        self.assertEqual(
+            {edge["source"]["kind"] for edge in source_edges},
+            {"table", "column", "measure", "entityType"},
+        )
+        amount = next(
+            edge
+            for edge in source_edges
+            if edge["source"]["name"] == "Amount"
+        )
+        self.assertEqual(amount["source"]["tableName"], "Sales")
+        self.assertEqual(amount["source"]["parentPath"], ["Sales"])
+        self.assertEqual(amount["target"]["parentPath"], ["Sales"])
+        ontology = next(
+            edge
+            for edge in source_edges
+            if edge["source"]["kind"] == "entityType"
+        )
+        self.assertEqual(ontology["source"]["itemId"], self.ontology_id)
+
+    def test_data_agent_matching_is_independent_of_workspace_names_and_mix(self):
+        source_id = "77777777-7777-4777-8777-777777777777"
+        agent_id = "88888888-8888-4888-8888-888888888888"
+        artifact = {"id": agent_id, "_type": "DataAgent"}
+        function_app._project_definition(
+            artifact,
+            {
+                "definition": {
+                    "parts": [
+                        _definition_part(
+                            "Files/Config/draft/custom-source/datasource.json",
+                            {
+                                "artifactId": source_id,
+                                "workspaceId": (
+                                    "99999999-9999-4999-8999-999999999999"
+                                ),
+                                "displayName": "Synthetic source",
+                                "type": "future_source_type",
+                                "elements": [
+                                    {
+                                        "display_name": "arbitrary_schema",
+                                        "type": "future.schema",
+                                        "is_selected": True,
+                                        "children": [
+                                            {
+                                                "display_name": "object_name",
+                                                "type": "semantic_model.table",
+                                                "is_selected": True,
+                                                "children": [
+                                                    {
+                                                        "display_name": "field_name",
+                                                        "type": "semantic_model.column",
+                                                        "data_type": "custom_type",
+                                                        "is_selected": True,
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        )
+                    ]
+                }
+            },
+        )
+
+        selected = artifact["_definitionSchema"][0]["columns"]
+        self.assertEqual(
+            [value["name"] for value in selected],
+            ["object_name", "field_name"],
+        )
+        self.assertEqual(
+            selected[0]["sourceObjectId"],
+            function_app._fabric_object_id(
+                source_id,
+                "semantic-model-table",
+                "arbitrary_schema.object_name",
+            ),
+        )
+        edges = function_app._atlas_object_edges({
+            agent_id: artifact["_definitionSchema"],
+        })
+        self.assertTrue(
+            all(
+                edge["source"]["itemId"] == source_id
+                for edge in edges
+                if edge["relation"] == "selected by data agent"
+            )
+        )
+        self.assertEqual(
+            function_app._source_object_kind("future_source_type"),
+            "table",
+        )
+
+    def test_data_agent_metadata_truncation_is_reported(self):
+        response = {
+            "definition": {
+                "parts": [
+                    _definition_part(
+                        "Files/Config/published/model-Source/datasource.json",
+                        {
+                            "artifactId": self.source_id,
+                            "displayName": "Synthetic model",
+                            "type": "semantic_model",
+                            "elements": [
+                                {
+                                    "id": "one",
+                                    "display_name": "One",
+                                    "type": "semantic_model.table",
+                                    "is_selected": True,
+                                },
+                                {
+                                    "id": "two",
+                                    "display_name": "Two",
+                                    "type": "semantic_model.table",
+                                    "is_selected": True,
+                                },
+                            ],
+                        },
+                    )
+                ]
+            }
+        }
+        artifact = {"id": self.agent_id, "_type": "DataAgent"}
+        trackers = {
+            "itemDetails": function_app._new_optional_tracker(),
+            "definitions": function_app._new_optional_tracker(),
+        }
+        with (
+            mock.patch.object(
+                function_app,
+                "MAX_ARTIFACT_METADATA_ELEMENTS",
+                1,
+            ),
+            mock.patch.object(
+                function_app,
+                "_get",
+                return_value={"id": self.agent_id},
+            ),
+            mock.patch.object(
+                function_app,
+                "_get_definition",
+                return_value=response,
+            ),
+        ):
+            function_app._enrich_artifact(
+                "token",
+                "workspace",
+                artifact,
+                trackers,
+                [],
+            )
+
+        self.assertTrue(artifact["_artifactMetadataTruncated"])
+        self.assertEqual(
+            artifact["_definitionStatus"],
+            "artifact-metadata-truncated",
+        )
+        self.assertIn(
+            "artifact-metadata-truncated",
+            trackers["definitions"]["codes"],
+        )
+
+    def test_definition_lro_polls_state_then_fetches_result(self):
+        operation_id = "55555555-5555-4555-8555-555555555555"
+        clock = _Clock()
+        deadline = function_app._ExecutionDeadline(10, clock.monotonic)
+        response = {"definition": {"parts": []}}
+        with (
+            function_app._deadline_scope(deadline),
+            mock.patch.object(
+                function_app,
+                "_req_response",
+                side_effect=[
+                    (
+                        202,
+                        {
+                            "Location": f"{function_app.FABRIC}/operations/{operation_id}",
+                            "x-ms-operation-id": operation_id,
+                            "Retry-After": "1",
+                        },
+                        {},
+                    ),
+                    (
+                        200,
+                        {
+                            "Location": (
+                                f"{function_app.FABRIC}/operations/"
+                                f"{operation_id}/result"
+                            )
+                        },
+                        {"status": "Succeeded"},
+                    ),
+                ],
+            ),
+            mock.patch.object(
+                function_app,
+                "_get",
+                return_value=response,
+            ) as get,
+            mock.patch.object(deadline, "sleep", side_effect=clock.sleep),
+        ):
+            result = function_app._get_definition(
+                "token",
+                "workspace",
+                "Ontology",
+                self.ontology_id,
+            )
+
+        self.assertEqual(result, response)
+        get.assert_called_once_with(
+            "token",
+            f"{function_app.FABRIC}/operations/{operation_id}/result",
+        )
+
+
+class KqlAndSqlMetadataTests(unittest.TestCase):
+    kql_id = "11111111-1111-4111-8111-111111111111"
+    eventhouse_id = "22222222-2222-4222-8222-222222222222"
+    sql_id = "33333333-3333-4333-8333-333333333333"
+
+    def test_sql_access_token_is_packed_for_attrs_before(self):
+        token = "header.payload.synthetic-signature-value"
+        token_bytes = token.encode("utf-16le")
+
+        packed = function_app._pack_sql_access_token(token)
+
+        self.assertEqual(
+            packed,
+            struct.pack(
+                f"<I{len(token_bytes)}s",
+                len(token_bytes),
+                token_bytes,
+            ),
+        )
+        self.assertNotIn(token.encode("utf-8"), packed)
+        with self.assertRaises(ValueError):
+            function_app._pack_sql_access_token("short")
+
+    def test_sql_endpoint_and_database_identity_are_allowlisted(self):
+        self.assertEqual(
+            function_app._sql_endpoint(
+                "server.database.fabric.microsoft.com,1433"
+            ),
+            ("server.database.fabric.microsoft.com", 1433),
+        )
+        self.assertEqual(
+            function_app._sql_endpoint(
+                "https://server.database.fabric.microsoft.com:1433"
+            ),
+            ("server.database.fabric.microsoft.com", 1433),
+        )
+        self.assertEqual(
+            function_app._sql_database_name("Catalog 2026"),
+            "Catalog 2026",
+        )
+        for endpoint in (
+            "http://server.database.fabric.microsoft.com",
+            "https://server.database.fabric.microsoft.com.evil.test",
+            "server.database.fabric.microsoft.com;UID=attacker",
+            "server.database.fabric.microsoft.com,1444",
+            "-server.database.fabric.microsoft.com,1433",
+            "localhost,1433",
+        ):
+            with self.subTest(endpoint=endpoint):
+                with self.assertRaises(ValueError):
+                    function_app._sql_endpoint(endpoint)
+        for database_name in ("", "Catalog;UID=attacker", "Catalog{Name}"):
+            with self.subTest(database_name=database_name):
+                with self.assertRaises(ValueError):
+                    function_app._sql_database_name(database_name)
+
+    def test_sql_catalog_collection_maps_only_system_metadata(self):
+        token = "header.payload.synthetic-signature-value"
+        connection = _SqlConnection(
+            [
+                [
+                    ("dbo", "Customers", "U", "CustomerId", "uniqueidentifier", 1),
+                    ("dbo", "Customers", "U", "Name", "nvarchar", 2),
+                    ("reporting", "CustomerSummary", "V", "CustomerId", "uniqueidentifier", 1),
+                ],
+                [
+                    ("dbo", "Customers", "PK_Customers", "CustomerId", 1),
+                ],
+                [
+                    (
+                        "FK_Customers_Accounts",
+                        "dbo",
+                        "Customers",
+                        "AccountId",
+                        "dbo",
+                        "Accounts",
+                        "AccountId",
+                        1,
+                    ),
+                ],
+            ]
+        )
+        driver = _SqlDriver(connection=connection)
+        artifact = {
+            "id": self.sql_id,
+            "_type": "SQLDatabase",
+            "_detail": {
+                "properties": {
+                    "serverFqdn": (
+                        "server.database.fabric.microsoft.com,1433"
+                    ),
+                    "databaseName": "Synthetic Catalog",
+                    "connectionString": "Password=must-not-be-used",
+                }
+            },
+        }
+
+        with mock.patch.object(
+            function_app.importlib,
+            "import_module",
+            return_value=driver,
+        ):
+            function_app._collect_sql_schema(token, artifact)
+
+        connection_string, kwargs = driver.calls[0]
+        self.assertEqual(
+            connection_string,
+            (
+                "Server=tcp:server.database.fabric.microsoft.com,1433;"
+                "Database=Synthetic Catalog;"
+                "Encrypt=yes;"
+                "TrustServerCertificate=no;"
+                "ApplicationIntent=ReadOnly;"
+            ),
+        )
+        self.assertEqual(kwargs["autocommit"], True)
+        self.assertLessEqual(kwargs["timeout"], function_app.REQUEST_TIMEOUT_SECONDS)
+        self.assertEqual(
+            kwargs["attrs_before"],
+            {
+                function_app.SQL_COPT_SS_ACCESS_TOKEN:
+                    function_app._pack_sql_access_token(token)
+            },
+        )
+        self.assertEqual(
+            [cursor.executed[0] for cursor in connection.cursors],
+            [
+                function_app.SQL_OBJECTS_QUERY,
+                function_app.SQL_PRIMARY_KEYS_QUERY,
+                function_app.SQL_FOREIGN_KEYS_QUERY,
+            ],
+        )
+        self.assertTrue(all(cursor.closed for cursor in connection.cursors))
+        self.assertTrue(connection.closed)
+        self.assertEqual(
+            [
+                (value["name"], value["objectType"])
+                for value in artifact["_sqlSchema"]
+            ],
+            [
+                ("dbo.Customers", "SQL table"),
+                ("reporting.CustomerSummary", "SQL view"),
+            ],
+        )
+        self.assertEqual(
+            [column["name"] for column in artifact["_sqlSchema"][0]["columns"]],
+            ["CustomerId", "Name"],
+        )
+        serialized = json.dumps(artifact)
+        self.assertNotIn(token, serialized)
+        self.assertNotIn("must-not-be-used", json.dumps({
+            "schema": artifact["_sqlSchema"],
+            "facts": artifact["_sqlMetadataFacts"],
+        }))
+        self.assertNotIn(
+            "Synthetic Catalog",
+            " ".join(cursor.executed[0] for cursor in connection.cursors),
+        )
+        self.assertIn("PK_Customers", serialized)
+        self.assertIn("FK_Customers_Accounts", serialized)
+
+    def test_sql_driver_import_auth_and_query_failures_are_safe(self):
+        artifact = {
+            "id": self.sql_id,
+            "_type": "SQLDatabase",
+            "_detail": {
+                "properties": {
+                    "serverFqdn": (
+                        "server.database.fabric.microsoft.com,1433"
+                    ),
+                    "databaseName": "Catalog",
+                }
+            },
+        }
+        with mock.patch.object(
+            function_app.importlib,
+            "import_module",
+            side_effect=ImportError("private import path"),
+        ):
+            with self.assertRaises(function_app.SqlRuntimeUnavailable):
+                function_app._collect_sql_schema("token", artifact)
+
+        auth_driver = _SqlDriver(
+            connect_error=RuntimeError(
+                "SQLSTATE:28000 login failed secret-token"
+            )
+        )
+        with mock.patch.object(
+            function_app.importlib,
+            "import_module",
+            return_value=auth_driver,
+        ):
+            with self.assertRaisesRegex(
+                function_app.SqlAuthorizationError,
+                "^SQL authentication failed$",
+            ):
+                function_app._collect_sql_schema(
+                    "header.payload.secret-token-signature",
+                    artifact,
+                )
+
+        connection = _SqlConnection(
+            [[]],
+            execute_error=RuntimeError("query internals secret-token"),
+        )
+        query_driver = _SqlDriver(connection=connection)
+        with mock.patch.object(
+            function_app.importlib,
+            "import_module",
+            return_value=query_driver,
+        ):
+            with self.assertRaisesRegex(
+                function_app.SqlCatalogQueryError,
+                "^SQL catalog query failed$",
+            ):
+                function_app._collect_sql_schema(
+                    "header.payload.secret-token-signature",
+                    artifact,
+                )
+        self.assertTrue(connection.cursors[0].closed)
+        self.assertTrue(connection.closed)
+
+    def test_sql_catalog_row_limit_fails_instead_of_silently_truncating(self):
+        connection = _SqlConnection([
+            [("dbo", f"Table{index}", "U", None, None, None) for index in range(3)]
+        ])
+        deadline = function_app._ExecutionDeadline(10)
+
+        with self.assertRaises(function_app.ResponseSizeExceeded):
+            function_app._sql_fetch_rows(
+                connection,
+                function_app.SQL_OBJECTS_QUERY,
+                2,
+                deadline,
+            )
+
+        self.assertTrue(connection.cursors[0].closed)
+
+    def test_sql_token_uses_live_catalog_before_injected_metadata(self):
+        artifact = {"id": self.sql_id, "_type": "SQLDatabase"}
+        trackers = {
+            "itemDetails": function_app._new_optional_tracker(),
+            "sqlSchema": function_app._new_optional_tracker(),
+        }
+        live_schema = [
+            {
+                "name": "dbo.Live",
+                "objectType": "SQL table",
+                "source": "Fabric SQL system catalog",
+                "columns": [],
+                "measures": [],
+            }
+        ]
+
+        def collect(_token, value):
+            value["_sqlSchema"] = live_schema
+            value["_sqlMetadataFacts"] = []
+
+        with (
+            mock.patch.object(
+                function_app,
+                "_get",
+                return_value={
+                    "id": self.sql_id,
+                    "properties": {
+                        "serverFqdn": (
+                            "server.database.fabric.microsoft.com,1433"
+                        ),
+                        "databaseName": "Catalog",
+                    },
+                },
+            ),
+            mock.patch.object(
+                function_app,
+                "_collect_sql_schema",
+                side_effect=collect,
+            ) as collect_sql,
+        ):
+            function_app._enrich_artifact(
+                "fabric-token",
+                "workspace",
+                artifact,
+                trackers,
+                [],
+                sql_token="sql-token",
+                sql_metadata={
+                    self.sql_id: {
+                        "tables": [{"name": "Injected"}],
+                    }
+                },
+            )
+
+        collect_sql.assert_called_once_with("sql-token", artifact)
+        self.assertEqual(artifact["_sqlSchema"], live_schema)
+        self.assertEqual(artifact["_sqlSchemaStatus"], "complete")
+
+    def test_kql_schema_uses_readonly_management_command(self):
+        schema_document = {
+            "Databases": {
+                "Telemetry": {
+                    "Tables": {
+                        "Events": {
+                            "Name": "Events",
+                            "OrderedColumns": [
+                                {"Name": "Timestamp", "CslType": "datetime"},
+                                {"Name": "DeviceId", "CslType": "string"},
+                            ],
+                        }
+                    },
+                    "MaterializedViews": {
+                        "LatestEvents": {
+                            "Name": "LatestEvents",
+                            "Schema": {
+                                "OrderedColumns": [
+                                    {"Name": "DeviceId", "CslType": "string"}
+                                ]
+                            },
+                            "Query": "secret-materialized-view-query",
+                        }
+                    },
+                    "Functions": {
+                        "NormalizeDevice": {
+                            "Name": "NormalizeDevice",
+                            "Body": "secret-function-body",
+                        }
+                    },
+                }
+            }
+        }
+        response = {
+            "Tables": [
+                {
+                    "TableName": "PrimaryResult",
+                    "Rows": [[json.dumps(schema_document)]],
+                }
+            ]
+        }
+        artifact = {
+            "id": self.kql_id,
+            "_type": "KQLDatabase",
+            "displayName": "Telemetry",
+            "_detail": {
+                "displayName": "Telemetry",
+                "properties": {
+                    "queryServiceUri": (
+                        "https://cluster.z1.kusto.fabric.microsoft.com"
+                    )
+                },
+            },
+        }
+        with mock.patch.object(
+            function_app,
+            "_req",
+            return_value=response,
+        ) as request:
+            function_app._collect_kql_schema("kusto-token", artifact)
+
+        kwargs = request.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["x-ms-readonly"], "true")
+        self.assertEqual(kwargs["method"], "POST")
+        self.assertIn(".show database", kwargs["body"]["csl"])
+        self.assertEqual(
+            [table["name"] for table in artifact["_kqlSchema"]],
+            ["Events", "LatestEvents", "NormalizeDevice"],
+        )
+        self.assertEqual(
+            [table["objectType"] for table in artifact["_kqlSchema"]],
+            [
+                "KQL table",
+                "KQL materialized view",
+                "KQL function",
+            ],
+        )
+        self.assertEqual(
+            artifact["_kqlFunctions"],
+            [{"name": "NormalizeDevice", "parameters": []}],
+        )
+        self.assertEqual(
+            artifact["_artifactMetadata"],
+            {
+                "kind": "kql",
+                "functions": [
+                    {"name": "NormalizeDevice", "parameters": []}
+                ],
+                "materializedViews": [
+                    {
+                        "name": "LatestEvents",
+                        "columns": [
+                            {
+                                "name": "DeviceId",
+                                "dataType": "string",
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        metadata_serialized = json.dumps(
+            artifact["_artifactMetadata"]
+        )
+        self.assertNotIn("secret-function-body", metadata_serialized)
+        self.assertNotIn(
+            "secret-materialized-view-query",
+            metadata_serialized,
+        )
+        serialized = json.dumps(
+            function_app._item_config(
+                "token",
+                "workspace",
+                artifact,
+                "KQLDatabase",
+                artifact["_kqlSchema"],
+            )
+        )
+        self.assertNotIn("secret-function-body", serialized)
+        self.assertNotIn("secret-materialized-view-query", serialized)
+
+    def test_kql_parent_relation_is_authoritative(self):
+        lineage = function_app._official_lineage(
+            [
+                {"id": self.eventhouse_id, "_type": "Eventhouse"},
+                {
+                    "id": self.kql_id,
+                    "_type": "KQLDatabase",
+                    "_detail": {
+                        "properties": {
+                            "parentEventhouseItemId": self.eventhouse_id
+                        }
+                    },
+                },
+            ],
+            {self.eventhouse_id, self.kql_id},
+            "workspace",
+        )
+        self.assertEqual(
+            lineage,
+            [
+                {
+                    "source": self.eventhouse_id,
+                    "target": self.kql_id,
+                    "relation": "KQL database",
+                }
+            ],
+        )
+
+    def test_kql_functions_respect_schema_object_limit(self):
+        schema_document = {
+            "Databases": {
+                "Telemetry": {
+                    "Tables": {},
+                    "Functions": {
+                        f"Function{index}": {"Name": f"Function{index}"}
+                        for index in range(5)
+                    },
+                }
+            }
+        }
+        with mock.patch.object(
+            function_app,
+            "MAX_SCHEMA_OBJECTS_PER_ITEM",
+            3,
+        ):
+            schema, functions, _views = function_app._kusto_schema(
+                schema_document,
+                "Telemetry",
+            )
+
+        self.assertEqual(len(schema), 3)
+        self.assertEqual(len(functions), 3)
+        self.assertTrue(
+            all(value["objectType"] == "KQL function" for value in schema)
+        )
+
+    def test_kql_token_absence_is_explicit_and_nonfatal(self):
+        artifact = {"id": self.kql_id, "_type": "KQLDatabase"}
+        trackers = {
+            "itemDetails": function_app._new_optional_tracker(),
+            "kqlSchema": function_app._new_optional_tracker(),
+        }
+        with mock.patch.object(
+            function_app,
+            "_get",
+            return_value={
+                "id": self.kql_id,
+                "displayName": "Telemetry",
+                "properties": {
+                    "queryServiceUri": (
+                        "https://cluster.z1.kusto.fabric.microsoft.com"
+                    )
+                },
+            },
+        ):
+            function_app._enrich_artifact(
+                "token",
+                "workspace",
+                artifact,
+                trackers,
+                [],
+            )
+
+        self.assertEqual(
+            artifact["_kqlSchemaStatus"],
+            "token-unavailable",
+        )
+        self.assertEqual(trackers["kqlSchema"]["unsupported"], 1)
+
+    def test_sql_precollected_catalog_is_allowlisted(self):
+        value = {
+            "tables": [
+                {
+                    "schema": "dbo",
+                    "name": "Customers",
+                    "rowCount": [{"name": "secret-business-row"}],
+                    "rows": [{"name": "secret-business-row"}],
+                    "primaryKey": ["CustomerId"],
+                    "columns": [
+                        {
+                            "name": "CustomerId",
+                            "dataType": "uniqueidentifier",
+                            "values": ["secret-value"],
+                        },
+                        {"name": "Name", "dataType": "nvarchar"},
+                    ],
+                    "moduleDefinition": "secret-sql-module",
+                }
+            ],
+            "views": [
+                {
+                    "schema": "reporting",
+                    "name": "CustomerSummary",
+                    "columns": [{"name": "CustomerId", "dataType": "uuid"}],
+                    "definition": "secret-view-definition",
+                }
+            ],
+            "foreignKeys": [
+                {
+                    "name": "FK_Customers_Accounts",
+                    "sourceTable": "dbo.Customers",
+                    "targetTable": "dbo.Accounts",
+                    "query": "secret-query",
+                }
+            ],
+            "credentials": "secret-credential",
+        }
+
+        schema, facts = function_app._sql_metadata_projection(value)
+        artifact = {
+            "id": self.sql_id,
+            "_type": "SQLDatabase",
+            "_sqlSchema": schema,
+            "_sqlMetadataFacts": facts,
+            "_sqlSchemaStatus": "complete",
+            "_detail": {
+                "properties": {
+                    "databaseName": "Catalog",
+                    "serverFqdn": "server.database.fabric.microsoft.com,1433",
+                    "connectionString": "Password=secret-password",
+                }
+            },
+        }
+        serialized = json.dumps({
+            "schema": schema,
+            "config": function_app._item_config(
+                "token",
+                "workspace",
+                artifact,
+                "SQLDatabase",
+                schema,
+            ),
+        })
+
+        self.assertEqual(
+            [(table["name"], table["objectType"]) for table in schema],
+            [
+                ("dbo.Customers", "SQL table"),
+                ("reporting.CustomerSummary", "SQL view"),
+            ],
+        )
+        self.assertNotIn("rows", schema[0])
+        for secret in (
+            "secret-business-row",
+            "secret-value",
+            "secret-sql-module",
+            "secret-view-definition",
+            "secret-query",
+            "secret-credential",
+            "secret-password",
+        ):
+            self.assertNotIn(secret, serialized)
+
+    def test_sql_without_token_or_injected_metadata_reports_token_absence(self):
+        artifact = {"id": self.sql_id, "_type": "SQLDatabase"}
+        trackers = {
+            "itemDetails": function_app._new_optional_tracker(),
+            "sqlSchema": function_app._new_optional_tracker(),
+        }
+        with mock.patch.object(
+            function_app,
+            "_get",
+            return_value={
+                "id": self.sql_id,
+                "properties": {
+                    "databaseName": "Catalog",
+                    "serverFqdn": "server.database.fabric.microsoft.com,1433",
+                },
+            },
+        ):
+            function_app._enrich_artifact(
+                "token",
+                "workspace",
+                artifact,
+                trackers,
+                [],
+            )
+
+        self.assertEqual(
+            artifact["_sqlSchemaStatus"],
+            "token-unavailable",
+        )
+        self.assertEqual(trackers["sqlSchema"]["unsupported"], 1)
+
+    def test_sql_item_failures_are_isolated_with_precise_codes(self):
+        cases = (
+            (
+                function_app.SqlRuntimeUnavailable("runtime"),
+                "tds-runtime-unavailable",
+                "unsupported",
+            ),
+            (
+                function_app.SqlAuthorizationError("auth"),
+                "authorization-failed",
+                "unsupported",
+            ),
+            (
+                function_app.SqlConnectionError("connect"),
+                "sql-connection-failed",
+                "failed",
+            ),
+            (
+                function_app.SqlCatalogQueryError("query"),
+                "sql-catalog-query-failed",
+                "failed",
+            ),
+        )
+        for error, expected_code, expected_status in cases:
+            with self.subTest(expected_code=expected_code):
+                artifact = {"id": self.sql_id, "_type": "SQLDatabase"}
+                trackers = {
+                    "itemDetails": function_app._new_optional_tracker(),
+                    "sqlSchema": function_app._new_optional_tracker(),
+                }
+                errors = []
+                with (
+                    mock.patch.object(
+                        function_app,
+                        "_get",
+                        return_value={
+                            "id": self.sql_id,
+                            "properties": {
+                                "serverFqdn": (
+                                    "server.database.fabric.microsoft.com,1433"
+                                ),
+                                "databaseName": "Catalog",
+                            },
+                        },
+                    ),
+                    mock.patch.object(
+                        function_app,
+                        "_collect_sql_schema",
+                        side_effect=error,
+                    ),
+                ):
+                    function_app._enrich_artifact(
+                        "fabric-token",
+                        "workspace",
+                        artifact,
+                        trackers,
+                        errors,
+                        sql_token="sql-token",
+                    )
+
+                self.assertEqual(
+                    artifact["_sqlSchemaStatus"],
+                    expected_code,
+                )
+                self.assertEqual(
+                    trackers["sqlSchema"][expected_status],
+                    1,
+                )
+                if expected_status == "failed":
+                    self.assertEqual(
+                        errors,
+                        [f"sqlSchema:{self.sql_id}: {expected_code}"],
+                    )
+                else:
+                    self.assertEqual(errors, [])
 
 
 class LineageTests(unittest.TestCase):
@@ -1163,6 +3307,19 @@ class SyncOrchestrationTests(unittest.TestCase):
                 "sensitivity": {"status": "complete", "code": "label-ids"},
                 "tags": {"status": "complete", "code": "tag-ids"},
                 "ownership": {"status": "complete", "code": "type-specific"},
+                "definitionEnrichment": {
+                    "status": "unsupported",
+                    "code": "not-applicable",
+                },
+                "kqlSchema": {
+                    "status": "unsupported",
+                    "code": "not-applicable",
+                },
+                "sqlSchema": {
+                    "status": "unsupported",
+                    "code": "not-applicable",
+                },
+                "objectLineage": {"status": "complete"},
             },
         )
         self.assertEqual(
@@ -1215,6 +3372,9 @@ class SyncOrchestrationTests(unittest.TestCase):
                 "itemDetails",
                 "lakehouseTables",
                 "reportPages",
+                "definitions",
+                "kqlSchema",
+                "sqlSchema",
             },
         )
 
@@ -1348,6 +3508,124 @@ class SyncOrchestrationTests(unittest.TestCase):
             {"status": "failed", "code": "upstream-failure"},
         )
         self.assertNotIn("secret tenant detail", json.dumps(result))
+
+    def test_definition_permission_failure_preserves_other_item_enrichment(self):
+        ontology_id = "22222222-2222-4222-8222-222222222222"
+        graph_id = "33333333-3333-4333-8333-333333333333"
+        ontology_definition = {
+            "definition": {
+                "parts": [
+                    _definition_part(
+                        "EntityTypes/101/definition.json",
+                        {
+                            "id": "101",
+                            "name": "Customer",
+                            "properties": [
+                                {
+                                    "id": "201",
+                                    "name": "CustomerId",
+                                    "valueType": "String",
+                                }
+                            ],
+                        },
+                    )
+                ]
+            }
+        }
+
+        def get_definition(
+            _token,
+            _workspace,
+            artifact_type,
+            _artifact_id,
+        ):
+            if artifact_type == "Ontology":
+                return ontology_definition
+            raise _http_error(403)
+
+        with mock.patch.object(
+            function_app,
+            "_get_definition",
+            side_effect=get_definition,
+        ):
+            result = self._run_sync(
+                [
+                    {
+                        "id": ontology_id,
+                        "type": "Ontology",
+                        "displayName": "Sales ontology",
+                    },
+                    {
+                        "id": graph_id,
+                        "type": "GraphModel",
+                        "displayName": "Sales graph",
+                    },
+                ],
+                {},
+            )
+
+        self.assertEqual(
+            result["sections"]["definitions"],
+            {"status": "complete", "code": "partial-unsupported"},
+        )
+        self.assertEqual(result["sections"]["config"]["status"], "complete")
+        self.assertEqual(result["sections"]["schema"]["status"], "complete")
+        serialized = json.dumps(result["config"])
+        self.assertIn("Ontology entity types", serialized)
+        self.assertIn("read-write-permission-required", serialized)
+        self.assertEqual(
+            result["schema"][ontology_id][0]["objectType"],
+            "Ontology entity",
+        )
+        self.assertIn("objectId", result["schema"][ontology_id][0])
+        self.assertIn(
+            "parentObjectId",
+            result["schema"][ontology_id][0]["columns"][0],
+        )
+        self.assertEqual(
+            result["artifactMetadata"][ontology_id]["kind"],
+            "ontology",
+        )
+        self.assertNotIn(
+            "artifactMetadata",
+            result["itemMetadata"][ontology_id],
+        )
+        self.assertEqual(
+            result["objectEdges"],
+            [
+                {
+                    "source": {
+                        "itemId": ontology_id,
+                        "kind": "entityType",
+                        "id": function_app._fabric_object_id(
+                            ontology_id,
+                            "ontology-entity",
+                            "101",
+                        ),
+                        "name": "Customer",
+                    },
+                    "target": {
+                        "itemId": ontology_id,
+                        "kind": "property",
+                        "id": function_app._fabric_object_id(
+                            ontology_id,
+                            "ontology-property",
+                            "201",
+                        ),
+                        "name": "CustomerId",
+                        "parentId": function_app._fabric_object_id(
+                            ontology_id,
+                            "ontology-entity",
+                            "101",
+                        ),
+                        "tableName": "Customer",
+                    },
+                    "relation": "contains",
+                    "confidence": "verified",
+                }
+            ],
+        )
+        self.assertEqual(result["errors"], [])
 
 
 class OptionalEndpointStatusTests(unittest.TestCase):

--- a/fabric/udf/atlas_sync_functions/test_function_app.py
+++ b/fabric/udf/atlas_sync_functions/test_function_app.py
@@ -396,11 +396,11 @@ class LakehouseSchemaTests(unittest.TestCase):
         item_id = "11111111-1111-4111-8111-111111111111"
         schema = function_app._finalize_schema_object_ids(
             item_id,
-            "SQLDatabase",
+            "KQLDatabase",
             [
                 {
-                    "name": "dbo.Customers",
-                    "objectType": "SQL table",
+                    "name": "Events",
+                    "objectType": "KQL table",
                     "columns": [
                         {"name": f"Column{index}", "dataType": "nvarchar"}
                         for index in range(4)
@@ -2214,7 +2214,10 @@ class DefinitionMetadataTests(unittest.TestCase):
                     (
                         202,
                         {
-                            "Location": f"{function_app.FABRIC}/operations/{operation_id}",
+                            "Location": (
+                                "https://region.analysis.windows.net/"
+                                f"operations/{operation_id}"
+                            ),
                             "x-ms-operation-id": operation_id,
                             "Retry-After": "1",
                         },
@@ -2224,14 +2227,14 @@ class DefinitionMetadataTests(unittest.TestCase):
                         200,
                         {
                             "Location": (
-                                f"{function_app.FABRIC}/operations/"
+                                "https://region.analysis.windows.net/operations/"
                                 f"{operation_id}/result"
                             )
                         },
                         {"status": "Succeeded"},
                     ),
                 ],
-            ),
+            ) as request,
             mock.patch.object(
                 function_app,
                 "_get",
@@ -2247,6 +2250,10 @@ class DefinitionMetadataTests(unittest.TestCase):
             )
 
         self.assertEqual(result, response)
+        self.assertEqual(
+            request.call_args_list[1].args[1],
+            f"{function_app.FABRIC}/operations/{operation_id}",
+        )
         get.assert_called_once_with(
             "token",
             f"{function_app.FABRIC}/operations/{operation_id}/result",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/rayfin/data/AccessReviewEvent.ts
+++ b/rayfin/data/AccessReviewEvent.ts
@@ -1,0 +1,36 @@
+import {
+  authenticated,
+  date,
+  entity,
+  set,
+  text,
+  uuid,
+} from '@microsoft/rayfin-core';
+
+export type AccessReviewEventStatus =
+  | 'reviewed'
+  | 'accepted'
+  | 'needsAction'
+  | 'cleared';
+
+/**
+ * An immutable, user-scoped access review decision or clear event.
+ */
+@entity()
+@authenticated(['create', 'read'], {
+  policy: (claims, item) => claims.sub.eq(item.user_id),
+})
+export class AccessReviewEvent {
+  @uuid() id!: string;
+  @uuid() workspace_id!: string;
+  @text({ max: 160 }) user_id!: string;
+  @text({ max: 700 }) rowKey!: string;
+  @uuid() itemFabricId!: string;
+  @text({ max: 200 }) principalRef!: string;
+  @set('reviewed', 'accepted', 'needsAction', 'cleared')
+  status!: AccessReviewEventStatus;
+  @text({ max: 80 }) evidenceKey!: string;
+  @text({ max: 80 }) eventOrder!: string;
+  @text({ max: 1000, optional: true }) note?: string;
+  @date() occurredAt!: Date;
+}

--- a/rayfin/data/GovernanceException.ts
+++ b/rayfin/data/GovernanceException.ts
@@ -1,0 +1,44 @@
+import { authenticated, date, entity, text, uuid } from '@microsoft/rayfin-core';
+import { SYNC_WRITER_EMAIL } from './sync-policy.js';
+
+@entity()
+@authenticated('read')
+@authenticated('create', {
+  policy: (claims, item) =>
+    claims.email
+      .eq(item.authorEmail)
+      .and(claims.sub.eq(item.authorId))
+      .and(claims.email.eq(SYNC_WRITER_EMAIL)),
+})
+@authenticated('update', {
+  policy: (claims, item) =>
+    claims.email
+      .eq(item.authorEmail)
+      .and(claims.sub.eq(item.authorId))
+      .and(claims.email.eq(SYNC_WRITER_EMAIL)),
+  include: [
+    'reason',
+    'expiresAt',
+    'authorId',
+    'authorName',
+    'authorEmail',
+    'updatedAt',
+  ],
+})
+@authenticated('delete', {
+  policy: (claims) => claims.email.eq(SYNC_WRITER_EMAIL),
+})
+export class GovernanceException {
+  @uuid() id!: string;
+  @uuid() workspace_id!: string;
+  @text({ max: 80, unique: true }) recordKey!: string;
+  @text({ max: 160 }) writerEmail!: string;
+  @text({ max: 700 }) findingId!: string;
+  @text({ max: 2000 }) reason!: string;
+  @date() expiresAt!: Date;
+  @text({ max: 160 }) authorId!: string;
+  @text({ max: 160 }) authorName!: string;
+  @text({ max: 160 }) authorEmail!: string;
+  @date() createdAt!: Date;
+  @date() updatedAt!: Date;
+}

--- a/rayfin/data/GovernancePolicy.ts
+++ b/rayfin/data/GovernancePolicy.ts
@@ -1,0 +1,45 @@
+import { authenticated, date, entity, int, text, uuid } from '@microsoft/rayfin-core';
+import { SYNC_WRITER_EMAIL } from './sync-policy.js';
+
+@entity()
+@authenticated('read')
+@authenticated('create', {
+  policy: (claims, item) =>
+    claims.email
+      .eq(item.writerEmail)
+      .and(claims.email.eq(SYNC_WRITER_EMAIL)),
+})
+@authenticated('update', {
+  policy: (claims) => claims.email.eq(SYNC_WRITER_EMAIL),
+  include: [
+    'documentationTarget',
+    'ownershipTarget',
+    'sensitivityTarget',
+    'accessTarget',
+    'lineageTarget',
+    'operationsTarget',
+    'updatedById',
+    'updatedByName',
+    'updatedByEmail',
+    'updatedAt',
+  ],
+})
+@authenticated('delete', {
+  policy: (claims) => claims.email.eq(SYNC_WRITER_EMAIL),
+})
+export class GovernancePolicy {
+  @uuid() id!: string;
+  @uuid() workspace_id!: string;
+  @text({ max: 100, unique: true }) recordKey!: string;
+  @text({ max: 160 }) writerEmail!: string;
+  @int() documentationTarget!: number;
+  @int() ownershipTarget!: number;
+  @int() sensitivityTarget!: number;
+  @int() accessTarget!: number;
+  @int() lineageTarget!: number;
+  @int() operationsTarget!: number;
+  @text({ max: 160 }) updatedById!: string;
+  @text({ max: 160 }) updatedByName!: string;
+  @text({ max: 160 }) updatedByEmail!: string;
+  @date() updatedAt!: Date;
+}

--- a/rayfin/data/schema.ts
+++ b/rayfin/data/schema.ts
@@ -9,7 +9,10 @@ import { Comment } from './Comment.js';
 import { SyncRun } from './SyncRun.js';
 import { SavedView } from './SavedView.js';
 import { AccessReview } from './AccessReview.js';
+import { AccessReviewEvent } from './AccessReviewEvent.js';
 import { FindingAck } from './FindingAck.js';
+import { GovernancePolicy } from './GovernancePolicy.js';
+import { GovernanceException } from './GovernanceException.js';
 
 /**
  * Schema type map — enables full type-safety through RayfinClient
@@ -27,7 +30,10 @@ export type AtlasSchema = {
   SyncRun: SyncRun;
   SavedView: SavedView;
   AccessReview: AccessReview;
+  AccessReviewEvent: AccessReviewEvent;
   FindingAck: FindingAck;
+  GovernancePolicy: GovernancePolicy;
+  GovernanceException: GovernanceException;
 };
 
 export const schema = [
@@ -42,5 +48,8 @@ export const schema = [
   SyncRun,
   SavedView,
   AccessReview,
+  AccessReviewEvent,
   FindingAck,
+  GovernancePolicy,
+  GovernanceException,
 ];

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -31,6 +31,7 @@ function renderApp() {
 describe("App", () => {
     beforeEach(() => {
         window.history.replaceState(null, "", "/#overview");
+        localStorage.clear();
     });
 
     it("renders without throwing", () => {
@@ -59,6 +60,18 @@ describe("App", () => {
     it("mounts content into the document", () => {
         renderApp();
         expect(document.body).not.toBeEmptyDOMElement();
+    });
+
+    it("applies and restores the personal display density", () => {
+        const app = renderApp();
+        expect(document.documentElement).toHaveAttribute("data-atlas-density", "comfortable");
+        fireEvent.click(screen.getByRole("button", { name: "Switch to compact density" }));
+        expect(document.documentElement).toHaveAttribute("data-atlas-density", "compact");
+        app.unmount();
+        renderApp();
+        expect(document.documentElement).toHaveAttribute("data-atlas-density", "compact");
+        fireEvent.click(screen.getByRole("button", { name: "Switch to comfortable density" }));
+        expect(document.documentElement).toHaveAttribute("data-atlas-density", "comfortable");
     });
 
     it("opens the grouped Governance Center from the sidebar", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Menu,
   Moon,
   RefreshCw,
+  Rows3,
   Search,
   Settings2,
   ShieldCheck,
@@ -53,6 +54,10 @@ import {
 } from "./atlas/model";
 import { buildSearchIndex } from "./atlas/search";
 import { workspaceDetailLabel } from "./atlas/workspace-display";
+import {
+  isDisplayDensity,
+  useDisplayPreference,
+} from "./atlas/display-preferences";
 
 import { OverviewView } from "./atlas/views/Overview";
 import { MapView } from "./atlas/views/Map";
@@ -223,6 +228,19 @@ function App() {
     hasData,
     requiresDeploymentSync,
   } = useAtlas();
+  const density = useDisplayPreference(
+    currentUser.id,
+    data.workspace.fabricId,
+    "density",
+    "comfortable",
+    isDisplayDensity,
+  );
+  useEffect(() => {
+    document.documentElement.dataset.atlasDensity = density.value;
+    return () => {
+      delete document.documentElement.dataset.atlasDensity;
+    };
+  }, [density.value]);
   const workspaceSearchIndex = useMemo(() => buildSearchIndex(data), [data]);
 
   useEffect(() => {
@@ -356,7 +374,7 @@ function App() {
 
       {/* Main */}
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="relative flex h-[52px] shrink-0 items-center justify-between gap-[10px] border-b border-border bg-card px-[12px] shadow-fabric-2 sm:px-[18px] lg:px-[20px]">
+        <header className="atlas-toolbar relative flex min-h-[52px] shrink-0 items-center justify-between border-b border-border bg-card px-m shadow-fabric-2 sm:px-l lg:px-xl">
           <div className="flex min-w-0 items-center gap-[8px]">
             <Dialog.Trigger asChild>
               <button
@@ -384,7 +402,7 @@ function App() {
             >
               <Search className="icon-size-100" aria-hidden="true" />
               Search workspace
-              <kbd className="rounded border border-border bg-muted px-xs py-xxs font-mono text-100">
+              <kbd className="rounded border border-border bg-muted px-xs py-xxs font-mono text-200">
                 Ctrl K
               </kbd>
             </button>
@@ -430,6 +448,19 @@ function App() {
             </button>
             <button
               type="button"
+              onClick={() =>
+                density.setValue(density.value === "compact" ? "comfortable" : "compact")
+              }
+              aria-label={density.value === "compact" ? "Switch to comfortable density" : "Switch to compact density"}
+              aria-pressed={density.value === "compact"}
+              title={density.value === "compact" ? "Use comfortable spacing" : "Use compact spacing"}
+              className="flex items-center gap-s rounded-md border border-border bg-card px-s text-200 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <Rows3 className="icon-size-200" aria-hidden="true" />
+              <span className="hidden xl:inline">{density.value === "compact" ? "Compact" : "Comfortable"}</span>
+            </button>
+            <button
+              type="button"
               onClick={toggleTheme}
               title={isDark ? "Switch to light theme" : "Switch to dark theme"}
               aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
@@ -455,6 +486,11 @@ function App() {
             </div>
           )}
         </header>
+        {density.error && (
+          <p role="status" className="border-b border-status-warning/30 bg-status-warning/10 px-l py-s text-200 text-foreground">
+            {density.error}
+          </p>
+        )}
 
         <main
           ref={mainRef}

--- a/src/atlas/access-review-evidence.spec.ts
+++ b/src/atlas/access-review-evidence.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  accessReviewEvidenceKey,
+  serializeAccessReviewEvidence,
+} from "./access-review-evidence";
+import { buildAccessReviewRows } from "./governance";
+import type { AtlasData, Grant } from "./model";
+
+function dataWithGrants(grants: Grant[]): AtlasData {
+  return {
+    workspace: {
+      fabricId: "11111111-1111-4111-8111-111111111111",
+      displayName: "Workspace",
+      capacity: "Capacity",
+      region: "Region",
+    },
+    items: [
+      {
+        fabricId: "22222222-2222-4222-8222-222222222222",
+        displayName: "Model",
+        itemType: "SemanticModel",
+        health: "healthy",
+        endorsement: "none",
+        tags: [],
+      },
+    ],
+    principals: [
+      {
+        principalId: "33333333-3333-4333-8333-333333333333",
+        displayName: "Analyst",
+        email: "analyst@example.com",
+        kind: "user",
+        workspaceRole: "Viewer",
+      },
+    ],
+    grants,
+    edges: [],
+    jobs: [],
+    config: [],
+    comments: [],
+    syncRuns: [],
+  };
+}
+
+const WORKSPACE_OWNER: Grant = {
+  principalRef: "33333333-3333-4333-8333-333333333333",
+  accessLevel: "owner",
+  source: "workspaceRole",
+  roleName: "Admin",
+};
+
+const DIRECT_VIEW: Grant = {
+  itemFabricId: "22222222-2222-4222-8222-222222222222",
+  principalRef: "analyst@example.com",
+  accessLevel: "view",
+  source: "directShare",
+};
+
+describe("access review evidence", () => {
+  it("is stable when grant order and display names change", async () => {
+    const initial = dataWithGrants([WORKSPACE_OWNER, DIRECT_VIEW]);
+    const reordered = dataWithGrants([DIRECT_VIEW, WORKSPACE_OWNER]);
+    reordered.items[0].displayName = "Renamed model";
+    reordered.principals[0].displayName = "Renamed analyst";
+
+    const initialRow = buildAccessReviewRows(initial)[0];
+    const reorderedRow = buildAccessReviewRows(reordered)[0];
+
+    expect(serializeAccessReviewEvidence(reorderedRow)).toBe(
+      serializeAccessReviewEvidence(initialRow),
+    );
+    await expect(accessReviewEvidenceKey(reorderedRow)).resolves.toBe(
+      await accessReviewEvidenceKey(initialRow),
+    );
+  });
+
+  it("changes when a contributing grant changes but the strongest level does not", async () => {
+    const initialRow = buildAccessReviewRows(
+      dataWithGrants([WORKSPACE_OWNER, DIRECT_VIEW]),
+    )[0];
+    const changedRow = buildAccessReviewRows(
+      dataWithGrants([
+        WORKSPACE_OWNER,
+        { ...DIRECT_VIEW, accessLevel: "edit" },
+      ]),
+    )[0];
+
+    expect(initialRow.effectiveAccess).toBe("owner");
+    expect(changedRow.effectiveAccess).toBe("owner");
+    await expect(accessReviewEvidenceKey(changedRow)).resolves.not.toBe(
+      await accessReviewEvidenceKey(initialRow),
+    );
+  });
+
+  it("changes when principal resolution changes", async () => {
+    const resolved = dataWithGrants([DIRECT_VIEW]);
+    const unresolved = dataWithGrants([DIRECT_VIEW]);
+    unresolved.principals = [];
+
+    const resolvedRow = buildAccessReviewRows(resolved)[0];
+    const unresolvedRow = buildAccessReviewRows(unresolved)[0];
+
+    expect(resolvedRow.principalResolution).toBe("resolved");
+    expect(unresolvedRow.principalResolution).toBe("unresolved");
+    await expect(accessReviewEvidenceKey(unresolvedRow)).resolves.not.toBe(
+      await accessReviewEvidenceKey(resolvedRow),
+    );
+  });
+});

--- a/src/atlas/access-review-evidence.ts
+++ b/src/atlas/access-review-evidence.ts
@@ -1,0 +1,86 @@
+import type { AccessReviewRow } from "./governance";
+import type { Grant } from "./model";
+
+const EVIDENCE_VERSION = 1;
+
+function normalize(value: string | undefined): string {
+  return (value ?? "")
+    .normalize("NFKC")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function canonicalPrincipal(row: AccessReviewRow): string {
+  return row.principalId
+    ? `principal:${normalize(row.principalId)}`
+    : row.principalKey;
+}
+
+function canonicalGrant(row: AccessReviewRow, grant: Grant): string {
+  const principal = row.principalId
+    ? canonicalPrincipal(row)
+    : `reference:${normalize(grant.principalRef) || "(blank)"}`;
+  return [
+    grant.itemFabricId
+      ? `item:${normalize(grant.itemFabricId)}`
+      : "workspace",
+    principal,
+    grant.accessLevel,
+    grant.source,
+    normalize(grant.roleName),
+    grant.flag ?? "",
+  ].join("\u0000");
+}
+
+export function serializeAccessReviewEvidence(row: AccessReviewRow): string {
+  const grants = [
+    ...new Set(row.applicableGrants.map((grant) => canonicalGrant(row, grant))),
+  ].sort();
+  const candidateIds = [
+    ...new Set(
+      row.principalCandidates.map((principal) =>
+        normalize(principal.principalId),
+      ),
+    ),
+  ].sort();
+
+  return JSON.stringify({
+    version: EVIDENCE_VERSION,
+    itemFabricId: normalize(row.itemId),
+    principal: canonicalPrincipal(row),
+    principalResolution: row.principalResolution,
+    principalCandidateIds: candidateIds,
+    effectiveAccess: row.effectiveAccess,
+    origin: row.origin,
+    grants,
+  });
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function accessReviewEvidenceKey(
+  row: AccessReviewRow,
+): Promise<string> {
+  return `v${EVIDENCE_VERSION}:sha256:${await sha256(
+    serializeAccessReviewEvidence(row),
+  )}`;
+}
+
+export async function accessReviewEvidenceKeys(
+  rows: AccessReviewRow[],
+): Promise<Map<string, string>> {
+  const entries = await Promise.all(
+    rows.map(
+      async (row) =>
+        [row.id, await accessReviewEvidenceKey(row)] as const,
+    ),
+  );
+  return new Map(entries);
+}

--- a/src/atlas/access-reviews.spec.ts
+++ b/src/atlas/access-reviews.spec.ts
@@ -1,172 +1,317 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  deleteAccessReview,
-  loadAccessReviews,
+  appendAccessReviewEvent,
+  buildAccessReviewHistories,
+  clearAccessReview,
+  loadAccessReviewHistories,
   saveAccessReview,
+  type AccessReviewHistoryEntry,
 } from "./access-reviews";
 
 const mocks = vi.hoisted(() => ({
-  execute: vi.fn(),
-  create: vi.fn(),
-  update: vi.fn(),
-  delete: vi.fn(),
-  where: vi.fn(),
-  orderBy: vi.fn(),
-  select: vi.fn(),
+  legacyRows: [] as Array<Record<string, unknown>>,
+  eventRows: [] as Array<Record<string, unknown>>,
+  legacySelect: vi.fn(),
+  eventSelect: vi.fn(),
+  legacyWhere: vi.fn(),
+  eventWhere: vi.fn(),
+  legacyExecute: vi.fn(),
+  eventExecute: vi.fn(),
+  eventCreate: vi.fn(),
 }));
 
 vi.mock("@/lib/rayfin-client", () => ({
   getRayfinClient: () => ({
     data: {
       AccessReview: {
-        select: mocks.select,
-        create: mocks.create,
-        update: mocks.update,
-        delete: mocks.delete,
+        select: mocks.legacySelect,
+      },
+      AccessReviewEvent: {
+        select: mocks.eventSelect,
+        create: mocks.eventCreate,
       },
     },
   }),
 }));
 
-describe("access review decisions", () => {
+function matchesScope(
+  row: Record<string, unknown>,
+  filter: Record<string, { eq?: unknown }>,
+): boolean {
+  return Object.entries(filter).every(
+    ([field, condition]) => row[field] === condition.eq,
+  );
+}
+
+function configureQuery(
+  select: typeof mocks.legacySelect,
+  where: typeof mocks.legacyWhere,
+  execute: typeof mocks.legacyExecute,
+  rows: Array<Record<string, unknown>>,
+) {
+  let filter: Record<string, { eq?: unknown }> = {};
+  const query = {
+    where: where.mockImplementation(
+      (next: Record<string, { eq?: unknown }>) => {
+        filter = next;
+        return query;
+      },
+    ),
+    orderBy: vi.fn(() => query),
+    execute: execute.mockImplementation(async () =>
+      rows.filter((row) => matchesScope(row, filter)),
+    ),
+  };
+  select.mockReturnValue(query);
+}
+
+function event(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: crypto.randomUUID(),
+    workspace_id: "workspace-1",
+    user_id: "user-1",
+    rowKey: "row-1",
+    itemFabricId: "item-1",
+    principalRef: "Analyst",
+    status: "accepted",
+    evidenceKey: "evidence-1",
+    eventOrder: "0000000000001:event",
+    occurredAt: "2026-09-05T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function legacy(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: crypto.randomUUID(),
+    workspace_id: "workspace-1",
+    user_id: "user-1",
+    recordKey: "legacy-key",
+    rowKey: "row-1",
+    itemFabricId: "item-1",
+    principalRef: "Analyst",
+    status: "reviewed",
+    reviewedAt: "2026-09-04T10:00:00.000Z",
+    updatedAt: "2026-09-04T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("access review history", () => {
   beforeEach(() => {
-    Object.values(mocks).forEach((mock) => mock.mockReset());
-    const query = {
-      where: mocks.where,
-      orderBy: mocks.orderBy,
-      execute: mocks.execute,
-    };
-    mocks.select.mockReturnValue(query);
-    mocks.where.mockReturnValue(query);
-    mocks.orderBy.mockReturnValue(query);
-    mocks.execute.mockResolvedValue([]);
+    mocks.legacyRows.length = 0;
+    mocks.eventRows.length = 0;
+    [
+      mocks.legacySelect,
+      mocks.eventSelect,
+      mocks.legacyWhere,
+      mocks.eventWhere,
+      mocks.legacyExecute,
+      mocks.eventExecute,
+      mocks.eventCreate,
+    ].forEach((mock) => mock.mockReset());
+    configureQuery(
+      mocks.legacySelect,
+      mocks.legacyWhere,
+      mocks.legacyExecute,
+      mocks.legacyRows,
+    );
+    configureQuery(
+      mocks.eventSelect,
+      mocks.eventWhere,
+      mocks.eventExecute,
+      mocks.eventRows,
+    );
+    mocks.eventCreate.mockImplementation(
+      async (value: Record<string, unknown>) => {
+        const row = { id: crypto.randomUUID(), ...value };
+        mocks.eventRows.push(row);
+        return row;
+      },
+    );
   });
 
-  it("loads decisions for the current user and workspace", async () => {
-    mocks.execute.mockResolvedValue([
-      {
-        id: "review-1",
-        workspace_id: "workspace-1",
-        user_id: "user-1",
-        rowKey: "row-1",
-        itemFabricId: "item-1",
-        principalRef: "Analyst",
-        status: "accepted",
-        reviewedAt: "2026-08-29T20:00:00.000Z",
-        updatedAt: "2026-08-29T20:00:00.000Z",
-      },
-    ]);
-
-    await expect(
-      loadAccessReviews(false, "workspace-1", "user-1"),
-    ).resolves.toEqual([
-      expect.objectContaining({
-        rowKey: "row-1",
-        status: "accepted",
+  it("loads only the requested workspace and user scope", async () => {
+    mocks.eventRows.push(
+      event(),
+      event({ id: "other-user", user_id: "user-2", rowKey: "row-2" }),
+      event({
+        id: "other-workspace",
+        workspace_id: "workspace-2",
+        rowKey: "row-3",
       }),
-    ]);
-    expect(mocks.where).toHaveBeenCalledWith({
+    );
+
+    const reviews = await loadAccessReviewHistories(
+      false,
+      "workspace-1",
+      "user-1",
+      new Map([["row-1", "evidence-1"]]),
+    );
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].rowKey).toBe("row-1");
+    expect(mocks.eventWhere).toHaveBeenCalledWith({
+      workspace_id: { eq: "workspace-1" },
+      user_id: { eq: "user-1" },
+    });
+    expect(mocks.legacyWhere).toHaveBeenCalledWith({
       workspace_id: { eq: "workspace-1" },
       user_id: { eq: "user-1" },
     });
   });
 
-  it("creates and updates a review decision", async () => {
-    mocks.create.mockImplementation(async (value) => ({
-      id: "review-2",
-      ...value,
-    }));
-    mocks.update.mockResolvedValue(undefined);
+  it("keeps legacy decisions as history and requires revalidation", async () => {
+    mocks.legacyRows.push(
+      legacy({ note: "Imported decision" }),
+    );
 
-    const created = await saveAccessReview(
+    const [review] = await loadAccessReviewHistories(
       false,
       "workspace-1",
       "user-1",
-      {
-        rowKey: "row-2",
-        itemFabricId: "item-2",
-        principalRef: "Guest",
-        status: "needsAction",
-      },
-    );
-    const updated = await saveAccessReview(
-      false,
-      "workspace-1",
-      "user-1",
-      {
-        current: created,
-        rowKey: created.rowKey,
-        itemFabricId: created.itemFabricId,
-        principalRef: created.principalRef,
-        status: "reviewed",
-        note: "Validated with the owner",
-      },
+      new Map([["row-1", "current-evidence"]]),
     );
 
-    expect(created.id).toBe("review-2");
-    expect(updated).toMatchObject({
+    expect(review.decision).toMatchObject({
       status: "reviewed",
-      note: "Validated with the owner",
+      note: "Imported decision",
+      needsReview: true,
+      source: "legacy",
     });
-    expect(mocks.update).toHaveBeenCalledWith(
-      { id: "review-2" },
-      expect.objectContaining({ status: "reviewed" }),
-    );
+    expect(review.history).toEqual([
+      expect.objectContaining({ source: "legacy" }),
+    ]);
+    expect(review.history[0].evidenceKey).toBeUndefined();
   });
 
-  it("keeps preview reviews local to the caller", async () => {
-    const decision = await saveAccessReview(
-      true,
-      "workspace-1",
-      "preview-user",
+  it("uses the latest event and distinguishes unchanged from changed evidence", () => {
+    const entries: AccessReviewHistoryEntry[] = [
       {
-        rowKey: "row-preview",
-        itemFabricId: "item-1",
-        principalRef: "Preview",
-        status: "reviewed",
-      },
-    );
-    await deleteAccessReview(true, decision.id);
-
-    expect(decision.id).toBeTruthy();
-    expect(mocks.create).not.toHaveBeenCalled();
-    expect(mocks.delete).not.toHaveBeenCalled();
-  });
-
-  it("reuses a persisted decision found by its unique record key", async () => {
-    mocks.execute.mockResolvedValueOnce([
-      {
-        id: "existing-review",
-        workspace_id: "workspace-1",
-        user_id: "user-1",
-        recordKey: "record-key",
-        rowKey: "row-existing",
+        id: "legacy",
+        rowKey: "row-1",
         itemFabricId: "item-1",
         principalRef: "Analyst",
         status: "reviewed",
-        reviewedAt: "2026-08-29T20:00:00.000Z",
-        updatedAt: "2026-08-29T20:00:00.000Z",
+        occurredAt: "2026-09-04T10:00:00.000Z",
+        source: "legacy",
       },
-    ]);
-    mocks.update.mockResolvedValue(undefined);
-
-    const decision = await saveAccessReview(
-      false,
-      "workspace-1",
-      "user-1",
       {
-        rowKey: "row-existing",
+        id: "newer",
+        rowKey: "row-1",
         itemFabricId: "item-1",
         principalRef: "Analyst",
         status: "accepted",
+        evidenceKey: "evidence-2",
+        eventOrder: "0000000000002:newer",
+        occurredAt: "2026-09-05T11:00:00.000Z",
+        source: "event",
+      },
+      {
+        id: "older",
+        rowKey: "row-1",
+        itemFabricId: "item-1",
+        principalRef: "Analyst",
+        status: "needsAction",
+        evidenceKey: "evidence-1",
+        eventOrder: "0000000000001:older",
+        occurredAt: "2026-09-05T10:00:00.000Z",
+        source: "event",
+      },
+    ];
+
+    expect(
+      buildAccessReviewHistories(
+        entries,
+        new Map([["row-1", "evidence-2"]]),
+      )[0].decision,
+    ).toMatchObject({ status: "accepted", needsReview: false });
+    expect(
+      buildAccessReviewHistories(
+        entries,
+        new Map([["row-1", "changed-evidence"]]),
+      )[0].decision,
+    ).toMatchObject({ status: "accepted", needsReview: true });
+  });
+
+  it("appends decisions and clears without deleting personal history", async () => {
+    const accepted = await saveAccessReview(
+      false,
+      "workspace-1",
+      "user-1",
+      {
+        rowKey: "row-1",
+        itemFabricId: "item-1",
+        principalRef: "Analyst",
+        status: "accepted",
+        evidenceKey: "evidence-1",
+        note: "Validated",
       },
     );
-
-    expect(decision.id).toBe("existing-review");
-    expect(mocks.create).not.toHaveBeenCalled();
-    expect(mocks.update).toHaveBeenCalledWith(
-      { id: "existing-review" },
-      expect.objectContaining({ status: "accepted" }),
+    const cleared = await clearAccessReview(
+      false,
+      "workspace-1",
+      "user-1",
+      {
+        rowKey: "row-1",
+        itemFabricId: "item-1",
+        principalRef: "Analyst",
+        evidenceKey: "evidence-1",
+      },
     );
+    const reviews = appendAccessReviewEvent(
+      appendAccessReviewEvent(
+        [],
+        accepted,
+        new Map([["row-1", "evidence-1"]]),
+      ),
+      cleared,
+      new Map([["row-1", "evidence-1"]]),
+    );
+
+    expect(mocks.eventCreate).toHaveBeenCalledTimes(2);
+    expect(mocks.eventCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        workspace_id: "workspace-1",
+        user_id: "user-1",
+        status: "accepted",
+      }),
+    );
+    expect(mocks.eventCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        workspace_id: "workspace-1",
+        user_id: "user-1",
+        status: "cleared",
+      }),
+    );
+    expect(reviews[0].decision).toBeUndefined();
+    expect(reviews[0].history.map((entry) => entry.status)).toEqual([
+      "cleared",
+      "accepted",
+    ]);
+  });
+
+  it("surfaces load and save failures", async () => {
+    mocks.eventExecute.mockRejectedValueOnce(new Error("load failed"));
+    await expect(
+      loadAccessReviewHistories(false, "workspace-1", "user-1"),
+    ).rejects.toThrow("load failed");
+
+    mocks.eventCreate.mockRejectedValueOnce(new Error("save failed"));
+    await expect(
+      saveAccessReview(false, "workspace-1", "user-1", {
+        rowKey: "row-1",
+        itemFabricId: "item-1",
+        principalRef: "Analyst",
+        status: "accepted",
+        evidenceKey: "evidence-1",
+      }),
+    ).rejects.toThrow("save failed");
   });
 });

--- a/src/atlas/access-reviews.ts
+++ b/src/atlas/access-reviews.ts
@@ -1,6 +1,21 @@
 import { getRayfinClient } from "@/lib/rayfin-client";
 
 export type AccessReviewStatus = "reviewed" | "accepted" | "needsAction";
+export type AccessReviewEventStatus = AccessReviewStatus | "cleared";
+export type AccessReviewHistorySource = "event" | "legacy";
+
+export interface AccessReviewHistoryEntry {
+  id: string;
+  rowKey: string;
+  itemFabricId: string;
+  principalRef: string;
+  status: AccessReviewEventStatus;
+  note?: string;
+  evidenceKey?: string;
+  eventOrder?: string;
+  occurredAt: string;
+  source: AccessReviewHistorySource;
+}
 
 export interface AccessReviewDecision {
   id: string;
@@ -9,11 +24,22 @@ export interface AccessReviewDecision {
   principalRef: string;
   status: AccessReviewStatus;
   note?: string;
+  evidenceKey?: string;
   reviewedAt: string;
   updatedAt: string;
+  needsReview: boolean;
+  source: AccessReviewHistorySource;
 }
 
-interface ReviewRow {
+export interface AccessReviewHistory {
+  rowKey: string;
+  itemFabricId: string;
+  principalRef: string;
+  decision?: AccessReviewDecision;
+  history: AccessReviewHistoryEntry[];
+}
+
+interface LegacyReviewRow {
   id: string;
   workspace_id: string;
   user_id: string;
@@ -27,23 +53,21 @@ interface ReviewRow {
   updatedAt: string | Date;
 }
 
-interface Query {
-  where(filter: Record<string, unknown>): Query;
-  orderBy(order: Record<string, "asc" | "desc">): Query;
-  execute(): Promise<ReviewRow[]>;
+interface EventRow {
+  id: string;
+  workspace_id: string;
+  user_id: string;
+  rowKey: string;
+  itemFabricId: string;
+  principalRef: string;
+  status: AccessReviewEventStatus;
+  evidenceKey: string;
+  eventOrder: string;
+  note?: string;
+  occurredAt: string | Date;
 }
 
-interface Api {
-  select(fields: readonly string[]): Query;
-  create(value: Record<string, unknown>): Promise<ReviewRow>;
-  update(
-    filter: Record<string, unknown>,
-    value: Record<string, unknown>,
-  ): Promise<unknown>;
-  delete(filter: Record<string, unknown>): Promise<unknown>;
-}
-
-const FIELDS = [
+const LEGACY_FIELDS = [
   "id",
   "workspace_id",
   "user_id",
@@ -57,13 +81,36 @@ const FIELDS = [
   "updatedAt",
 ] as const;
 
-function api(): Api {
-  return (
-    getRayfinClient().data as unknown as { AccessReview: Api }
-  ).AccessReview;
+const EVENT_FIELDS = [
+  "id",
+  "workspace_id",
+  "user_id",
+  "rowKey",
+  "itemFabricId",
+  "principalRef",
+  "status",
+  "evidenceKey",
+  "eventOrder",
+  "note",
+  "occurredAt",
+] as const;
+
+let lastEventTime = 0;
+
+function nextEventDate(): Date {
+  lastEventTime = Math.max(Date.now(), lastEventTime + 1);
+  return new Date(lastEventTime);
 }
 
-function parse(row: ReviewRow): AccessReviewDecision {
+function apis() {
+  const data = getRayfinClient().data;
+  return {
+    legacy: data.AccessReview,
+    events: data.AccessReviewEvent,
+  };
+}
+
+function legacyEntry(row: LegacyReviewRow): AccessReviewHistoryEntry {
   return {
     id: String(row.id),
     rowKey: String(row.rowKey),
@@ -71,56 +118,227 @@ function parse(row: ReviewRow): AccessReviewDecision {
     principalRef: String(row.principalRef),
     status: row.status,
     note: row.note ? String(row.note) : undefined,
-    reviewedAt: new Date(row.reviewedAt).toISOString(),
-    updatedAt: new Date(row.updatedAt).toISOString(),
+    occurredAt: new Date(row.reviewedAt).toISOString(),
+    source: "legacy",
   };
 }
 
-function reviewRecordKey(
-  workspaceId: string,
-  userId: string,
-  rowKey: string,
-): string {
-  const key = [workspaceId, userId, rowKey]
-    .map((value) => encodeURIComponent(value))
-    .join("|");
-  if (key.length > 450) {
-    throw new Error("Access review identity is too large to persist.");
-  }
-  return key;
+function eventEntry(row: EventRow): AccessReviewHistoryEntry {
+  return {
+    id: String(row.id),
+    rowKey: String(row.rowKey),
+    itemFabricId: String(row.itemFabricId),
+    principalRef: String(row.principalRef),
+    status: row.status,
+    note: row.note ? String(row.note) : undefined,
+    evidenceKey: String(row.evidenceKey),
+    eventOrder: String(row.eventOrder),
+    occurredAt: new Date(row.occurredAt).toISOString(),
+    source: "event",
+  };
 }
 
-async function findExisting(recordKey: string): Promise<ReviewRow | undefined> {
-  const rows = await api()
-    .select(FIELDS)
-    .where({ recordKey: { eq: recordKey } })
-    .orderBy({ reviewedAt: "desc" })
-    .execute();
-  return rows[0];
+function compareHistory(
+  left: AccessReviewHistoryEntry,
+  right: AccessReviewHistoryEntry,
+): number {
+  if (left.eventOrder && right.eventOrder) {
+    const byEventOrder = right.eventOrder.localeCompare(left.eventOrder);
+    if (byEventOrder !== 0) return byEventOrder;
+  }
+  const byDate =
+    new Date(right.occurredAt).getTime() -
+    new Date(left.occurredAt).getTime();
+  if (byDate !== 0) return byDate;
+  if (left.source !== right.source) return left.source === "event" ? -1 : 1;
+  return left.id.localeCompare(right.id);
+}
+
+function decisionFromEntry(
+  entry: AccessReviewHistoryEntry,
+  currentEvidence: string | undefined,
+): AccessReviewDecision | undefined {
+  if (entry.status === "cleared") return undefined;
+  return {
+    id: entry.id,
+    rowKey: entry.rowKey,
+    itemFabricId: entry.itemFabricId,
+    principalRef: entry.principalRef,
+    status: entry.status,
+    note: entry.note,
+    evidenceKey: entry.evidenceKey,
+    reviewedAt: entry.occurredAt,
+    updatedAt: entry.occurredAt,
+    needsReview:
+      !entry.evidenceKey ||
+      !currentEvidence ||
+      entry.evidenceKey !== currentEvidence,
+    source: entry.source,
+  };
+}
+
+function currentEntry(
+  history: AccessReviewHistoryEntry[],
+): AccessReviewHistoryEntry | undefined {
+  return (
+    history.find((entry) => entry.source === "event") ??
+    history.find((entry) => entry.source === "legacy")
+  );
+}
+
+export function buildAccessReviewHistories(
+  entries: AccessReviewHistoryEntry[],
+  evidenceByRowKey: ReadonlyMap<string, string> = new Map(),
+): AccessReviewHistory[] {
+  const grouped = new Map<string, AccessReviewHistoryEntry[]>();
+  for (const entry of entries) {
+    const history = grouped.get(entry.rowKey) ?? [];
+    history.push(entry);
+    grouped.set(entry.rowKey, history);
+  }
+
+  return [...grouped.entries()]
+    .map(([rowKey, values]) => {
+      const history = [...values].sort(compareHistory);
+      const latest = currentEntry(history);
+      const identity = latest ?? history[0];
+      return {
+        rowKey,
+        itemFabricId: identity.itemFabricId,
+        principalRef: identity.principalRef,
+        decision: latest
+          ? decisionFromEntry(latest, evidenceByRowKey.get(rowKey))
+          : undefined,
+        history,
+      };
+    })
+    .sort((left, right) => left.rowKey.localeCompare(right.rowKey));
+}
+
+export function revalidateAccessReviewHistories(
+  reviews: AccessReviewHistory[],
+  evidenceByRowKey: ReadonlyMap<string, string>,
+): AccessReviewHistory[] {
+  return reviews.map((review) => {
+    const latest = currentEntry(review.history);
+    return {
+      ...review,
+      decision: latest
+        ? decisionFromEntry(latest, evidenceByRowKey.get(review.rowKey))
+        : undefined,
+    };
+  });
+}
+
+export function appendAccessReviewEvent(
+  reviews: AccessReviewHistory[],
+  event: AccessReviewHistoryEntry,
+  evidenceByRowKey: ReadonlyMap<string, string>,
+): AccessReviewHistory[] {
+  const entries = reviews.flatMap((review) => review.history);
+  return buildAccessReviewHistories(
+    [event, ...entries],
+    evidenceByRowKey,
+  );
+}
+
+export async function loadAccessReviewHistories(
+  isPreview: boolean,
+  workspaceId: string,
+  userId: string,
+  evidenceByRowKey: ReadonlyMap<string, string> = new Map(),
+): Promise<AccessReviewHistory[]> {
+  if (isPreview) return [];
+  const { legacy, events } = apis();
+  const scope = {
+    workspace_id: { eq: workspaceId },
+    user_id: { eq: userId },
+  };
+  const [eventRows, legacyRows] = await Promise.all([
+    events
+      .select(EVENT_FIELDS)
+      .where(scope)
+      .orderBy({ eventOrder: "desc" })
+      .execute(),
+    legacy
+      .select(LEGACY_FIELDS)
+      .where(scope)
+      .orderBy({ reviewedAt: "desc" })
+      .execute(),
+  ]);
+  return buildAccessReviewHistories(
+    [
+      ...eventRows.map(eventEntry),
+      ...legacyRows.map(legacyEntry),
+    ],
+    evidenceByRowKey,
+  );
 }
 
 export async function loadAccessReviews(
   isPreview: boolean,
   workspaceId: string,
   userId: string,
+  evidenceByRowKey: ReadonlyMap<string, string> = new Map(),
 ): Promise<AccessReviewDecision[]> {
-  if (isPreview) return [];
-  const rows = await api()
-    .select(FIELDS)
-    .where({
-      workspace_id: { eq: workspaceId },
-      user_id: { eq: userId },
-    })
-    .orderBy({ reviewedAt: "desc" })
-    .execute();
-  const decisions: AccessReviewDecision[] = [];
-  const seen = new Set<string>();
-  for (const row of rows) {
-    if (seen.has(row.rowKey)) continue;
-    seen.add(row.rowKey);
-    decisions.push(parse(row));
+  const reviews = await loadAccessReviewHistories(
+    isPreview,
+    workspaceId,
+    userId,
+    evidenceByRowKey,
+  );
+  return reviews.flatMap((review) =>
+    review.decision ? [review.decision] : [],
+  );
+}
+
+async function appendEvent(
+  isPreview: boolean,
+  workspaceId: string,
+  userId: string,
+  input: {
+    rowKey: string;
+    itemFabricId: string;
+    principalRef: string;
+    status: AccessReviewEventStatus;
+    evidenceKey: string;
+    note?: string;
+  },
+): Promise<AccessReviewHistoryEntry> {
+  if (!input.evidenceKey) {
+    throw new Error("Access review evidence is required.");
   }
-  return decisions;
+  const occurredAt = nextEventDate();
+  const eventOrder = `${occurredAt.getTime().toString().padStart(13, "0")}:${crypto.randomUUID()}`;
+  const row: EventRow = {
+    id: crypto.randomUUID(),
+    workspace_id: workspaceId,
+    user_id: userId,
+    rowKey: input.rowKey,
+    itemFabricId: input.itemFabricId,
+    principalRef: input.principalRef,
+    status: input.status,
+    evidenceKey: input.evidenceKey,
+    eventOrder,
+    note: input.note?.trim() || undefined,
+    occurredAt,
+  };
+  if (isPreview) return eventEntry(row);
+  const { events } = apis();
+  return eventEntry(
+    await events.create({
+      workspace_id: workspaceId,
+      user_id: userId,
+      rowKey: row.rowKey,
+      itemFabricId: row.itemFabricId,
+      principalRef: row.principalRef,
+      status: row.status,
+      evidenceKey: row.evidenceKey,
+      eventOrder: row.eventOrder,
+      note: row.note,
+      occurredAt,
+    }),
+  );
 }
 
 export async function saveAccessReview(
@@ -128,83 +346,30 @@ export async function saveAccessReview(
   workspaceId: string,
   userId: string,
   input: {
-    current?: AccessReviewDecision;
     rowKey: string;
     itemFabricId: string;
     principalRef: string;
     status: AccessReviewStatus;
+    evidenceKey: string;
     note?: string;
   },
-): Promise<AccessReviewDecision> {
-  const now = new Date();
-  const recordKey = reviewRecordKey(workspaceId, userId, input.rowKey);
-  const row: ReviewRow = {
-    id: input.current?.id ?? crypto.randomUUID(),
-    workspace_id: workspaceId,
-    user_id: userId,
-    recordKey,
-    rowKey: input.rowKey,
-    itemFabricId: input.itemFabricId,
-    principalRef: input.principalRef,
-    status: input.status,
-    note: input.note?.trim() || undefined,
-    reviewedAt: now,
-    updatedAt: now,
-  };
-  if (isPreview) return parse(row);
-  const existing = input.current
-    ? ({
-        ...row,
-        id: input.current.id,
-      } as ReviewRow)
-    : await findExisting(recordKey);
-  if (existing) {
-    await api().update(
-      { id: existing.id },
-      {
-        status: row.status,
-        note: row.note,
-        reviewedAt: now,
-        updatedAt: now,
-      },
-    );
-    return parse({ ...row, id: existing.id });
-  }
-  try {
-    return parse(
-      await api().create({
-        workspace_id: workspaceId,
-        user_id: userId,
-        recordKey,
-        rowKey: row.rowKey,
-        itemFabricId: row.itemFabricId,
-        principalRef: row.principalRef,
-        status: row.status,
-        note: row.note,
-        reviewedAt: now,
-        updatedAt: now,
-      }),
-    );
-  } catch (error) {
-    const concurrent = await findExisting(recordKey);
-    if (!concurrent) throw error;
-    await api().update(
-      { id: concurrent.id },
-      {
-        status: row.status,
-        note: row.note,
-        reviewedAt: now,
-        updatedAt: now,
-      },
-    );
-    return parse({ ...row, id: concurrent.id });
-  }
+): Promise<AccessReviewHistoryEntry> {
+  return appendEvent(isPreview, workspaceId, userId, input);
 }
 
-export async function deleteAccessReview(
+export async function clearAccessReview(
   isPreview: boolean,
-  id: string,
-): Promise<void> {
-  if (isPreview) return;
-  await api().delete({ id });
+  workspaceId: string,
+  userId: string,
+  input: {
+    rowKey: string;
+    itemFabricId: string;
+    principalRef: string;
+    evidenceKey: string;
+  },
+): Promise<AccessReviewHistoryEntry> {
+  return appendEvent(isPreview, workspaceId, userId, {
+    ...input,
+    status: "cleared",
+  });
 }

--- a/src/atlas/backend.spec.ts
+++ b/src/atlas/backend.spec.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SAMPLE_DATA } from "./model";
 import {
+  metadataObjectLineageEdges,
+  parseOntologyMetadata,
+  projectItemMetadataToSchema,
+} from "./item-metadata";
+import {
   loadFromDb,
   loadHistoryFromDb,
   persistComment,
@@ -738,6 +743,78 @@ describe("Rayfin snapshot persistence", () => {
     expect(schemaWrites).toHaveLength(1);
     expect(schemaWrites[0].value).not.toContain("businessValue");
     expect(schemaWrites[0].value).not.toContain("secret");
+  });
+
+  it("persists safe item metadata and verified object lineage as hidden chunks", async () => {
+    const atlas = structuredClone(SAMPLE_DATA);
+    const ontology = atlas.items.find(
+      (item) => item.itemType === "SemanticModel",
+    )!;
+    const source = atlas.items.find((item) => item.itemType === "Lakehouse")!;
+    ontology.itemType = "Ontology";
+    const metadata = parseOntologyMetadata({
+      entities: [
+        {
+          id: "customer",
+          name: "Customer",
+          properties: [
+            { id: "customer-id", name: "Customer ID", valueType: "String" },
+          ],
+          entityIdParts: ["customer-id"],
+        },
+      ],
+      relationships: [],
+      bindings: [
+        {
+          id: "customer-binding",
+          entityId: "customer",
+          dataBindingConfiguration: {
+            sourceTableProperties: {
+              itemId: source.fabricId,
+              sourceSchema: "dbo",
+              sourceTableName: "Customers",
+            },
+            propertyBindings: [
+              {
+                sourceColumnName: "CustomerId",
+                targetPropertyId: "customer-id",
+              },
+            ],
+          },
+        },
+      ],
+      contextualizations: [],
+    })!;
+    atlas.schema = {
+      [ontology.fabricId]: projectItemMetadataToSchema(metadata),
+    };
+    atlas.itemMetadata = { [ontology.fabricId]: metadata };
+    atlas.objectEdges = metadataObjectLineageEdges(
+      ontology.fabricId,
+      metadata,
+    );
+    mocks.mapSyncToAtlas.mockReturnValue(atlas);
+
+    await runFabricSync(false, identity);
+
+    const writes = mocks.data.ConfigEntry.create.mock.calls.map(
+      ([row]) => row as Record<string, unknown>,
+    );
+    expect(
+      writes.some((row) => row.section === "__object_edges__"),
+    ).toBe(true);
+    expect(
+      writes
+        .filter((row) => row.section === "__object_edges__")
+        .map((row) => String(row.value))
+        .join(""),
+    ).toContain("binds property");
+    expect(
+      writes
+        .filter((row) => row.section === "__schema__")
+        .map((row) => String(row.value))
+        .join(""),
+    ).not.toMatch(/aiInstructions|fewShots|businessValue/);
   });
 
   it("falls back to the previous complete manifest during hydration", async () => {

--- a/src/atlas/backend.ts
+++ b/src/atlas/backend.ts
@@ -44,6 +44,11 @@ import type {
   Principal,
   WorkspaceInfo,
 } from "./model";
+import {
+  itemMetadataFromSchema,
+  parseObjectLineagePayload,
+  type MetadataObjectLineageEdge,
+} from "./item-metadata";
 
 export type SyncProgressReporter = (progress: number, stage: string) => void;
 
@@ -432,7 +437,7 @@ async function persistSync(
     })),
   );
   reportProgress?.(94, "Writing object metadata");
-  // Persist the sub-object schema (tables/columns/measures) as hidden ConfigEntry
+  // Persist the sub-object schema as hidden ConfigEntry
   // rows so the Asset Catalog and deep lineage survive a reload without re-sync.
   // Values are chunked instead of truncated so wide table schemas retain every
   // real column while staying within ConfigEntry.value's 2,000-character limit.
@@ -465,6 +470,23 @@ async function persistSync(
     }
   }
   if (schemaRows.length) await insertAll("ConfigEntry", schemaRows);
+  const objectEdgeRows: Row[] = [];
+  const serializedObjectEdges = JSON.stringify(atlas.objectEdges ?? []);
+  const objectEdgeChunks =
+    serializedObjectEdges === "[]"
+      ? []
+      : serializedObjectEdges.match(/[\s\S]{1,1960}/g) ?? [];
+  for (let part = 0; part < objectEdgeChunks.length; part += 1) {
+    objectEdgeRows.push({
+      itemFabricId: atlas.workspace.fabricId,
+      section: "__object_edges__",
+      label: "workspace",
+      value: `v1:${String(part + 1).padStart(4, "0")}:${String(objectEdgeChunks.length).padStart(4, "0")}:${objectEdgeChunks[part]}`,
+    });
+  }
+  if (objectEdgeRows.length) {
+    await insertAll("ConfigEntry", objectEdgeRows);
+  }
 
   // The audit row and every snapshot row must succeed before the Workspace
   // marker is written. That final marker is the atomic visibility switch:
@@ -501,7 +523,7 @@ async function persistSync(
     grantCount: atlas.grants.length,
     jobCount: atlas.jobs.length,
     configCount: atlas.config.length,
-    schemaEntryCount: schemaRows.length,
+    schemaEntryCount: schemaRows.length + objectEdgeRows.length,
     summaryVersion: 1,
     healthyCount: snapshotSummary.healthyCount,
     staleCount: snapshotSummary.staleCount,
@@ -621,6 +643,38 @@ const MANIFEST_COUNTS = [
   ["schemaEntryCount", "schema chunks"],
 ] as const;
 
+function parseChunkedValue(
+  rawValues: string[],
+  malformedMessage: string,
+  incompleteMessage: string,
+): string {
+  if (rawValues.length === 1 && !rawValues[0].startsWith("v1:")) {
+    return rawValues[0];
+  }
+  const chunks = rawValues.map((value) => {
+    const match = /^v1:(\d{4}):(\d{4}):([\s\S]*)$/.exec(value);
+    if (!match) throw new Error(malformedMessage);
+    return {
+      part: Number(match[1]),
+      total: Number(match[2]),
+      value: match[3],
+    };
+  });
+  const total = chunks[0]?.total ?? 0;
+  if (
+    total !== chunks.length ||
+    chunks.some((chunk) => chunk.total !== total) ||
+    new Set(chunks.map((chunk) => chunk.part)).size !== total ||
+    chunks.some((chunk) => chunk.part < 1 || chunk.part > total)
+  ) {
+    throw new Error(incompleteMessage);
+  }
+  return chunks
+    .sort((left, right) => left.part - right.part)
+    .map((chunk) => chunk.value)
+    .join("");
+}
+
 function validateManifest(
   marker: Row,
   counts: Record<(typeof MANIFEST_COUNTS)[number][0], number>,
@@ -659,33 +713,11 @@ function parseSchemaRows(
   for (const [key, parts] of grouped) {
     const [itemId, label] = JSON.parse(key) as [string, string];
     const rawValues = parts.map((part) => String(part.value ?? ""));
-    let serialized: string;
-    if (rawValues.length === 1 && !rawValues[0].startsWith("v1:")) {
-      serialized = rawValues[0];
-    } else {
-      const chunks = rawValues.map((value) => {
-        const match = /^v1:(\d{4}):(\d{4}):([\s\S]*)$/.exec(value);
-        if (!match) throw new Error("snapshot contains a malformed schema chunk");
-        return {
-          part: Number(match[1]),
-          total: Number(match[2]),
-          value: match[3],
-        };
-      });
-      const total = chunks[0]?.total ?? 0;
-      if (
-        total !== chunks.length ||
-        chunks.some((chunk) => chunk.total !== total) ||
-        new Set(chunks.map((chunk) => chunk.part)).size !== total ||
-        chunks.some((chunk) => chunk.part < 1 || chunk.part > total)
-      ) {
-        throw new Error("snapshot contains an incomplete schema");
-      }
-      serialized = chunks
-        .sort((left, right) => left.part - right.part)
-        .map((chunk) => chunk.value)
-        .join("");
-    }
+    const serialized = parseChunkedValue(
+      rawValues,
+      "snapshot contains a malformed schema chunk",
+      "snapshot contains an incomplete schema",
+    );
     const parsed = JSON.parse(serialized) as {
       rows?: number;
       objectType?: string;
@@ -694,6 +726,7 @@ function parseSchemaRows(
       isHidden?: boolean;
       columns?: ModelTableSchema["columns"];
       measures?: ModelTableSchema["measures"];
+      metadata?: ModelTableSchema["metadata"];
     };
     const tables = schema[itemId] ?? [];
     tables.push({
@@ -705,10 +738,38 @@ function parseSchemaRows(
       isHidden: parsed.isHidden,
       columns: Array.isArray(parsed.columns) ? parsed.columns : [],
       measures: Array.isArray(parsed.measures) ? parsed.measures : [],
+      metadata: parsed.metadata,
     });
     schema[itemId] = tables;
   }
   return schema;
+}
+
+function parseObjectEdgeRows(rows: Row[]): MetadataObjectLineageEdge[] {
+  if (rows.length === 0) return [];
+  if (
+    rows.some(
+      (row) =>
+        String(row.section) !== "__object_edges__" ||
+        String(row.label) !== "workspace",
+    )
+  ) {
+    throw new Error("snapshot contains malformed object lineage chunks");
+  }
+  const serialized = parseChunkedValue(
+    rows.map((row) => String(row.value ?? "")),
+    "snapshot contains a malformed object lineage chunk",
+    "snapshot contains incomplete object lineage",
+  );
+  let raw: unknown;
+  try {
+    raw = JSON.parse(serialized);
+  } catch {
+    throw new Error("snapshot contains invalid object lineage");
+  }
+  const parsed = parseObjectLineagePayload(raw);
+  if (!parsed) throw new Error("snapshot contains invalid object lineage");
+  return parsed.objectEdges;
 }
 
 type ReadEntity = (entity: string, filter: Row) => Promise<Row[]>;
@@ -721,6 +782,7 @@ interface SnapshotRows {
   jobRows: Row[];
   regularConfigRows: Row[];
   schemaRows: Row[];
+  objectEdgeRows: Row[];
   syncRows: Row[];
 }
 
@@ -938,10 +1000,15 @@ async function readSnapshotRows(
     grantRows: rowsForSnapshot(allGrantRows, wid, snapshotId, writerEmail),
     jobRows: rowsForSnapshot(allJobRows, wid, snapshotId, writerEmail),
     regularConfigRows: configRows.filter(
-      (row) => String(row.section) !== "__schema__",
+      (row) =>
+        String(row.section) !== "__schema__" &&
+        String(row.section) !== "__object_edges__",
     ),
     schemaRows: configRows.filter(
       (row) => String(row.section) === "__schema__",
+    ),
+    objectEdgeRows: configRows.filter(
+      (row) => String(row.section) === "__object_edges__",
     ),
     syncRows: rowsForSnapshot(allSyncRows, wid, snapshotId, writerEmail),
   };
@@ -958,7 +1025,7 @@ function catalogFromRows(
     grantCount: rows.grantRows.length,
     jobCount: rows.jobRows.length,
     configCount: rows.regularConfigRows.length,
-    schemaEntryCount: rows.schemaRows.length,
+    schemaEntryCount: rows.schemaRows.length + rows.objectEdgeRows.length,
   });
 
   const items: Item[] = rows.itemRows.map((row) => {
@@ -1063,6 +1130,16 @@ function catalogFromRows(
     value: String(row.value ?? ""),
   }));
   const schema = parseSchemaRows(rows.schemaRows, itemIds);
+  const itemMetadata = Object.fromEntries(
+    items.flatMap((item) => {
+      const metadata = itemMetadataFromSchema(
+        item.itemType,
+        schema[item.fabricId],
+      );
+      return metadata ? [[item.fabricId, metadata] as const] : [];
+    }),
+  );
+  const objectEdges = parseObjectEdgeRows(rows.objectEdgeRows);
   const snapshotId = String(marker.snapshotId);
   const syncedAt = validDateIso(marker.syncedAt) ?? markerTime;
   const workspace: WorkspaceInfo = {
@@ -1085,6 +1162,8 @@ function catalogFromRows(
     jobs,
     config,
     schema,
+    itemMetadata,
+    objectEdges,
   };
 }
 
@@ -1147,7 +1226,14 @@ async function deleteSnapshot(
 ): Promise<void> {
   const snapshotId = String(marker.snapshotId);
   const groups: Array<[string, Row[]]> = [
-    ["ConfigEntry", [...rows.regularConfigRows, ...rows.schemaRows]],
+    [
+      "ConfigEntry",
+      [
+        ...rows.regularConfigRows,
+        ...rows.schemaRows,
+        ...rows.objectEdgeRows,
+      ],
+    ],
     ["JobRun", rows.jobRows],
     ["AccessGrant", rows.grantRows],
     ["Principal", rows.principalRows],

--- a/src/atlas/catalog-objects.spec.ts
+++ b/src/atlas/catalog-objects.spec.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCatalogObjects,
+  metadataObjectImpact,
+} from "./catalog-objects";
+import {
+  metadataObjectLineageEdges,
+  parseDataAgentMetadata,
+  parseGraphModelMetadata,
+  parseKqlDatabaseMetadata,
+  parseOntologyMetadata,
+} from "./item-metadata";
+import type { AtlasData, Item } from "./model";
+
+function item(
+  fabricId: string,
+  itemType: Item["itemType"],
+  displayName: string,
+): Item {
+  return {
+    fabricId,
+    displayName,
+    itemType,
+    health: "healthy",
+    endorsement: "none",
+    tags: [],
+  };
+}
+
+function workspaceData(): AtlasData {
+  const ontology = parseOntologyMetadata({
+    entities: [
+      {
+        id: "device",
+        name: "Device",
+        namespace: "operations",
+        properties: [
+          {
+            id: "device-id",
+            name: "Device ID",
+            valueType: "String",
+          },
+        ],
+        timeSeriesProperties: [
+          {
+            id: "observed-at",
+            name: "Observed at",
+            valueType: "DateTime",
+          },
+        ],
+      },
+      { id: "site", name: "Site", properties: [] },
+    ],
+    relationships: [
+      {
+        id: "installed-at",
+        name: "Installed at",
+        sourceEntityId: "device",
+        targetEntityId: "site",
+      },
+    ],
+    bindings: [
+      {
+        id: "device-binding",
+        entityId: "device",
+        bindingType: "table",
+        sourceItemId: "warehouse",
+        sourceSchema: "dbo",
+        sourceObject: "Devices",
+        propertyBindings: [
+          { sourceColumn: "DeviceId", targetPropertyId: "device-id" },
+          { sourceColumn: "ObservedAt", targetPropertyId: "observed-at" },
+        ],
+      },
+    ],
+    contextualizations: [
+      {
+        id: "site-context",
+        relationshipId: "installed-at",
+        sourceItemId: "warehouse",
+        sourceObject: "Installations",
+        sourceKeyBindings: [
+          { sourceColumn: "DeviceId", targetPropertyId: "device-id" },
+        ],
+        targetKeyBindings: [],
+      },
+    ],
+  })!;
+  const graph = parseGraphModelMetadata({
+    graphType: {
+      nodeTypes: [
+        {
+          alias: "Device",
+          labels: ["Device"],
+          primaryKeyProperties: ["DeviceId"],
+          properties: [{ name: "DeviceId", type: "STRING" }],
+        },
+        {
+          alias: "Site",
+          labels: ["Site"],
+          primaryKeyProperties: [],
+          properties: [],
+        },
+      ],
+      edgeTypes: [
+        {
+          alias: "INSTALLED_AT",
+          labels: ["INSTALLED_AT"],
+          sourceNodeType: { alias: "Device" },
+          destinationNodeType: { alias: "Site" },
+          properties: [],
+        },
+      ],
+    },
+    dataSources: [
+      {
+        name: "Device source",
+        itemId: "warehouse",
+        tableName: "Devices",
+        type: "WarehouseTable",
+      },
+    ],
+    graphDefinition: {
+      nodeTables: [
+        {
+          id: "device-map",
+          nodeTypeAlias: "Device",
+          dataSourceName: "Device source",
+          propertyMappings: [
+            { propertyName: "DeviceId", sourceColumn: "DeviceId" },
+          ],
+        },
+      ],
+      edgeTables: [],
+    },
+  })!;
+  const agent = parseDataAgentMetadata({
+    sources: [
+      {
+        artifactId: "warehouse",
+        displayName: "Operations warehouse",
+        type: "data_warehouse",
+        elements: [
+          {
+            id: "devices",
+            display_name: "Devices",
+            type: "warehouse_tables.table",
+            is_selected: true,
+            children: [
+              {
+                id: "device-id",
+                display_name: "DeviceId",
+                type: "warehouse_tables.column",
+                data_type: "string",
+                is_selected: true,
+              },
+              {
+                id: "private-note",
+                display_name: "PrivateNote",
+                type: "warehouse_tables.column",
+                data_type: "string",
+                is_selected: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })!;
+  const kql = parseKqlDatabaseMetadata({
+    functions: [
+      {
+        name: "RecentDevices",
+        parameters: [{ name: "window", type: "timespan" }],
+        returnType: "table",
+      },
+    ],
+    materializedViews: [
+      {
+        name: "DeviceHourly",
+        sourceTable: "DeviceEvents",
+        columns: [{ name: "DeviceCount", dataType: "long" }],
+      },
+    ],
+  })!;
+  const items = [
+    item("warehouse", "Warehouse", "Operations warehouse"),
+    item("ontology", "Ontology", "Operations ontology"),
+    item("graph", "GraphModel", "Operations graph"),
+    item("agent", "DataAgent", "Operations agent"),
+    item("kql", "KQLDatabase", "Telemetry database"),
+  ];
+  return {
+    workspace: {
+      fabricId: "workspace",
+      displayName: "Operations workspace",
+      capacity: "F2",
+      region: "West Europe",
+    },
+    items,
+    edges: [],
+    principals: [],
+    grants: [],
+    jobs: [],
+    config: [],
+    comments: [],
+    syncRuns: [],
+    schema: {
+      warehouse: [
+        {
+          name: "Devices",
+          objectType: "Table",
+          columns: [{ name: "DeviceId", dataType: "varchar" }],
+          measures: [],
+        },
+      ],
+      kql: [
+        {
+          name: "DeviceEvents",
+          objectType: "Table",
+          columns: [{ name: "DeviceId", dataType: "string" }],
+          measures: [],
+        },
+      ],
+    },
+    itemMetadata: { ontology, graph, agent, kql },
+    objectEdges: [
+      ...metadataObjectLineageEdges("ontology", ontology),
+      ...metadataObjectLineageEdges("graph", graph),
+      ...metadataObjectLineageEdges("agent", agent),
+      ...metadataObjectLineageEdges("kql", kql),
+    ],
+  };
+}
+
+describe("catalog object discovery", () => {
+  it("classifies full workspace metadata without exposing unselected elements", () => {
+    const objects = buildCatalogObjects(workspaceData());
+    const kinds = new Set(objects.map((object) => object.kind));
+
+    expect([...kinds]).toEqual(
+      expect.arrayContaining([
+        "sqlTable",
+        "sqlColumn",
+        "kqlTable",
+        "kqlFunction",
+        "kqlFunctionParameter",
+        "kqlMaterializedView",
+        "ontologyEntity",
+        "ontologyProperty",
+        "ontologyTimeSeriesProperty",
+        "ontologyRelationship",
+        "ontologyContextualization",
+        "graphNode",
+        "graphEdge",
+        "graphProperty",
+        "graphSourceMapping",
+        "dataAgentSource",
+        "dataAgentElement",
+      ]),
+    );
+    expect(objects.some((object) => object.name === "PrivateNote")).toBe(false);
+    expect(JSON.stringify(objects)).not.toMatch(
+      /prompt|few.?shot|filter.?value|business.?row/i,
+    );
+  });
+
+  it("returns verified source-to-consumer impact for metadata objects", () => {
+    const data = workspaceData();
+    const property = buildCatalogObjects(data).find(
+      (object) =>
+        object.kind === "ontologyProperty" &&
+        object.name === "Device ID",
+    )!;
+    const impact = metadataObjectImpact(data.objectEdges, property.metadataRef!);
+
+    expect(impact.upstream).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "sourceField",
+          name: "DeviceId",
+          itemId: "warehouse",
+        }),
+      ]),
+    );
+    expect(impact.relevantEdges.length).toBeGreaterThan(0);
+  });
+
+  it("renders projected UDF schema when no metadata envelope is available", () => {
+    const ontology = item("ontology", "Ontology", "Operations ontology");
+    const data: AtlasData = {
+      workspace: {
+        fabricId: "workspace",
+        displayName: "Workspace",
+        capacity: "F2",
+        region: "West Europe",
+      },
+      items: [ontology],
+      edges: [],
+      principals: [],
+      grants: [],
+      jobs: [],
+      config: [],
+      comments: [],
+      syncRuns: [],
+      schema: {
+        ontology: [
+          {
+            name: "Device",
+            objectType: "Ontology entity",
+            columns: [
+              {
+                name: "Device ID",
+                dataType: "String",
+                objectType: "Ontology property",
+              },
+            ],
+            measures: [],
+          },
+        ],
+      },
+      objectEdges: [
+        {
+          source: {
+            itemId: "ontology",
+            kind: "ontologyEntity",
+            id: "device",
+            name: "Device",
+          },
+          target: {
+            itemId: "ontology",
+            kind: "ontologyProperty",
+            id: "device-id",
+            name: "Device ID",
+            tableName: "Device",
+          },
+          relation: "contains",
+          confidence: "verified",
+        },
+      ],
+    };
+
+    expect(buildCatalogObjects(data)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "ontologyEntity",
+          objectId: "device",
+        }),
+        expect.objectContaining({
+          kind: "ontologyProperty",
+          objectId: "device-id",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/atlas/catalog-objects.ts
+++ b/src/atlas/catalog-objects.ts
@@ -1,0 +1,1003 @@
+import {
+  METADATA_OBJECT_TYPES,
+  itemMetadataFor,
+  type MetadataObjectKind,
+  type MetadataObjectLineageEdge,
+  type MetadataObjectRef,
+} from "./item-metadata";
+import {
+  schemaFor,
+  type AtlasData,
+  type Item,
+  type ItemType,
+  type ModelColumn,
+  type ModelMeasure,
+  type ModelTableSchema,
+} from "./model";
+
+export const ASSET_OBJECT_KINDS = [
+  "table",
+  "view",
+  "column",
+  "measure",
+  "kqlTable",
+  "kqlColumn",
+  "kqlFunction",
+  "kqlFunctionParameter",
+  "kqlMaterializedView",
+  "sqlTable",
+  "sqlView",
+  "sqlColumn",
+  "ontologyEntity",
+  "ontologyProperty",
+  "ontologyTimeSeriesProperty",
+  "ontologyRelationship",
+  "ontologyContextualization",
+  "graphNode",
+  "graphEdge",
+  "graphProperty",
+  "graphSourceMapping",
+  "dataAgentSource",
+  "dataAgentElement",
+] as const;
+
+export type AssetObjectKind = (typeof ASSET_OBJECT_KINDS)[number];
+
+export interface CatalogObject {
+  id: string;
+  objectId: string;
+  itemFabricId: string;
+  itemName: string;
+  itemType: ItemType;
+  kind: AssetObjectKind;
+  name: string;
+  tableName?: string;
+  parentName?: string;
+  dataType?: string;
+  source?: string;
+  sourceItemId?: string;
+  sourceItemName?: string;
+  description?: string;
+  isHidden?: boolean;
+  expression?: string;
+  details: Record<string, unknown>;
+  metadataRef?: MetadataObjectRef;
+}
+
+const PROJECTED_METADATA_TYPES = new Set(
+  Object.values(METADATA_OBJECT_TYPES).map((value) => value.toLowerCase()),
+);
+
+const SQL_ITEM_TYPES = new Set<ItemType>([
+  "Warehouse",
+  "SQLEndpoint",
+  "SQLDatabase",
+  "Datamart",
+]);
+
+const KIND_LABELS: Record<AssetObjectKind, string> = {
+  table: "Table",
+  view: "View",
+  column: "Column",
+  measure: "Measure / KPI",
+  kqlTable: "KQL table",
+  kqlColumn: "KQL column",
+  kqlFunction: "KQL function",
+  kqlFunctionParameter: "KQL function parameter",
+  kqlMaterializedView: "KQL materialized view",
+  sqlTable: "SQL table",
+  sqlView: "SQL view",
+  sqlColumn: "SQL column",
+  ontologyEntity: "Ontology entity",
+  ontologyProperty: "Ontology property",
+  ontologyTimeSeriesProperty: "Ontology time-series property",
+  ontologyRelationship: "Ontology relationship",
+  ontologyContextualization: "Ontology contextualization",
+  graphNode: "Graph node type",
+  graphEdge: "Graph edge type",
+  graphProperty: "Graph property",
+  graphSourceMapping: "Graph source mapping",
+  dataAgentSource: "Data Agent source",
+  dataAgentElement: "Data Agent selected source element",
+};
+
+const METADATA_KIND_LABELS: Record<MetadataObjectKind, string> = {
+  sourceObject: "Source object",
+  sourceField: "Source field",
+  sourceElement: "Source element",
+  ontologyEntity: "Ontology entity",
+  ontologyProperty: "Ontology property",
+  ontologyRelationship: "Ontology relationship",
+  ontologyContextualization: "Ontology contextualization",
+  graphNode: "Graph node type",
+  graphEdge: "Graph edge type",
+  graphProperty: "Graph property",
+  dataAgentSource: "Data Agent source",
+  dataAgentElement: "Data Agent selected element",
+  kqlFunction: "KQL function",
+  kqlMaterializedView: "KQL materialized view",
+};
+
+export function assetObjectKindLabel(kind: AssetObjectKind): string {
+  return KIND_LABELS[kind];
+}
+
+export function metadataObjectKindLabel(kind: MetadataObjectKind): string {
+  return METADATA_KIND_LABELS[kind];
+}
+
+export function isAssetObjectKind(value: string): value is AssetObjectKind {
+  return (ASSET_OBJECT_KINDS as readonly string[]).includes(value);
+}
+
+export function isMetadataAssetKind(kind: AssetObjectKind): boolean {
+  return !["table", "view", "column", "measure"].includes(kind);
+}
+
+export function catalogObjectKey(
+  itemId: string,
+  kind: AssetObjectKind,
+  objectId: string,
+): string {
+  return [itemId, kind, objectId].map(encodeURIComponent).join("::");
+}
+
+function clean(value: string | undefined): string | undefined {
+  const result = value?.trim();
+  return result || undefined;
+}
+
+function sourceItemName(
+  itemsById: ReadonlyMap<string, Item>,
+  itemId: string | undefined,
+): string | undefined {
+  return itemId ? itemsById.get(itemId)?.displayName : undefined;
+}
+
+function schemaTableKind(
+  itemType: ItemType,
+  table: ModelTableSchema,
+): AssetObjectKind {
+  const objectType = table.objectType?.trim().toLowerCase() ?? "";
+  if (objectType === METADATA_OBJECT_TYPES.kqlFunction.toLowerCase()) {
+    return "kqlFunction";
+  }
+  if (
+    objectType === METADATA_OBJECT_TYPES.kqlMaterializedView.toLowerCase()
+  ) {
+    return "kqlMaterializedView";
+  }
+  if (objectType === METADATA_OBJECT_TYPES.ontologyEntity.toLowerCase()) {
+    return "ontologyEntity";
+  }
+  if (
+    objectType === METADATA_OBJECT_TYPES.ontologyRelationship.toLowerCase()
+  ) {
+    return "ontologyRelationship";
+  }
+  if (objectType === METADATA_OBJECT_TYPES.graphNode.toLowerCase()) {
+    return "graphNode";
+  }
+  if (objectType === METADATA_OBJECT_TYPES.graphEdge.toLowerCase()) {
+    return "graphEdge";
+  }
+  if (objectType === METADATA_OBJECT_TYPES.dataAgentSource.toLowerCase()) {
+    return "dataAgentSource";
+  }
+  const isView = objectType.includes("view");
+  if (itemType === "KQLDatabase") {
+    return isView ? "kqlMaterializedView" : "kqlTable";
+  }
+  if (SQL_ITEM_TYPES.has(itemType)) return isView ? "sqlView" : "sqlTable";
+  return isView ? "view" : "table";
+}
+
+function schemaColumnKind(
+  itemType: ItemType,
+  tableKind: AssetObjectKind,
+  column: ModelColumn,
+): AssetObjectKind {
+  const objectType = column.objectType?.trim().toLowerCase();
+  if (objectType === "ontology property") return "ontologyProperty";
+  if (objectType === "ontology time-series property") {
+    return "ontologyTimeSeriesProperty";
+  }
+  if (objectType === "graph property") return "graphProperty";
+  if (objectType === "data agent selected element") {
+    return "dataAgentElement";
+  }
+  if (itemType === "KQLDatabase") {
+    return tableKind === "kqlFunction"
+      ? "kqlFunctionParameter"
+      : "kqlColumn";
+  }
+  return SQL_ITEM_TYPES.has(itemType) ? "sqlColumn" : "column";
+}
+
+function metadataKindForAsset(
+  kind: AssetObjectKind,
+): MetadataObjectKind | undefined {
+  const mapping: Partial<Record<AssetObjectKind, MetadataObjectKind>> = {
+    table: "sourceObject",
+    view: "sourceObject",
+    column: "sourceField",
+    measure: "sourceField",
+    kqlTable: "sourceObject",
+    kqlColumn: "sourceField",
+    kqlFunction: "kqlFunction",
+    kqlMaterializedView: "kqlMaterializedView",
+    sqlTable: "sourceObject",
+    sqlView: "sourceObject",
+    sqlColumn: "sourceField",
+    ontologyEntity: "ontologyEntity",
+    ontologyProperty: "ontologyProperty",
+    ontologyTimeSeriesProperty: "ontologyProperty",
+    ontologyRelationship: "ontologyRelationship",
+    ontologyContextualization: "ontologyContextualization",
+    graphNode: "graphNode",
+    graphEdge: "graphEdge",
+    graphProperty: "graphProperty",
+    dataAgentSource: "dataAgentSource",
+    dataAgentElement: "dataAgentElement",
+  };
+  return mapping[kind];
+}
+
+function matchingMetadataRef(
+  data: Pick<AtlasData, "objectEdges">,
+  itemId: string,
+  kind: AssetObjectKind,
+  name: string,
+  tableName?: string,
+): MetadataObjectRef | undefined {
+  const metadataKind = metadataKindForAsset(kind);
+  if (!metadataKind) return undefined;
+  const references = (data.objectEdges ?? []).flatMap((edge) => [
+    edge.source,
+    edge.target,
+  ]);
+  return references.find(
+    (reference) =>
+      reference.itemId === itemId &&
+      reference.kind === metadataKind &&
+      reference.name === name &&
+      (!tableName || reference.tableName === tableName),
+  );
+}
+
+function schemaTableValue(table: ModelTableSchema): Record<string, unknown> {
+  return {
+    rows: table.rows,
+    objectType: clean(table.objectType),
+    source: clean(table.source),
+    description: clean(table.description),
+    isHidden: table.isHidden,
+  };
+}
+
+function schemaColumnValue(column: ModelColumn): Record<string, unknown> {
+  return {
+    dataType: clean(column.dataType),
+    description: clean(column.description),
+    isHidden: column.isHidden,
+  };
+}
+
+function schemaMeasureValue(measure: ModelMeasure): Record<string, unknown> {
+  return {
+    expression: clean(measure.expr),
+    description: clean(measure.description),
+    isHidden: measure.isHidden,
+  };
+}
+
+function dataAgentElementStableId(element: {
+  id: string;
+  elementType: string;
+  parentPath: string[];
+}): string {
+  return [...element.parentPath, `${element.elementType}:${element.id}`].join(
+    "/",
+  );
+}
+
+function metadataReference(
+  itemId: string,
+  kind: MetadataObjectKind,
+  id: string,
+  name: string,
+  options: {
+    parentId?: string;
+    parentPath?: string[];
+    tableName?: string;
+  } = {},
+): MetadataObjectRef {
+  return { itemId, kind, id, name, ...options };
+}
+
+export function buildCatalogObjects(
+  data: Pick<
+    AtlasData,
+    "items" | "schema" | "itemMetadata" | "objectEdges" | "config"
+  >,
+  options: { includeConfigTables?: boolean } = {},
+): CatalogObject[] {
+  const result: CatalogObject[] = [];
+  const seen = new Set<string>();
+  const itemsById = new Map(data.items.map((item) => [item.fabricId, item]));
+  const add = (
+    item: Item,
+    object: Omit<CatalogObject, "id" | "itemFabricId" | "itemName" | "itemType">,
+  ) => {
+    const id = catalogObjectKey(item.fabricId, object.kind, object.objectId);
+    if (seen.has(id)) return;
+    seen.add(id);
+    result.push({
+      ...object,
+      id,
+      itemFabricId: item.fabricId,
+      itemName: item.displayName,
+      itemType: item.itemType,
+    });
+  };
+
+  for (const item of data.items) {
+    const metadata =
+      data.itemMetadata?.[item.fabricId] ??
+      itemMetadataFor(data, item.fabricId, item.itemType);
+    for (const table of schemaFor(data, item.fabricId) ?? []) {
+      const normalizedObjectType =
+        table.objectType?.trim().toLowerCase() ?? "";
+      if (
+        (metadata &&
+          PROJECTED_METADATA_TYPES.has(normalizedObjectType)) ||
+        (metadata?.kind === "kql" &&
+          ["function", "stored function", "materialized view", "materializedview"].includes(
+            normalizedObjectType,
+          ))
+      ) {
+        continue;
+      }
+      const tableKind = schemaTableKind(item.itemType, table);
+      const tableRef = matchingMetadataRef(
+        data,
+        item.fabricId,
+        tableKind,
+        table.name,
+      );
+      const tableObjectId = tableRef?.id ?? table.name;
+      add(item, {
+        objectId: tableObjectId,
+        kind: tableKind,
+        name: table.name,
+        dataType: clean(table.objectType),
+        source: clean(table.source),
+        description: clean(table.description),
+        isHidden: table.isHidden,
+        details: schemaTableValue(table),
+        metadataRef: tableRef,
+      });
+      for (const column of table.columns) {
+        const columnKind = schemaColumnKind(
+          item.itemType,
+          tableKind,
+          column,
+        );
+        const columnRef = matchingMetadataRef(
+          data,
+          item.fabricId,
+          columnKind,
+          column.name,
+          table.name,
+        );
+        add(item, {
+          objectId: columnRef?.id ?? `${tableObjectId}/${column.name}`,
+          kind: columnKind,
+          name: column.name,
+          tableName: table.name,
+          parentName: table.name,
+          dataType: column.dataType,
+          description: clean(column.description),
+          isHidden: column.isHidden,
+          details: schemaColumnValue(column),
+          metadataRef: columnRef,
+        });
+      }
+      for (const measure of table.measures) {
+        add(item, {
+          objectId: `${tableObjectId}/${measure.name}`,
+          kind: "measure",
+          name: measure.name,
+          tableName: table.name,
+          parentName: table.name,
+          description: clean(measure.description),
+          isHidden: measure.isHidden,
+          expression: clean(measure.expr),
+          details: schemaMeasureValue(measure),
+        });
+      }
+    }
+
+    if (!metadata) continue;
+    if (metadata.kind === "ontology") {
+      const entityById = new Map(
+        metadata.entities.map((entity) => [entity.id, entity]),
+      );
+      for (const entity of metadata.entities) {
+        const bindings = metadata.bindings.filter(
+          (binding) => binding.entityId === entity.id,
+        );
+        add(item, {
+          objectId: entity.id,
+          kind: "ontologyEntity",
+          name: entity.name,
+          source: clean(entity.namespace),
+          sourceItemId: bindings[0]?.sourceItemId,
+          sourceItemName: sourceItemName(
+            itemsById,
+            bindings[0]?.sourceItemId,
+          ),
+          details: {
+            namespace: clean(entity.namespace),
+            keyPropertyIds: [...entity.keyPropertyIds],
+            displayNamePropertyId: clean(entity.displayNamePropertyId),
+            sourceBindings: bindings.map((binding) => ({
+              sourceItemId: binding.sourceItemId,
+              sourceSchema: clean(binding.sourceSchema),
+              sourceObject: binding.sourceObject,
+              bindingType: binding.bindingType,
+            })),
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "ontologyEntity",
+            entity.id,
+            entity.name,
+          ),
+        });
+        for (const property of entity.properties) {
+          const binding = bindings
+            .flatMap((candidate) =>
+              candidate.propertyBindings.map((propertyBinding) => ({
+                candidate,
+                propertyBinding,
+              })),
+            )
+            .find(
+              ({ propertyBinding }) =>
+                propertyBinding.targetPropertyId === property.id,
+            );
+          const kind = property.timeSeries
+            ? "ontologyTimeSeriesProperty"
+            : "ontologyProperty";
+          add(item, {
+            objectId: `${entity.id}/${property.id}`,
+            kind,
+            name: property.name,
+            tableName: entity.name,
+            parentName: entity.name,
+            dataType: property.valueType,
+            source: binding?.propertyBinding.sourceColumn,
+            sourceItemId: binding?.candidate.sourceItemId,
+            sourceItemName: sourceItemName(
+              itemsById,
+              binding?.candidate.sourceItemId,
+            ),
+            details: {
+              valueType: property.valueType,
+              timeSeries: property.timeSeries,
+              sourceColumn: binding?.propertyBinding.sourceColumn,
+              sourceObject: binding?.candidate.sourceObject,
+              sourceSchema: clean(binding?.candidate.sourceSchema),
+            },
+            metadataRef: metadataReference(
+              item.fabricId,
+              "ontologyProperty",
+              property.id,
+              property.name,
+              { parentId: entity.id, tableName: entity.name },
+            ),
+          });
+        }
+      }
+      for (const relationship of metadata.relationships) {
+        add(item, {
+          objectId: relationship.id,
+          kind: "ontologyRelationship",
+          name: relationship.name,
+          source: `${entityById.get(relationship.sourceEntityId)?.name ?? relationship.sourceEntityId} to ${entityById.get(relationship.targetEntityId)?.name ?? relationship.targetEntityId}`,
+          details: {
+            sourceEntityId: relationship.sourceEntityId,
+            targetEntityId: relationship.targetEntityId,
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "ontologyRelationship",
+            relationship.id,
+            relationship.name,
+          ),
+        });
+      }
+      for (const contextualization of metadata.contextualizations) {
+        const relationship = metadata.relationships.find(
+          (candidate) => candidate.id === contextualization.relationshipId,
+        );
+        add(item, {
+          objectId: contextualization.id,
+          kind: "ontologyContextualization",
+          name: contextualization.sourceObject,
+          parentName: relationship?.name ?? contextualization.relationshipId,
+          source: clean(contextualization.sourceSchema)
+            ? `${contextualization.sourceSchema}.${contextualization.sourceObject}`
+            : contextualization.sourceObject,
+          sourceItemId: contextualization.sourceItemId,
+          sourceItemName: sourceItemName(
+            itemsById,
+            contextualization.sourceItemId,
+          ),
+          details: {
+            relationshipId: contextualization.relationshipId,
+            sourceItemId: contextualization.sourceItemId,
+            sourceSchema: clean(contextualization.sourceSchema),
+            sourceObject: contextualization.sourceObject,
+            sourceKeyColumns: contextualization.sourceKeyBindings.map(
+              (binding) => binding.sourceColumn,
+            ),
+            targetKeyColumns: contextualization.targetKeyBindings.map(
+              (binding) => binding.sourceColumn,
+            ),
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "ontologyContextualization",
+            contextualization.id,
+            contextualization.sourceObject,
+            { parentId: contextualization.relationshipId },
+          ),
+        });
+      }
+    } else if (metadata.kind === "graphModel") {
+      const mappingsByType = new Map<string, typeof metadata.mappings>();
+      for (const mapping of metadata.mappings) {
+        mappingsByType.set(mapping.typeAlias, [
+          ...(mappingsByType.get(mapping.typeAlias) ?? []),
+          mapping,
+        ]);
+      }
+      for (const node of metadata.nodeTypes) {
+        const mappings = mappingsByType.get(node.alias) ?? [];
+        add(item, {
+          objectId: node.alias,
+          kind: "graphNode",
+          name: node.alias,
+          description: node.labels.join(", ") || undefined,
+          source: mappings[0]?.sourceObject,
+          sourceItemId: mappings[0]?.sourceItemId,
+          sourceItemName: sourceItemName(
+            itemsById,
+            mappings[0]?.sourceItemId,
+          ),
+          details: {
+            labels: [...node.labels],
+            primaryKeyProperties: [...node.primaryKeyProperties],
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "graphNode",
+            node.alias,
+            node.alias,
+          ),
+        });
+        for (const property of node.properties) {
+          const mapping = mappings
+            .flatMap((candidate) =>
+              candidate.propertyMappings.map((propertyMapping) => ({
+                candidate,
+                propertyMapping,
+              })),
+            )
+            .find(
+              ({ propertyMapping }) =>
+                propertyMapping.propertyName === property.name,
+            );
+          add(item, {
+            objectId: `${node.alias}/${property.name}`,
+            kind: "graphProperty",
+            name: property.name,
+            tableName: node.alias,
+            parentName: node.alias,
+            dataType: property.dataType,
+            source: mapping?.propertyMapping.sourceColumn,
+            sourceItemId: mapping?.candidate.sourceItemId,
+            sourceItemName: sourceItemName(
+              itemsById,
+              mapping?.candidate.sourceItemId,
+            ),
+            details: {
+              dataType: property.dataType,
+              primaryKey: node.primaryKeyProperties.includes(property.name),
+              sourceColumn: mapping?.propertyMapping.sourceColumn,
+              sourceObject: mapping?.candidate.sourceObject,
+            },
+            metadataRef: metadataReference(
+              item.fabricId,
+              "graphProperty",
+              `${node.alias}.${property.name}`,
+              property.name,
+              { parentId: node.alias, tableName: node.alias },
+            ),
+          });
+        }
+      }
+      for (const edge of metadata.edgeTypes) {
+        const mappings = mappingsByType.get(edge.alias) ?? [];
+        add(item, {
+          objectId: edge.alias,
+          kind: "graphEdge",
+          name: edge.alias,
+          description: edge.labels.join(", ") || undefined,
+          source: `${edge.sourceNodeType} to ${edge.destinationNodeType}`,
+          sourceItemId: mappings[0]?.sourceItemId,
+          sourceItemName: sourceItemName(
+            itemsById,
+            mappings[0]?.sourceItemId,
+          ),
+          details: {
+            labels: [...edge.labels],
+            sourceNodeType: edge.sourceNodeType,
+            destinationNodeType: edge.destinationNodeType,
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "graphEdge",
+            edge.alias,
+            edge.alias,
+          ),
+        });
+        for (const property of edge.properties) {
+          const mapping = mappings
+            .flatMap((candidate) =>
+              candidate.propertyMappings.map((propertyMapping) => ({
+                candidate,
+                propertyMapping,
+              })),
+            )
+            .find(
+              ({ propertyMapping }) =>
+                propertyMapping.propertyName === property.name,
+            );
+          add(item, {
+            objectId: `${edge.alias}/${property.name}`,
+            kind: "graphProperty",
+            name: property.name,
+            tableName: edge.alias,
+            parentName: edge.alias,
+            dataType: property.dataType,
+            source: mapping?.propertyMapping.sourceColumn,
+            sourceItemId: mapping?.candidate.sourceItemId,
+            sourceItemName: sourceItemName(
+              itemsById,
+              mapping?.candidate.sourceItemId,
+            ),
+            details: {
+              dataType: property.dataType,
+              sourceColumn: mapping?.propertyMapping.sourceColumn,
+              sourceObject: mapping?.candidate.sourceObject,
+            },
+            metadataRef: metadataReference(
+              item.fabricId,
+              "graphProperty",
+              `${edge.alias}.${property.name}`,
+              property.name,
+              { parentId: edge.alias, tableName: edge.alias },
+            ),
+          });
+        }
+      }
+      for (const mapping of metadata.mappings) {
+        add(item, {
+          objectId: mapping.id,
+          kind: "graphSourceMapping",
+          name: mapping.dataSourceName,
+          parentName: mapping.typeAlias,
+          source: mapping.sourceObject,
+          sourceItemId: mapping.sourceItemId,
+          sourceItemName: sourceItemName(itemsById, mapping.sourceItemId),
+          details: {
+            mappingKind: mapping.kind,
+            targetType: mapping.typeAlias,
+            sourceItemId: mapping.sourceItemId,
+            sourceObject: mapping.sourceObject,
+            propertyMappings: mapping.propertyMappings.map(
+              (propertyMapping) => ({
+                propertyName: propertyMapping.propertyName,
+                sourceColumn: propertyMapping.sourceColumn,
+              }),
+            ),
+          },
+        });
+      }
+    } else if (metadata.kind === "dataAgent") {
+      for (const source of metadata.sources) {
+        add(item, {
+          objectId: source.artifactId,
+          kind: "dataAgentSource",
+          name: source.displayName,
+          dataType: source.sourceType,
+          source: source.artifactId,
+          sourceItemId: source.artifactId,
+          sourceItemName:
+            sourceItemName(itemsById, source.artifactId) ??
+            source.displayName,
+          details: {
+            artifactId: source.artifactId,
+            workspaceId: clean(source.workspaceId),
+            sourceType: source.sourceType,
+            selectedElementCount: source.selectedElements.length,
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "dataAgentSource",
+            source.artifactId,
+            source.displayName,
+          ),
+        });
+        for (const element of source.selectedElements) {
+          const stableId = dataAgentElementStableId(element);
+          const tableName =
+            element.elementType.toLowerCase().endsWith(".table") ||
+            element.elementType.toLowerCase() === "ontology.entity"
+              ? element.displayName
+              : element.parentName;
+          add(item, {
+            objectId: `${source.artifactId}:${stableId}`,
+            kind: "dataAgentElement",
+            name: element.displayName,
+            tableName,
+            parentName:
+              element.parentName ??
+              element.parentPath.at(-1) ??
+              source.displayName,
+            dataType: clean(element.dataType) ?? element.elementType,
+            source: element.parentPath.join(" / ") || source.displayName,
+            sourceItemId: source.artifactId,
+            sourceItemName:
+              sourceItemName(itemsById, source.artifactId) ??
+              source.displayName,
+            details: {
+              elementType: element.elementType,
+              dataType: clean(element.dataType),
+              parentPath: [...element.parentPath],
+              sourceArtifactId: source.artifactId,
+            },
+            metadataRef: metadataReference(
+              item.fabricId,
+              "dataAgentElement",
+              `${source.artifactId}:${stableId}`,
+              element.displayName,
+              {
+                parentId: element.parentId
+                  ? `${source.artifactId}:${element.parentId}`
+                  : source.artifactId,
+                parentPath: [...element.parentPath],
+                tableName,
+              },
+            ),
+          });
+        }
+      }
+    } else {
+      for (const fn of metadata.functions) {
+        add(item, {
+          objectId: fn.name,
+          kind: "kqlFunction",
+          name: fn.name,
+          dataType: clean(fn.returnType),
+          source: clean(fn.folder),
+          description: clean(fn.description),
+          details: {
+            folder: clean(fn.folder),
+            description: clean(fn.description),
+            returnType: clean(fn.returnType),
+            parameters: fn.parameters.map((parameter) => ({
+              name: parameter.name,
+              dataType: parameter.dataType,
+            })),
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "kqlFunction",
+            fn.name,
+            fn.name,
+          ),
+        });
+        for (const parameter of fn.parameters) {
+          add(item, {
+            objectId: `${fn.name}/${parameter.name}`,
+            kind: "kqlFunctionParameter",
+            name: parameter.name,
+            tableName: fn.name,
+            parentName: fn.name,
+            dataType: parameter.dataType,
+            details: { dataType: parameter.dataType },
+          });
+        }
+      }
+      for (const view of metadata.materializedViews) {
+        add(item, {
+          objectId: view.name,
+          kind: "kqlMaterializedView",
+          name: view.name,
+          source: clean(view.sourceTable),
+          description: clean(view.description),
+          details: {
+            sourceTable: clean(view.sourceTable),
+            description: clean(view.description),
+          },
+          metadataRef: metadataReference(
+            item.fabricId,
+            "kqlMaterializedView",
+            view.name,
+            view.name,
+          ),
+        });
+        for (const column of view.columns) {
+          add(item, {
+            objectId: `${view.name}/${column.name}`,
+            kind: "kqlColumn",
+            name: column.name,
+            tableName: view.name,
+            parentName: view.name,
+            dataType: column.dataType,
+            details: { dataType: column.dataType },
+          });
+        }
+      }
+    }
+  }
+
+  if (options.includeConfigTables) {
+    for (const entry of data.config) {
+      if (entry.section !== "Tables") continue;
+      const item = itemsById.get(entry.itemFabricId);
+      if (!item) continue;
+      add(item, {
+        objectId: entry.label,
+        kind: schemaTableKind(item.itemType, {
+          name: entry.label,
+          columns: [],
+          measures: [],
+        }),
+        name: entry.label,
+        details: {},
+      });
+    }
+  }
+
+  return result.sort(
+    (left, right) =>
+      left.itemName.localeCompare(right.itemName) ||
+      assetObjectKindLabel(left.kind).localeCompare(
+        assetObjectKindLabel(right.kind),
+      ) ||
+      left.name.localeCompare(right.name) ||
+      left.id.localeCompare(right.id),
+  );
+}
+
+export function findCatalogObject(
+  data: Pick<
+    AtlasData,
+    "items" | "schema" | "itemMetadata" | "objectEdges" | "config"
+  >,
+  reference: {
+    itemId: string;
+    kind: AssetObjectKind;
+    objectId?: string;
+    name?: string;
+    tableName?: string;
+  },
+): CatalogObject | undefined {
+  return buildCatalogObjects(data).find(
+    (object) =>
+      object.itemFabricId === reference.itemId &&
+      object.kind === reference.kind &&
+      (reference.objectId
+        ? object.objectId === reference.objectId
+        : object.name === reference.name &&
+          (!reference.tableName ||
+            object.tableName === reference.tableName ||
+            object.parentName === reference.tableName)),
+  );
+}
+
+export function metadataObjectRefKey(reference: MetadataObjectRef): string {
+  return [
+    reference.itemId,
+    reference.kind,
+    reference.id,
+    reference.parentId ?? "",
+  ].join("\u0000");
+}
+
+export function verifiedMetadataEdgesForItem(
+  edges: readonly MetadataObjectLineageEdge[] | undefined,
+  itemId: string,
+): MetadataObjectLineageEdge[] {
+  return (edges ?? []).filter(
+    (edge) =>
+      edge.confidence === "verified" &&
+      (edge.source.itemId === itemId || edge.target.itemId === itemId),
+  );
+}
+
+export function metadataObjectImpact(
+  edges: readonly MetadataObjectLineageEdge[] | undefined,
+  subject: MetadataObjectRef,
+): {
+  upstream: MetadataObjectRef[];
+  downstream: MetadataObjectRef[];
+  relevantEdges: MetadataObjectLineageEdge[];
+} {
+  const verified = (edges ?? []).filter(
+    (edge) => edge.confidence === "verified",
+  );
+  const incoming = new Map<string, MetadataObjectLineageEdge[]>();
+  const outgoing = new Map<string, MetadataObjectLineageEdge[]>();
+  for (const edge of verified) {
+    const sourceKey = metadataObjectRefKey(edge.source);
+    const targetKey = metadataObjectRefKey(edge.target);
+    outgoing.set(sourceKey, [...(outgoing.get(sourceKey) ?? []), edge]);
+    incoming.set(targetKey, [...(incoming.get(targetKey) ?? []), edge]);
+  }
+  const walk = (direction: "upstream" | "downstream") => {
+    const start = metadataObjectRefKey(subject);
+    const visited = new Set([start]);
+    const queue = [subject];
+    const objects = new Map<string, MetadataObjectRef>();
+    const relevant = new Map<string, MetadataObjectLineageEdge>();
+    for (let head = 0; head < queue.length; head += 1) {
+      const current = queue[head];
+      const candidates =
+        direction === "upstream"
+          ? incoming.get(metadataObjectRefKey(current)) ?? []
+          : outgoing.get(metadataObjectRefKey(current)) ?? [];
+      for (const edge of candidates) {
+        const next =
+          direction === "upstream" ? edge.source : edge.target;
+        const key = metadataObjectRefKey(next);
+        relevant.set(
+          [
+            metadataObjectRefKey(edge.source),
+            metadataObjectRefKey(edge.target),
+            edge.relation,
+          ].join("\u0001"),
+          edge,
+        );
+        if (visited.has(key)) continue;
+        visited.add(key);
+        objects.set(key, next);
+        queue.push(next);
+      }
+    }
+    return { objects: [...objects.values()], edges: [...relevant.values()] };
+  };
+  const upstream = walk("upstream");
+  const downstream = walk("downstream");
+  return {
+    upstream: upstream.objects,
+    downstream: downstream.objects,
+    relevantEdges: [
+      ...new Map(
+        [...upstream.edges, ...downstream.edges].map((edge) => [
+          [
+            metadataObjectRefKey(edge.source),
+            metadataObjectRefKey(edge.target),
+            edge.relation,
+          ].join("\u0001"),
+          edge,
+        ]),
+      ).values(),
+    ],
+  };
+}

--- a/src/atlas/catalog-table.spec.ts
+++ b/src/atlas/catalog-table.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { groupCatalogItems, sortCatalogItems } from "./catalog-table";
+import { SAMPLE_DATA, type Item } from "./model";
+
+const base = SAMPLE_DATA.items[0];
+const item = (fabricId: string, displayName: string, extra: Partial<Item> = {}): Item => ({
+  ...base,
+  fabricId,
+  displayName,
+  ...extra,
+});
+
+describe("catalog table sorting", () => {
+  it("sorts names naturally without modifying the input", () => {
+    const rows = [item("b", "Model 10"), item("a", "Model 2")];
+    expect(sortCatalogItems(rows, "name", "asc").map((row) => row.fabricId)).toEqual(["a", "b"]);
+    expect(rows.map((row) => row.fabricId)).toEqual(["b", "a"]);
+  });
+
+  it("keeps unavailable refresh metadata last in either direction", () => {
+    const rows = [
+      item("none", "None", { lastRefresh: undefined }),
+      item("old", "Old", { lastRefresh: "2026-08-01T12:00:00Z" }),
+      item("new", "New", { lastRefresh: "2026-08-02T12:00:00Z" }),
+    ];
+    expect(sortCatalogItems(rows, "refresh", "asc").map((row) => row.fabricId)).toEqual(["old", "new", "none"]);
+    expect(sortCatalogItems(rows, "refresh", "desc").map((row) => row.fabricId)).toEqual(["new", "old", "none"]);
+  });
+
+  it("retains sorted order inside item-type groups", () => {
+    const rows = sortCatalogItems([
+      item("z", "Zulu", { itemType: "Lakehouse" }),
+      item("r", "Report", { itemType: "Report" }),
+      item("a", "Alpha", { itemType: "Lakehouse" }),
+    ], "name", "asc");
+    expect(groupCatalogItems(rows).find(([type]) => type === "Lakehouse")?.[1].map((row) => row.fabricId)).toEqual(["a", "z"]);
+  });
+});

--- a/src/atlas/catalog-table.ts
+++ b/src/atlas/catalog-table.ts
@@ -1,0 +1,45 @@
+import { typeMeta, type Item } from "./model";
+
+export type CatalogSortKey = "name" | "health" | "owner" | "refresh";
+export type CatalogSortDirection = "asc" | "desc";
+
+const HEALTH_ORDER = { failing: 0, stale: 1, healthy: 2, unknown: 3 };
+
+function sortValue(item: Item, key: CatalogSortKey): string | number | undefined {
+  if (key === "name") return item.displayName;
+  if (key === "health") return HEALTH_ORDER[item.health];
+  if (key === "owner") return item.ownerName?.trim() || item.ownerEmail?.trim() || undefined;
+  const date = item.lastRefresh ? Date.parse(item.lastRefresh) : NaN;
+  return Number.isFinite(date) ? date : undefined;
+}
+
+export function sortCatalogItems(
+  items: readonly Item[],
+  key: CatalogSortKey,
+  direction: CatalogSortDirection,
+): Item[] {
+  const sign = direction === "asc" ? 1 : -1;
+  return [...items].sort((left, right) => {
+    const a = sortValue(left, key);
+    const b = sortValue(right, key);
+    if (a == null && b != null) return 1;
+    if (a != null && b == null) return -1;
+    const difference =
+      typeof a === "number" && typeof b === "number"
+        ? a - b
+        : String(a ?? "").localeCompare(String(b ?? ""), undefined, { numeric: true, sensitivity: "base" });
+    return difference * sign || left.fabricId.localeCompare(right.fabricId);
+  });
+}
+
+export function groupCatalogItems(items: readonly Item[]) {
+  const groups = new Map<Item["itemType"], Item[]>();
+  for (const item of items) {
+    const group = groups.get(item.itemType) ?? [];
+    group.push(item);
+    groups.set(item.itemType, group);
+  }
+  return [...groups].sort(([left], [right]) =>
+    typeMeta(left).label.localeCompare(typeMeta(right).label),
+  );
+}

--- a/src/atlas/components/CatalogTable.spec.tsx
+++ b/src/atlas/components/CatalogTable.spec.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CatalogTable } from "./CatalogTable";
+import { SAMPLE_DATA, type ItemType } from "../model";
+
+const model = SAMPLE_DATA.items.find((item) => item.itemType === "SemanticModel")!;
+
+function Harness({ searching = false, onSelect = vi.fn() }) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (type: ItemType) => setExpanded((previous) => {
+    const next = new Set(previous);
+    if (next.has(type)) next.delete(type);
+    else next.add(type);
+    return next;
+  });
+  return <CatalogTable items={[model]} expanded={expanded} searching={searching} selectedId={null} onToggle={toggle} onSelect={onSelect} />;
+}
+
+describe("CatalogTable", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("keeps groups collapsed until opened", () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    expect(screen.queryByRole("button", { name: `Open details for ${model.displayName}` })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Semantic model/i }));
+    fireEvent.click(screen.getByRole("button", { name: `Open details for ${model.displayName}` }));
+    expect(onSelect).toHaveBeenCalledWith(model.fabricId);
+  });
+
+  it("opens matching groups while searching without changing stored expansion", () => {
+    const { rerender } = render(<Harness searching />);
+    expect(screen.getByRole("button", { name: `Open details for ${model.displayName}` })).toBeVisible();
+    rerender(<Harness />);
+    expect(screen.queryByRole("button", { name: `Open details for ${model.displayName}` })).not.toBeInTheDocument();
+  });
+
+  it("announces the active sort direction", () => {
+    render(<Harness />);
+    const sort = screen.getByRole("button", { name: "Sort by item" });
+    expect(sort.closest("th")).toHaveAttribute("aria-sort", "ascending");
+    fireEvent.click(sort);
+    expect(sort.closest("th")).toHaveAttribute("aria-sort", "descending");
+  });
+});

--- a/src/atlas/components/CatalogTable.tsx
+++ b/src/atlas/components/CatalogTable.tsx
@@ -1,0 +1,128 @@
+import { Fragment, useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  groupCatalogItems,
+  sortCatalogItems,
+  type CatalogSortDirection,
+  type CatalogSortKey,
+} from "../catalog-table";
+import { relativeTime, typeMeta, type Item, type ItemType } from "../model";
+import { HealthChip, TypeGlyph, cn } from "../ui";
+
+const COLUMNS: Array<{ key: CatalogSortKey; label: string }> = [
+  { key: "name", label: "Item" },
+  { key: "health", label: "Health" },
+  { key: "owner", label: "Documented owner" },
+  { key: "refresh", label: "Last refresh" },
+];
+
+export function CatalogTable({
+  items,
+  expanded,
+  searching,
+  selectedId,
+  onToggle,
+  onSelect,
+}: {
+  items: Item[];
+  expanded: ReadonlySet<string>;
+  searching: boolean;
+  selectedId: string | null;
+  onToggle: (type: ItemType) => void;
+  onSelect: (id: string) => void;
+}) {
+  const [sortKey, setSortKey] = useState<CatalogSortKey>("name");
+  const [direction, setDirection] = useState<CatalogSortDirection>("asc");
+  const groups = useMemo(
+    () => groupCatalogItems(sortCatalogItems(items, sortKey, direction)),
+    [items, sortKey, direction],
+  );
+  const sort = (key: CatalogSortKey) => {
+    setDirection((previous) =>
+      key === sortKey ? (previous === "asc" ? "desc" : "asc") : key === "refresh" ? "desc" : "asc",
+    );
+    setSortKey(key);
+  };
+
+  return (
+    <div role="region" aria-label="Catalog table" tabIndex={0} className="max-w-full overflow-auto rounded-xl border border-border bg-card">
+      <table className="atlas-catalog-table">
+        <caption className="sr-only">
+          Catalog items grouped by type. Sorting applies within each group.
+        </caption>
+        <thead>
+          <tr>
+            {COLUMNS.map(({ key, label }) => (
+              <th key={key} scope="col" aria-sort={sortKey === key ? (direction === "asc" ? "ascending" : "descending") : "none"}>
+                <button
+                  type="button"
+                  onClick={() => sort(key)}
+                  aria-label={`Sort by ${label.toLowerCase()}`}
+                  className="atlas-control inline-flex items-center gap-xs rounded-md text-left hover:text-brand-foreground"
+                >
+                  {label}
+                  {sortKey === key && (
+                    direction === "asc"
+                      ? <ArrowUp className="icon-size-100" aria-hidden="true" />
+                      : <ArrowDown className="icon-size-100" aria-hidden="true" />
+                  )}
+                </button>
+              </th>
+            ))}
+            <th scope="col">Tags</th>
+          </tr>
+        </thead>
+        {groups.map(([type, group], index) => {
+          const open = searching || expanded.has(type);
+          const regionId = `catalog-table-items-${index}`;
+          return (
+            <Fragment key={type}>
+              <tbody>
+                <tr className="bg-secondary/60">
+                  <th scope="rowgroup" colSpan={5}>
+                    <button
+                      type="button"
+                      disabled={searching}
+                      onClick={() => onToggle(type)}
+                      aria-expanded={open}
+                      aria-controls={regionId}
+                      className="atlas-control inline-flex w-full items-center gap-s rounded-md text-left disabled:cursor-default"
+                    >
+                      {open ? <ChevronDown className="icon-size-200" aria-hidden="true" /> : <ChevronRight className="icon-size-200" aria-hidden="true" />}
+                      <TypeGlyph type={type} size={24} />
+                      <span>{typeMeta(type).label}</span>
+                      <span className="ml-auto font-numeric text-200 text-muted-foreground">{group.length}</span>
+                    </button>
+                  </th>
+                </tr>
+              </tbody>
+              <tbody id={regionId} hidden={!open}>
+                {group.map((item) => (
+                  <tr key={item.fabricId} className={cn(selectedId === item.fabricId && "bg-primary/10")}>
+                    <th scope="row" className="font-medium">
+                      <button type="button" aria-haspopup="dialog" aria-label={`Open details for ${item.displayName}`} onClick={() => onSelect(item.fabricId)} className="atlas-control rounded-md text-left font-semibold text-brand-foreground hover:underline">
+                        {item.displayName}
+                      </button>
+                    </th>
+                    <td><HealthChip health={item.health} /></td>
+                    <td className="text-200">
+                      {item.ownerName || item.ownerEmail || (
+                        <span className="text-muted-foreground">
+                          {item.ownerMetadataAvailable === false ? "Not collected" : "Unassigned"}
+                        </span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap text-200 text-muted-foreground">
+                      {item.lastRefresh ? relativeTime(item.lastRefresh) : "Not available"}
+                    </td>
+                    <td className="text-200 text-muted-foreground">{item.tags.join(", ") || "None"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Fragment>
+          );
+        })}
+      </table>
+    </div>
+  );
+}

--- a/src/atlas/components/GovernanceExceptionControl.spec.tsx
+++ b/src/atlas/components/GovernanceExceptionControl.spec.tsx
@@ -1,0 +1,69 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GovernanceExceptionControl } from "./GovernanceExceptionControl";
+
+const base = {
+  findingId: "finding-1",
+  findingTitle: "External access",
+  canEdit: true,
+  loading: false,
+  pending: false,
+  onSave: vi.fn(async () => undefined),
+  onRemove: vi.fn(async () => undefined),
+};
+
+describe("GovernanceExceptionControl", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requires a reason and submits a future expiry", async () => {
+    const onSave = vi.fn(async () => undefined);
+    render(<GovernanceExceptionControl {...base} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add exception" }));
+    fireEvent.change(screen.getByLabelText("Justification"), {
+      target: { value: "Accepted during the migration window." },
+    });
+    fireEvent.change(screen.getByLabelText("Expires"), {
+      target: { value: "2099-09-05T12:00" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save exception" }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          findingId: "finding-1",
+          reason: "Accepted during the migration window.",
+        }),
+      ),
+    );
+  });
+
+  it("changes an active exception to expired while the view remains open", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-05T12:00:00.000Z"));
+    render(
+      <GovernanceExceptionControl
+        {...base}
+        exception={{
+          id: "exception-1",
+          findingId: "finding-1",
+          reason: "Short maintenance window.",
+          expiresAt: "2026-09-05T12:00:01.000Z",
+          authorId: "admin-1",
+          authorName: "Admin",
+          authorEmail: "admin@example.com",
+          createdAt: "2026-09-05T11:00:00.000Z",
+          updatedAt: "2026-09-05T11:00:00.000Z",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Active exception")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1_100);
+    });
+    expect(screen.getByText("Expired exception")).toBeInTheDocument();
+  });
+});

--- a/src/atlas/components/GovernanceExceptionControl.tsx
+++ b/src/atlas/components/GovernanceExceptionControl.tsx
@@ -1,0 +1,274 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { CalendarClock, ShieldCheck, Trash2, X } from "lucide-react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type FormEvent,
+} from "react";
+import {
+  governanceExceptionStatus,
+  type GovernanceException,
+} from "../governance-exceptions";
+import { cn } from "../ui";
+
+function localDateTime(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.valueOf())) return "";
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.valueOf() - offset).toISOString().slice(0, 16);
+}
+
+function nextDay(): string {
+  return localDateTime(new Date(Date.now() + 86_400_000).toISOString());
+}
+
+function useLiveExceptionStatus(
+  exception: GovernanceException | undefined,
+) {
+  const expiresAt = exception ? Date.parse(exception.expiresAt) : Number.NaN;
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      if (!Number.isFinite(expiresAt)) return () => undefined;
+      let timer: number | undefined;
+      const schedule = () => {
+        const remaining = expiresAt - Date.now();
+        if (remaining <= 0) {
+          notify();
+          return;
+        }
+        timer = window.setTimeout(
+          schedule,
+          Math.min(remaining + 10, 60_000),
+        );
+      };
+      schedule();
+      return () => {
+        if (timer != null) window.clearTimeout(timer);
+      };
+    },
+    [expiresAt],
+  );
+  const getSnapshot = useCallback(
+    () => Number.isFinite(expiresAt) && Date.now() >= expiresAt,
+    [expiresAt],
+  );
+  const expired = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (!exception) return undefined;
+  if (!Number.isFinite(expiresAt)) return "invalid";
+  return expired
+    ? "expired"
+    : governanceExceptionStatus(exception, expiresAt - 1);
+}
+
+export function GovernanceExceptionControl({
+  findingId,
+  findingTitle,
+  exception,
+  canEdit,
+  loading,
+  pending,
+  onSave,
+  onRemove,
+}: {
+  findingId: string;
+  findingTitle: string;
+  exception?: GovernanceException;
+  canEdit: boolean;
+  loading: boolean;
+  pending: boolean;
+  onSave: (input: {
+    findingId: string;
+    reason: string;
+    expiresAt: string;
+  }) => Promise<void>;
+  onRemove: (id: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState(exception?.reason ?? "");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [error, setError] = useState<string>();
+  const status = useLiveExceptionStatus(exception);
+
+  const statusLabel = useMemo(() => {
+    if (status === "active") return "Active exception";
+    if (status === "expired") return "Expired exception";
+    if (status === "invalid") return "Invalid exception";
+    return undefined;
+  }, [status]);
+
+  if (!canEdit && !exception) return null;
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setError(undefined);
+      const parsedExpiry = new Date(expiresAt);
+      if (!Number.isFinite(parsedExpiry.valueOf())) {
+        throw new Error("Enter a valid exception expiry.");
+      }
+      await onSave({
+        findingId,
+        reason,
+        expiresAt: parsedExpiry.toISOString(),
+      });
+      setOpen(false);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error ? saveError.message : String(saveError),
+      );
+    }
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          setReason(exception?.reason ?? "");
+          setExpiresAt(
+            exception ? localDateTime(exception.expiresAt) : nextDay(),
+          );
+          setError(undefined);
+        }
+        setOpen(nextOpen);
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-s">
+        {statusLabel && (
+          <span
+            className={cn(
+              "rounded-md border px-s py-xxs text-100 font-semibold",
+              status === "active"
+                ? "border-status-warning/30 bg-status-warning/10 text-status-warning"
+                : status === "expired"
+                  ? "border-border bg-secondary text-muted-foreground"
+                  : "border-status-failing/30 bg-status-failing/10 text-status-failing",
+            )}
+          >
+            {statusLabel}
+          </span>
+        )}
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            disabled={loading || pending}
+            className="atlas-control inline-flex items-center gap-s rounded-lg border border-border px-m font-semibold text-primary hover:bg-primary/10 disabled:opacity-50"
+          >
+            <CalendarClock className="icon-size-100" aria-hidden="true" />
+            {exception ? "Review exception" : "Add exception"}
+          </button>
+        </Dialog.Trigger>
+      </div>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[110] bg-black/55" />
+        <div className="pointer-events-none fixed inset-0 z-[111] flex items-center justify-center p-m">
+          <Dialog.Content className="pointer-events-auto w-full max-w-xl rounded-xl border border-border bg-card shadow-fabric-16">
+            <header className="atlas-page-header flex items-start gap-m border-b border-border">
+              <span className="flex icon-size-600 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-brand-foreground">
+                <ShieldCheck className="icon-size-200" aria-hidden="true" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <Dialog.Title className="text-400 font-semibold">
+                  Governance exception
+                </Dialog.Title>
+                <Dialog.Description className="mt-xs text-200 text-muted-foreground">
+                  {findingTitle}
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  aria-label="Close governance exception"
+                  className="atlas-control rounded-lg p-s text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <X className="icon-size-200" />
+                </button>
+              </Dialog.Close>
+            </header>
+
+            <form onSubmit={submit} className="grid gap-m p-l">
+              {exception && (
+                <div className="rounded-lg bg-secondary px-m py-s text-200 text-muted-foreground">
+                  {statusLabel}. Recorded by {exception.authorName} and expires{" "}
+                  {new Date(exception.expiresAt).toLocaleString()}.
+                </div>
+              )}
+              <label className="grid gap-xs text-200 font-semibold">
+                Justification
+                <textarea
+                  required
+                  maxLength={2000}
+                  disabled={!canEdit || pending}
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  className="atlas-control min-h-28 resize-y rounded-lg border border-input bg-card px-m text-300 disabled:opacity-60"
+                />
+              </label>
+              <label className="grid gap-xs text-200 font-semibold">
+                Expires
+                <input
+                  required
+                  type="datetime-local"
+                  disabled={!canEdit || pending}
+                  value={expiresAt}
+                  onChange={(event) => setExpiresAt(event.target.value)}
+                  className="atlas-control rounded-lg border border-input bg-card px-m disabled:opacity-60"
+                />
+              </label>
+              {error && (
+                <p
+                  role="alert"
+                  className="rounded-lg border border-status-warning/30 bg-status-warning/10 px-m py-s text-200 text-status-warning"
+                >
+                  {error}
+                </p>
+              )}
+              <div className="atlas-toolbar flex flex-wrap justify-end gap-s border-t border-border pt-m">
+                {canEdit && exception && (
+                  <button
+                    type="button"
+                    disabled={pending}
+                    onClick={() =>
+                      void onRemove(exception.id)
+                        .then(() => setOpen(false))
+                        .catch((removeError) =>
+                          setError(
+                            removeError instanceof Error
+                              ? removeError.message
+                              : String(removeError),
+                          ),
+                        )
+                    }
+                    className="atlas-control mr-auto inline-flex items-center gap-s rounded-lg border border-status-failing/30 px-m font-semibold text-status-failing hover:bg-status-failing/10 disabled:opacity-50"
+                  >
+                    <Trash2 className="icon-size-100" aria-hidden="true" />
+                    Remove exception
+                  </button>
+                )}
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    className="atlas-control rounded-lg border border-border px-m font-semibold hover:bg-accent"
+                  >
+                    Close
+                  </button>
+                </Dialog.Close>
+                {canEdit && (
+                  <button
+                    type="submit"
+                    disabled={pending}
+                    className="atlas-control rounded-lg bg-primary px-m font-semibold text-primary-foreground hover:brightness-110 disabled:opacity-50"
+                  >
+                    {exception ? "Update exception" : "Save exception"}
+                  </button>
+                )}
+              </div>
+            </form>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/atlas/components/GovernancePolicyEditor.spec.tsx
+++ b/src/atlas/components/GovernancePolicyEditor.spec.tsx
@@ -16,6 +16,9 @@ describe("GovernancePolicyEditor", () => {
   it("saves all six validated targets", async () => {
     const onSave = vi.fn(async () => undefined);
     render(<GovernancePolicyEditor {...props} onSave={onSave} />);
+    expect(
+      screen.getByText(/standard target is 70% for every pillar/i),
+    ).toBeVisible();
 
     fireEvent.change(screen.getByLabelText("Access target"), {
       target: { value: "82" },

--- a/src/atlas/components/GovernancePolicyEditor.spec.tsx
+++ b/src/atlas/components/GovernancePolicyEditor.spec.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { POSTURE_TARGETS } from "../posture";
+import { GovernancePolicyEditor } from "./GovernancePolicyEditor";
+
+describe("GovernancePolicyEditor", () => {
+  const props = {
+    targets: POSTURE_TARGETS,
+    loading: false,
+    canEdit: true,
+    onRetry: vi.fn(async () => undefined),
+    onSave: vi.fn(async () => undefined),
+    onReset: vi.fn(async () => undefined),
+  };
+
+  it("saves all six validated targets", async () => {
+    const onSave = vi.fn(async () => undefined);
+    render(<GovernancePolicyEditor {...props} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText("Access target"), {
+      target: { value: "82" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save targets" }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        ...POSTURE_TARGETS,
+        access: 82,
+      }),
+    );
+  });
+
+  it("shows a retry state instead of loaded defaults after a read failure", () => {
+    render(
+      <GovernancePolicyEditor
+        {...props}
+        error="policy unavailable"
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("policy unavailable");
+    expect(screen.queryByLabelText("Access target")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry targets" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/atlas/components/GovernancePolicyEditor.tsx
+++ b/src/atlas/components/GovernancePolicyEditor.tsx
@@ -88,7 +88,8 @@ export function GovernancePolicyEditor({
         <div>
           <h3 className="text-300 font-semibold">Workspace targets</h3>
           <p className="text-200 text-muted-foreground">
-            Current goals apply to the live score and historical comparisons.
+            The standard target is 70% for every pillar. Custom workspace goals
+            apply to the live score and historical comparisons.
           </p>
         </div>
         {!canEdit && (

--- a/src/atlas/components/GovernancePolicyEditor.tsx
+++ b/src/atlas/components/GovernancePolicyEditor.tsx
@@ -1,0 +1,168 @@
+import { RotateCcw, Save } from "lucide-react";
+import { useState, type FormEvent } from "react";
+import {
+  validateGovernanceTargets,
+  type GovernanceTargets,
+} from "../governance-policy";
+import { POSTURE_PILLARS, type PosturePillar } from "../posture";
+import { Card } from "../ui";
+
+const LABELS: Record<PosturePillar, string> = {
+  documentation: "Documentation",
+  ownership: "Ownership",
+  sensitivity: "Sensitivity",
+  access: "Access",
+  lineage: "Lineage",
+  operations: "Operations",
+};
+
+export function GovernancePolicyEditor({
+  targets,
+  loading,
+  error,
+  canEdit,
+  onRetry,
+  onSave,
+  onReset,
+}: {
+  targets: GovernanceTargets;
+  loading: boolean;
+  error?: string;
+  canEdit: boolean;
+  onRetry: () => Promise<void>;
+  onSave: (targets: GovernanceTargets) => Promise<void>;
+  onReset: () => Promise<void>;
+}) {
+  const [draft, setDraft] = useState<GovernanceTargets>({ ...targets });
+  const [formError, setFormError] = useState<string>();
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setFormError(undefined);
+      await onSave(validateGovernanceTargets(draft));
+    } catch (saveError) {
+      setFormError(
+        saveError instanceof Error ? saveError.message : String(saveError),
+      );
+    }
+  };
+
+  if (loading) {
+    return (
+      <div role="status">
+        <Card className="p-l">
+          <p className="text-300 text-muted-foreground">
+            Loading workspace governance targets...
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert">
+        <Card
+          className="flex flex-col gap-m border-status-warning/30 bg-status-warning/10 p-l sm:flex-row sm:items-center"
+        >
+          <p className="min-w-0 flex-1 text-300 text-status-warning">
+            Governance targets could not be loaded. {error}
+          </p>
+          <button
+            type="button"
+            onClick={() => void onRetry().catch(() => undefined)}
+            className="atlas-control inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent"
+          >
+            <RotateCcw className="icon-size-100" aria-hidden="true" />
+            Retry targets
+          </button>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="atlas-row flex flex-col gap-s border-b border-border bg-secondary/55 px-l py-m sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-300 font-semibold">Workspace targets</h3>
+          <p className="text-200 text-muted-foreground">
+            Current goals apply to the live score and historical comparisons.
+          </p>
+        </div>
+        {!canEdit && (
+          <span className="text-200 text-muted-foreground">
+            Only the configured sync administrator can edit.
+          </span>
+        )}
+      </div>
+      <form onSubmit={submit}>
+        <div className="grid gap-m p-l sm:grid-cols-2 xl:grid-cols-3">
+          {POSTURE_PILLARS.map((pillar) => (
+            <label key={pillar} className="grid gap-xs text-200 font-semibold">
+              {LABELS[pillar]}
+              <span className="flex items-center gap-s">
+                <input
+                  aria-label={`${LABELS[pillar]} target`}
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={1}
+                  disabled={!canEdit || loading}
+                  value={draft[pillar]}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      [pillar]: Number(event.target.value),
+                    }))
+                  }
+                  className="atlas-control min-w-0 flex-1 rounded-lg border border-input bg-card px-m font-numeric disabled:opacity-60"
+                />
+                <span className="text-muted-foreground">%</span>
+              </span>
+            </label>
+          ))}
+        </div>
+        {(formError || error) && (
+          <p
+            role="alert"
+            className="border-t border-status-warning/25 bg-status-warning/10 px-l py-s text-200 text-status-warning"
+          >
+            {formError ?? error}
+          </p>
+        )}
+        {canEdit && (
+          <div className="atlas-toolbar flex flex-wrap justify-end gap-s border-t border-border px-l py-m">
+            <button
+              type="button"
+              disabled={loading}
+              onClick={() => {
+                setFormError(undefined);
+                void onReset().catch((resetError) => {
+                  setFormError(
+                    resetError instanceof Error
+                      ? resetError.message
+                      : String(resetError),
+                  );
+                });
+              }}
+              className="atlas-control inline-flex items-center gap-s rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent disabled:opacity-50"
+            >
+              <RotateCcw className="icon-size-100" aria-hidden="true" />
+              Restore 70% defaults
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="atlas-control inline-flex items-center gap-s rounded-lg bg-primary px-m font-semibold text-primary-foreground hover:brightness-110 disabled:opacity-50"
+            >
+              <Save className="icon-size-100" aria-hidden="true" />
+              Save targets
+            </button>
+          </div>
+        )}
+      </form>
+    </Card>
+  );
+}

--- a/src/atlas/components/HistoricalChangeDetails.spec.tsx
+++ b/src/atlas/components/HistoricalChangeDetails.spec.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  compareSnapshots,
+  snapshotFromData,
+  type HistoricalSnapshot,
+} from "../history";
+import { SAMPLE_DATA } from "../model";
+import { HistoricalChangeDetails } from "./HistoricalChangeDetails";
+
+function snapshots(): {
+  previous: HistoricalSnapshot;
+  current: HistoricalSnapshot;
+} {
+  const previousData = structuredClone(SAMPLE_DATA);
+  const model = previousData.items.find(
+    (item) => item.itemType === "SemanticModel",
+  )!;
+  previousData.items = [
+    model,
+    {
+      ...model,
+      fabricId: "consumer-report",
+      displayName: "Consumer report",
+      itemType: "Report",
+    },
+  ];
+  previousData.edges = [
+    {
+      source: model.fabricId,
+      target: "consumer-report",
+      relation: "report",
+    },
+  ];
+  previousData.schema = {
+    [model.fabricId]: [
+      {
+        name: "Measures",
+        columns: [{ name: "Amount", dataType: "decimal" }],
+        measures: [
+          {
+            name: "Revenue",
+            expr: "SUMX(FILTER(Sales, Sales[Region] = \"<West>\"), Sales[Amount])",
+          },
+        ],
+      },
+    ],
+  };
+  const currentData = structuredClone(previousData);
+  currentData.schema = { [model.fabricId]: [] };
+  return {
+    previous: snapshotFromData(
+      previousData,
+      "old",
+      "2026-09-04T12:00:00.000Z",
+    ),
+    current: snapshotFromData(
+      currentData,
+      "new",
+      "2026-09-05T12:00:00.000Z",
+    ),
+  };
+}
+
+describe("HistoricalChangeDetails", () => {
+  it("uses old snapshot evidence for a deleted schema object", () => {
+    const { previous, current } = snapshots();
+    const change = compareSnapshots(previous, current).find(
+      (candidate) =>
+        candidate.type === "schema-object-removed" &&
+        candidate.objectName === "Revenue",
+    )!;
+
+    render(
+      <HistoricalChangeDetails
+        change={change}
+        previousSnapshotId="old"
+        currentSnapshotId="new"
+        snapshots={[previous, current]}
+        historyLoading={false}
+        failedSnapshotIds={new Set()}
+        loadHistorySnapshot={vi.fn(async () => undefined)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect change" }));
+    expect(screen.getByText(/SUMX\(FILTER/)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open before impact report" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Revenue" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Consumer report")).toBeInTheDocument();
+  });
+
+  it("does not treat unavailable history as empty impact", () => {
+    const { previous, current } = snapshots();
+    const change = compareSnapshots(previous, current).find(
+      (candidate) =>
+        candidate.type === "schema-object-removed" &&
+        candidate.objectName === "Revenue",
+    )!;
+    const loadHistorySnapshot = vi.fn(async () => undefined);
+
+    render(
+      <HistoricalChangeDetails
+        change={change}
+        previousSnapshotId="old"
+        currentSnapshotId="new"
+        snapshots={[current]}
+        historyLoading={false}
+        historyError="snapshot unavailable"
+        failedSnapshotIds={new Set(["old"])}
+        loadHistorySnapshot={loadHistorySnapshot}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect change" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Historical impact is unavailable",
+    );
+    expect(
+      screen.queryByText("No downstream consumer was returned."),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry history" }));
+    expect(loadHistorySnapshot).toHaveBeenCalledWith("old");
+  });
+});

--- a/src/atlas/components/HistoricalChangeDetails.spec.tsx
+++ b/src/atlas/components/HistoricalChangeDetails.spec.tsx
@@ -5,7 +5,11 @@ import {
   snapshotFromData,
   type HistoricalSnapshot,
 } from "../history";
-import { SAMPLE_DATA } from "../model";
+import {
+  metadataObjectLineageEdges,
+  parseOntologyMetadata,
+} from "../item-metadata";
+import { SAMPLE_DATA, type AtlasData } from "../model";
 import { HistoricalChangeDetails } from "./HistoricalChangeDetails";
 
 function snapshots(): {
@@ -125,5 +129,116 @@ describe("HistoricalChangeDetails", () => {
     ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry history" }));
     expect(loadHistorySnapshot).toHaveBeenCalledWith("old");
+  });
+
+  it("uses verified object edges from the selected historical snapshot", () => {
+    const ontology = parseOntologyMetadata({
+      entities: [
+        {
+          id: "device",
+          name: "Device",
+          properties: [
+            { id: "device-id", name: "Device ID", valueType: "String" },
+          ],
+        },
+      ],
+      relationships: [],
+      bindings: [
+        {
+          id: "device-binding",
+          entityId: "device",
+          bindingType: "table",
+          sourceItemId: "warehouse",
+          sourceObject: "Devices",
+          propertyBindings: [
+            { sourceColumn: "DeviceId", targetPropertyId: "device-id" },
+          ],
+        },
+      ],
+      contextualizations: [],
+    })!;
+    const base: AtlasData = {
+      workspace: {
+        fabricId: "workspace",
+        displayName: "Operations workspace",
+        capacity: "F2",
+        region: "West Europe",
+      },
+      items: [
+        {
+          fabricId: "warehouse",
+          displayName: "Operations warehouse",
+          itemType: "Warehouse",
+          health: "healthy",
+          endorsement: "none",
+          tags: [],
+        },
+        {
+          fabricId: "ontology",
+          displayName: "Operations ontology",
+          itemType: "Ontology",
+          health: "healthy",
+          endorsement: "none",
+          tags: [],
+        },
+      ],
+      edges: [],
+      principals: [],
+      grants: [],
+      jobs: [],
+      config: [],
+      comments: [],
+      syncRuns: [],
+      schema: {},
+      itemMetadata: { ontology },
+      objectEdges: metadataObjectLineageEdges("ontology", ontology),
+    };
+    const previous = snapshotFromData(
+      base,
+      "metadata-old",
+      "2026-09-04T12:00:00.000Z",
+    );
+    const currentData = structuredClone(base);
+    currentData.itemMetadata = {
+      ontology: {
+        ...ontology,
+        entities: [{ ...ontology.entities[0], properties: [] }],
+      },
+    };
+    currentData.objectEdges = [];
+    const current = snapshotFromData(
+      currentData,
+      "metadata-new",
+      "2026-09-05T12:00:00.000Z",
+    );
+    const change = compareSnapshots(previous, current).find(
+      (candidate) =>
+        candidate.type === "schema-object-removed" &&
+        candidate.objectName === "Device ID",
+    )!;
+
+    render(
+      <HistoricalChangeDetails
+        change={change}
+        previousSnapshotId="metadata-old"
+        currentSnapshotId="metadata-new"
+        snapshots={[previous, current]}
+        historyLoading={false}
+        failedSnapshotIds={new Set()}
+        loadHistorySnapshot={vi.fn(async () => undefined)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect change" }));
+    expect(screen.getByText(/Ontology property evidence/)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open before impact report" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Device ID" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Source field · Operations warehouse/),
+    ).toBeVisible();
   });
 });

--- a/src/atlas/components/HistoricalChangeDetails.tsx
+++ b/src/atlas/components/HistoricalChangeDetails.tsx
@@ -8,9 +8,15 @@ import {
   type AtlasChange,
   type HistoricalSnapshot,
 } from "../history";
+import {
+  assetObjectKindLabel,
+  findCatalogObject,
+  type CatalogObject,
+} from "../catalog-objects";
 import type { SchemaObjectRef } from "../lineage";
 import { cn } from "../ui";
 import { ImpactReportDialog } from "./ImpactReportDialog";
+import { MetadataObjectImpactDialog } from "./MetadataObjectImpactDialog";
 
 type EvidenceSide = "before" | "after";
 
@@ -31,29 +37,33 @@ function subjectExists(
     return false;
   }
   if (!change.objectType || !change.objectName) return true;
-  const tables = snapshot.catalog.schema?.[change.itemFabricId] ?? [];
-  if (change.objectType === "table" || change.objectType === "view") {
-    return tables.some(
-      (table) =>
-        table.name === change.objectName &&
-        (change.objectType !== "view" ||
-          table.objectType?.toLowerCase() === "view"),
-    );
-  }
-  const table = tables.find((candidate) => candidate.name === change.tableName);
-  if (!table) return false;
-  return change.objectType === "column"
-    ? table.columns.some((column) => column.name === change.objectName)
-    : table.measures.some((measure) => measure.name === change.objectName);
+  return Boolean(subjectObject(snapshot, change));
+}
+
+function subjectObject(
+  snapshot: HistoricalSnapshot,
+  change: AtlasChange,
+): CatalogObject | undefined {
+  if (!change.itemFabricId || !change.objectType) return undefined;
+  return findCatalogObject(snapshot.catalog, {
+    itemId: change.itemFabricId,
+    kind: change.objectType,
+    objectId: change.objectId,
+    name: change.objectName,
+    tableName: change.tableName,
+  });
 }
 
 function objectReference(change: AtlasChange): SchemaObjectRef | undefined {
   if (!change.itemFabricId || !change.objectType || !change.objectName) {
     return undefined;
   }
+  if (!["table", "view", "column", "measure"].includes(change.objectType)) {
+    return undefined;
+  }
   return {
     itemId: change.itemFabricId,
-    kind: change.objectType,
+    kind: change.objectType as SchemaObjectRef["kind"],
     name: change.objectName,
     tableName: change.tableName,
   };
@@ -117,11 +127,15 @@ export function HistoricalChangeDetails({
     (candidate) => candidate.snapshotId === snapshotId,
   );
   const hasSubject = snapshot ? subjectExists(snapshot, change) : false;
+  const selectedSubject = snapshot
+    ? subjectObject(snapshot, change)
+    : undefined;
   const historicalData = useMemo(
     () => (snapshot ? snapshotDataForInspection(snapshot) : undefined),
     [snapshot],
   );
   const object = objectReference(change);
+  const metadataObject = selectedSubject?.metadataRef;
   const hasBefore = change.before !== undefined;
   const hasAfter = change.after !== undefined;
 
@@ -158,7 +172,9 @@ export function HistoricalChangeDetails({
                     {change.label}
                   </Dialog.Title>
                   <Dialog.Description className="mt-xs text-200 text-muted-foreground">
-                    Full before and after evidence from validated snapshots.
+                    {change.objectType
+                      ? `${assetObjectKindLabel(change.objectType)} evidence from validated snapshots.`
+                      : "Full before and after evidence from validated snapshots."}
                   </Dialog.Description>
                 </div>
                 <Dialog.Close asChild>
@@ -300,7 +316,17 @@ export function HistoricalChangeDetails({
           </div>
         </Dialog.Portal>
       </Dialog.Root>
-      {historicalData && change.itemFabricId && hasSubject && (
+      {historicalData &&
+      change.itemFabricId &&
+      hasSubject &&
+      metadataObject ? (
+        <MetadataObjectImpactDialog
+          data={historicalData}
+          subject={metadataObject}
+          open={impactOpen}
+          onClose={() => setImpactOpen(false)}
+        />
+      ) : historicalData && change.itemFabricId && hasSubject ? (
         <ImpactReportDialog
           data={historicalData}
           itemId={change.itemFabricId}
@@ -308,7 +334,7 @@ export function HistoricalChangeDetails({
           open={impactOpen}
           onClose={() => setImpactOpen(false)}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/atlas/components/HistoricalChangeDetails.tsx
+++ b/src/atlas/components/HistoricalChangeDetails.tsx
@@ -1,0 +1,314 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { GitCompareArrows, RotateCcw, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  changeFieldValue,
+  readableChangeValue,
+  snapshotDataForInspection,
+  type AtlasChange,
+  type HistoricalSnapshot,
+} from "../history";
+import type { SchemaObjectRef } from "../lineage";
+import { cn } from "../ui";
+import { ImpactReportDialog } from "./ImpactReportDialog";
+
+type EvidenceSide = "before" | "after";
+
+function evidenceSideForChange(change: AtlasChange): EvidenceSide {
+  return change.after === undefined ? "before" : "after";
+}
+
+function subjectExists(
+  snapshot: HistoricalSnapshot,
+  change: AtlasChange,
+): boolean {
+  if (!change.itemFabricId) return false;
+  if (
+    !snapshot.catalog.items.some(
+      (item) => item.fabricId === change.itemFabricId,
+    )
+  ) {
+    return false;
+  }
+  if (!change.objectType || !change.objectName) return true;
+  const tables = snapshot.catalog.schema?.[change.itemFabricId] ?? [];
+  if (change.objectType === "table" || change.objectType === "view") {
+    return tables.some(
+      (table) =>
+        table.name === change.objectName &&
+        (change.objectType !== "view" ||
+          table.objectType?.toLowerCase() === "view"),
+    );
+  }
+  const table = tables.find((candidate) => candidate.name === change.tableName);
+  if (!table) return false;
+  return change.objectType === "column"
+    ? table.columns.some((column) => column.name === change.objectName)
+    : table.measures.some((measure) => measure.name === change.objectName);
+}
+
+function objectReference(change: AtlasChange): SchemaObjectRef | undefined {
+  if (!change.itemFabricId || !change.objectType || !change.objectName) {
+    return undefined;
+  }
+  return {
+    itemId: change.itemFabricId,
+    kind: change.objectType,
+    name: change.objectName,
+    tableName: change.tableName,
+  };
+}
+
+function DiffValue({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: unknown;
+  tone: "before" | "after";
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 rounded-lg border p-m",
+        tone === "before"
+          ? "border-status-failing/20 bg-status-failing/5"
+          : "border-status-healthy/20 bg-status-healthy/5",
+      )}
+    >
+      <div className="text-100 font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <pre className="mt-s max-h-80 overflow-auto whitespace-pre-wrap break-words font-mono text-200 leading-300 text-foreground">
+        {readableChangeValue(value)}
+      </pre>
+    </div>
+  );
+}
+
+export function HistoricalChangeDetails({
+  change,
+  previousSnapshotId,
+  currentSnapshotId,
+  snapshots,
+  historyLoading,
+  historyError,
+  failedSnapshotIds,
+  loadHistorySnapshot,
+}: {
+  change: AtlasChange;
+  previousSnapshotId: string;
+  currentSnapshotId: string;
+  snapshots: HistoricalSnapshot[];
+  historyLoading: boolean;
+  historyError?: string;
+  failedSnapshotIds: Set<string>;
+  loadHistorySnapshot: (snapshotId: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [impactOpen, setImpactOpen] = useState(false);
+  const [side, setSide] = useState<EvidenceSide>(() =>
+    evidenceSideForChange(change),
+  );
+  const snapshotId =
+    side === "before" ? previousSnapshotId : currentSnapshotId;
+  const snapshot = snapshots.find(
+    (candidate) => candidate.snapshotId === snapshotId,
+  );
+  const hasSubject = snapshot ? subjectExists(snapshot, change) : false;
+  const historicalData = useMemo(
+    () => (snapshot ? snapshotDataForInspection(snapshot) : undefined),
+    [snapshot],
+  );
+  const object = objectReference(change);
+  const hasBefore = change.before !== undefined;
+  const hasAfter = change.after !== undefined;
+
+  useEffect(() => {
+    if (!open || !snapshotId || snapshot) return;
+    void loadHistorySnapshot(snapshotId);
+  }, [loadHistorySnapshot, open, snapshot, snapshotId]);
+
+  return (
+    <>
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            className="atlas-control inline-flex items-center gap-s self-start rounded-lg border border-border px-m font-semibold text-primary hover:bg-primary/10"
+          >
+            <GitCompareArrows className="icon-size-100" aria-hidden="true" />
+            Inspect change
+          </button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[110] bg-black/55" />
+          <div className="pointer-events-none fixed inset-0 z-[111] flex items-center justify-center p-m sm:p-xl">
+            <Dialog.Content className="pointer-events-auto flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-fabric-16">
+              <header className="atlas-page-header flex items-start gap-m border-b border-border">
+                <span className="flex icon-size-600 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-brand-foreground">
+                  <GitCompareArrows
+                    className="icon-size-200"
+                    aria-hidden="true"
+                  />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <Dialog.Title className="text-400 font-semibold">
+                    {change.label}
+                  </Dialog.Title>
+                  <Dialog.Description className="mt-xs text-200 text-muted-foreground">
+                    Full before and after evidence from validated snapshots.
+                  </Dialog.Description>
+                </div>
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    aria-label="Close change details"
+                    className="atlas-control rounded-lg p-s text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    <X className="icon-size-200" />
+                  </button>
+                </Dialog.Close>
+              </header>
+
+              <div className="min-h-0 flex-1 overflow-y-auto p-l">
+                {change.changedFields?.length ? (
+                  <section aria-label="Changed fields">
+                    <h3 className="text-300 font-semibold">Changed fields</h3>
+                    <div className="mt-s grid gap-s">
+                      {change.changedFields.map((field) => (
+                        <div
+                          key={field}
+                          className="grid gap-s rounded-lg border border-border p-m lg:grid-cols-[10rem_1fr_1fr]"
+                        >
+                          <div className="text-200 font-semibold">{field}</div>
+                          <DiffValue
+                            label="Before"
+                            value={changeFieldValue(change.before, field)}
+                            tone="before"
+                          />
+                          <DiffValue
+                            label="After"
+                            value={changeFieldValue(change.after, field)}
+                            tone="after"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                ) : null}
+
+                <section className="mt-l grid gap-m lg:grid-cols-2">
+                  <DiffValue label="Full before" value={change.before} tone="before" />
+                  <DiffValue label="Full after" value={change.after} tone="after" />
+                </section>
+
+                {change.itemFabricId && (
+                  <section className="mt-l rounded-xl border border-border">
+                    <div className="atlas-row flex flex-col gap-s border-b border-border bg-secondary/55 px-l sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <h3 className="text-300 font-semibold">
+                          Historical impact evidence
+                        </h3>
+                        <p className="text-200 text-muted-foreground">
+                          Impact is calculated only from the selected historical
+                          snapshot.
+                        </p>
+                      </div>
+                      {hasBefore && hasAfter && (
+                        <div
+                          className="atlas-toolbar flex gap-s"
+                          aria-label="Impact evidence version"
+                        >
+                          {(["before", "after"] as const).map((value) => (
+                            <button
+                              key={value}
+                              type="button"
+                              aria-pressed={side === value}
+                              onClick={() => setSide(value)}
+                              className={cn(
+                                "atlas-control rounded-lg border px-m font-semibold",
+                                side === value
+                                  ? "border-primary bg-primary/10 text-primary"
+                                  : "border-border hover:bg-accent",
+                              )}
+                            >
+                              {value === "before" ? "Before impact" : "After impact"}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="p-l">
+                      {!snapshot ? (
+                        failedSnapshotIds.has(snapshotId) ? (
+                          <div
+                            role="alert"
+                            className="flex flex-col gap-m rounded-lg border border-status-warning/30 bg-status-warning/10 p-m sm:flex-row sm:items-center"
+                          >
+                            <p className="min-w-0 flex-1 text-200 text-status-warning">
+                              Historical impact is unavailable.{" "}
+                              {historyError ??
+                                "The validated snapshot could not be loaded."}
+                            </p>
+                            <button
+                              type="button"
+                              disabled={historyLoading}
+                              onClick={() =>
+                                void loadHistorySnapshot(snapshotId)
+                              }
+                              className="atlas-control inline-flex items-center gap-s rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent disabled:opacity-50"
+                            >
+                              <RotateCcw
+                                className="icon-size-100"
+                                aria-hidden="true"
+                              />
+                              Retry history
+                            </button>
+                          </div>
+                        ) : (
+                          <p role="status" className="text-200 text-muted-foreground">
+                            Loading validated historical impact...
+                          </p>
+                        )
+                      ) : !hasSubject ? (
+                        <p
+                          role="alert"
+                          className="text-200 text-status-warning"
+                        >
+                          The selected historical snapshot does not contain the
+                          item or schema object needed for impact analysis.
+                        </p>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setOpen(false);
+                            setImpactOpen(true);
+                          }}
+                          className="atlas-control rounded-lg bg-primary px-m font-semibold text-primary-foreground hover:brightness-110"
+                        >
+                          Open {side} impact report
+                        </button>
+                      )}
+                    </div>
+                  </section>
+                )}
+              </div>
+            </Dialog.Content>
+          </div>
+        </Dialog.Portal>
+      </Dialog.Root>
+      {historicalData && change.itemFabricId && hasSubject && (
+        <ImpactReportDialog
+          data={historicalData}
+          itemId={change.itemFabricId}
+          object={object}
+          open={impactOpen}
+          onClose={() => setImpactOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/atlas/components/MetadataObjectImpactDialog.tsx
+++ b/src/atlas/components/MetadataObjectImpactDialog.tsx
@@ -1,0 +1,157 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { GitBranch, X } from "lucide-react";
+import { useMemo } from "react";
+import {
+  metadataObjectImpact,
+  metadataObjectKindLabel,
+} from "../catalog-objects";
+import type { MetadataObjectRef } from "../item-metadata";
+import type { AtlasData } from "../model";
+
+function ObjectList({
+  title,
+  values,
+  itemNames,
+}: {
+  title: string;
+  values: MetadataObjectRef[];
+  itemNames: ReadonlyMap<string, string>;
+}) {
+  return (
+    <section className="rounded-xl border border-border bg-secondary/40 p-m">
+      <h3 className="text-300 font-semibold">
+        {title} · {values.length}
+      </h3>
+      <div className="mt-s space-y-xs">
+        {values.length === 0 ? (
+          <p className="text-200 text-muted-foreground">
+            No verified object relationship was returned.
+          </p>
+        ) : (
+          values.map((object) => (
+            <div
+              key={`${object.itemId}:${object.kind}:${object.id}`}
+              className="rounded-lg border border-border bg-card px-m py-s"
+            >
+              <div className="break-words text-300 font-semibold">
+                {object.name}
+              </div>
+              <div className="mt-xxs break-words text-200 text-muted-foreground">
+                {metadataObjectKindLabel(object.kind)} ·{" "}
+                {itemNames.get(object.itemId) ?? object.itemId}
+                {object.tableName ? ` · ${object.tableName}` : ""}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function MetadataObjectImpactDialog({
+  data,
+  subject,
+  open,
+  onClose,
+}: {
+  data: AtlasData;
+  subject: MetadataObjectRef;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const impact = useMemo(
+    () => metadataObjectImpact(data.objectEdges, subject),
+    [data.objectEdges, subject],
+  );
+  const itemNames = useMemo(
+    () =>
+      new Map(data.items.map((item) => [item.fabricId, item.displayName])),
+    [data.items],
+  );
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[120] bg-black/55" />
+        <div className="pointer-events-none fixed inset-0 z-[121] flex items-center justify-center p-m sm:p-xl">
+          <Dialog.Content className="pointer-events-auto flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-fabric-16">
+            <header className="atlas-page-header flex items-start gap-m border-b border-border">
+              <span className="flex icon-size-600 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-brand-foreground">
+                <GitBranch className="icon-size-200" aria-hidden="true" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <Dialog.Title className="break-words text-400 font-semibold">
+                  {subject.name}
+                </Dialog.Title>
+                <Dialog.Description className="mt-xs text-200 text-muted-foreground">
+                  Verified object impact from the selected synchronized
+                  workspace snapshot.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  aria-label="Close object impact"
+                  className="atlas-control rounded-lg p-s text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <X className="icon-size-200" />
+                </button>
+              </Dialog.Close>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-y-auto p-l">
+              <div className="grid gap-m md:grid-cols-2">
+                <ObjectList
+                  title="Upstream"
+                  values={impact.upstream}
+                  itemNames={itemNames}
+                />
+                <ObjectList
+                  title="Downstream"
+                  values={impact.downstream}
+                  itemNames={itemNames}
+                />
+              </div>
+              <section className="mt-m rounded-xl border border-border p-m">
+                <h3 className="text-300 font-semibold">
+                  Verified relationships · {impact.relevantEdges.length}
+                </h3>
+                <div className="mt-s space-y-xs">
+                  {impact.relevantEdges.length === 0 ? (
+                    <p className="text-200 text-muted-foreground">
+                      This snapshot contains the object, but no verified
+                      object-level lineage for it.
+                    </p>
+                  ) : (
+                    impact.relevantEdges.map((edge) => (
+                      <div
+                        key={`${edge.source.itemId}:${edge.source.kind}:${edge.source.id}:${edge.target.itemId}:${edge.target.kind}:${edge.target.id}:${edge.relation}`}
+                        className="grid gap-xs rounded-lg bg-secondary px-m py-s text-200 sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center"
+                      >
+                        <span className="break-words font-semibold">
+                          {edge.source.name}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {edge.relation}
+                        </span>
+                        <span className="break-words font-semibold sm:text-right">
+                          {edge.target.name}
+                        </span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </section>
+            </div>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/atlas/components/ResizableInspector.spec.tsx
+++ b/src/atlas/components/ResizableInspector.spec.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAP_INSPECTOR_DEFAULT_WIDTH,
+  MAP_INSPECTOR_MAX_WIDTH,
+  MAP_INSPECTOR_MIN_WIDTH,
+} from "../map-inspector";
+import { ResizableInspector } from "./ResizableInspector";
+
+describe("ResizableInspector", () => {
+  it("supports keyboard resizing and viewport-aware clamping", () => {
+    vi.stubGlobal("innerWidth", 1100);
+    const onWidthChange = vi.fn();
+    render(
+      <ResizableInspector
+        width={MAP_INSPECTOR_DEFAULT_WIDTH}
+        onWidthChange={onWidthChange}
+      >
+        <aside>Details</aside>
+      </ResizableInspector>,
+    );
+
+    const separator = screen.getByRole("separator", {
+      name: "Resize details inspector",
+    });
+    expect(separator).toHaveAttribute("aria-valuemax", "620");
+    expect(separator).toHaveClass("hidden", "xl:flex");
+    expect(separator.parentElement).toHaveClass(
+      "w-full",
+      "xl:w-[var(--atlas-inspector-width)]",
+    );
+
+    fireEvent.keyDown(separator, { key: "ArrowLeft" });
+    expect(onWidthChange).toHaveBeenLastCalledWith(376);
+
+    fireEvent.keyDown(separator, { key: "End" });
+    expect(onWidthChange).toHaveBeenLastCalledWith(620);
+
+    fireEvent.keyDown(separator, { key: "Home" });
+    expect(onWidthChange).toHaveBeenLastCalledWith(MAP_INSPECTOR_MIN_WIDTH);
+    vi.unstubAllGlobals();
+  });
+
+  it("supports pointer resizing and exposes preference errors", () => {
+    vi.stubGlobal("innerWidth", 1600);
+    const onWidthChange = vi.fn();
+    render(
+      <ResizableInspector
+        width={400}
+        onWidthChange={onWidthChange}
+        error="The saved display setting could not be loaded."
+      >
+        <aside>Details</aside>
+      </ResizableInspector>,
+    );
+
+    const separator = screen.getByRole("separator", {
+      name: "Resize details inspector",
+    });
+    fireEvent.pointerDown(separator, { pointerId: 1, clientX: 400 });
+    fireEvent.pointerMove(separator, { pointerId: 1, clientX: -100 });
+    expect(onWidthChange).not.toHaveBeenCalled();
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: -100 });
+    expect(onWidthChange).toHaveBeenLastCalledWith(MAP_INSPECTOR_MAX_WIDTH);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "could not be loaded",
+    );
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/atlas/components/ResizableInspector.tsx
+++ b/src/atlas/components/ResizableInspector.tsx
@@ -1,0 +1,162 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import { GripVertical } from "lucide-react";
+import {
+  MAP_INSPECTOR_KEYBOARD_STEP,
+  MAP_INSPECTOR_MIN_WIDTH,
+  clampMapInspectorWidth,
+  mapInspectorMaxWidth,
+} from "../map-inspector";
+import { cn } from "../ui";
+
+interface ResizableInspectorProps {
+  width: number;
+  onWidthChange: (width: number) => void;
+  error?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ResizableInspector({
+  width,
+  onWidthChange,
+  error,
+  children,
+  className,
+}: ResizableInspectorProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [availableWidth, setAvailableWidth] = useState(() =>
+    typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerWidth,
+  );
+  const [dragWidth, setDragWidth] = useState<number>();
+  const drag = useRef<{
+    pointerX: number;
+    startWidth: number;
+    nextWidth: number;
+  } | null>(null);
+  const effectiveWidth = clampMapInspectorWidth(
+    dragWidth ?? width,
+    availableWidth,
+  );
+  const maximumWidth = mapInspectorMaxWidth(availableWidth);
+
+  useEffect(() => {
+    const parent = rootRef.current?.parentElement;
+    const updateAvailableWidth = () =>
+      setAvailableWidth(parent?.clientWidth || window.innerWidth);
+    updateAvailableWidth();
+    window.addEventListener("resize", updateAvailableWidth);
+    const observer =
+      parent && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(updateAvailableWidth)
+        : undefined;
+    if (parent) observer?.observe(parent);
+    return () => {
+      window.removeEventListener("resize", updateAvailableWidth);
+      observer?.disconnect();
+    };
+  }, []);
+
+  const setClampedWidth = (nextWidth: number) => {
+    onWidthChange(clampMapInspectorWidth(nextWidth, availableWidth));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey
+      ? MAP_INSPECTOR_KEYBOARD_STEP * 3
+      : MAP_INSPECTOR_KEYBOARD_STEP;
+    let nextWidth: number | undefined;
+    if (event.key === "ArrowLeft") nextWidth = effectiveWidth + step;
+    if (event.key === "ArrowRight") nextWidth = effectiveWidth - step;
+    if (event.key === "Home") nextWidth = MAP_INSPECTOR_MIN_WIDTH;
+    if (event.key === "End") nextWidth = maximumWidth;
+    if (nextWidth == null) return;
+    event.preventDefault();
+    setClampedWidth(nextWidth);
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    drag.current = {
+      pointerX: event.clientX,
+      startWidth: effectiveWidth,
+      nextWidth: effectiveWidth,
+    };
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!drag.current) return;
+    const nextWidth = clampMapInspectorWidth(
+      drag.current.startWidth + drag.current.pointerX - event.clientX,
+      availableWidth,
+    );
+    drag.current.nextWidth = nextWidth;
+    setDragWidth(nextWidth);
+  };
+
+  const finishPointerResize = () => {
+    if (!drag.current) return;
+    onWidthChange(drag.current.nextWidth);
+    drag.current = null;
+    setDragWidth(undefined);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    finishPointerResize();
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        "relative flex min-h-0 w-full shrink-0 flex-col xl:w-[var(--atlas-inspector-width)]",
+        className,
+      )}
+      style={
+        {
+          "--atlas-inspector-width": `${effectiveWidth}px`,
+        } as CSSProperties
+      }
+    >
+      <div
+        role="separator"
+        aria-label="Resize details inspector"
+        aria-orientation="vertical"
+        aria-valuemin={MAP_INSPECTOR_MIN_WIDTH}
+        aria-valuemax={maximumWidth}
+        aria-valuenow={effectiveWidth}
+        aria-valuetext={`${effectiveWidth} pixels`}
+        tabIndex={0}
+        title="Drag to resize. Use Left and Right arrow keys for precise adjustment."
+        onKeyDown={handleKeyDown}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={finishPointerResize}
+        onLostPointerCapture={finishPointerResize}
+        className="absolute inset-y-0 left-0 z-30 hidden w-m -translate-x-1/2 touch-none cursor-col-resize items-center justify-center text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring xl:flex"
+      >
+        <span className="flex h-[var(--atlas-touch-target)] w-m items-center justify-center rounded-md border border-border bg-card shadow-fabric-2">
+          <GripVertical className="icon-size-100" aria-hidden="true" />
+        </span>
+      </div>
+      {error && (
+        <div
+          role="status"
+          className="border-b border-destructive/30 bg-destructive/10 px-l py-s text-200 text-destructive"
+        >
+          {error}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/atlas/display-preferences.spec.tsx
+++ b/src/atlas/display-preferences.spec.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  displayPreferenceKey,
+  isDisplayDensity,
+  useDisplayPreference,
+} from "./display-preferences";
+
+describe("personal display preferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("persists density only for the matching user and workspace", () => {
+    const { result, rerender } = renderHook(
+      ({ userId, workspaceId }) =>
+        useDisplayPreference(userId, workspaceId, "density", "comfortable", isDisplayDensity),
+      { initialProps: { userId: "user-a", workspaceId: "workspace-a" } },
+    );
+    act(() => result.current.setValue("compact"));
+    expect(result.current.value).toBe("compact");
+    rerender({ userId: "user-b", workspaceId: "workspace-a" });
+    expect(result.current.value).toBe("comfortable");
+    rerender({ userId: "user-a", workspaceId: "workspace-b" });
+    expect(result.current.value).toBe("comfortable");
+    rerender({ userId: "user-a", workspaceId: "workspace-a" });
+    expect(result.current.value).toBe("compact");
+  });
+
+  it("reports invalid stored values instead of applying them", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    localStorage.setItem(displayPreferenceKey("u", "w", "density"), '"tiny"');
+    const { result } = renderHook(() =>
+      useDisplayPreference("u", "w", "density", "comfortable", isDisplayDensity),
+    );
+    expect(result.current.value).toBe("comfortable");
+    expect(result.current.error).toContain("could not be loaded");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("reloads a previous scope after another tab changes its preference", () => {
+    const { result, rerender } = renderHook(
+      ({ userId }) =>
+        useDisplayPreference(userId, "w", "density", "comfortable", isDisplayDensity),
+      { initialProps: { userId: "a" } },
+    );
+    act(() => result.current.setValue("compact"));
+    rerender({ userId: "b" });
+    localStorage.setItem(displayPreferenceKey("a", "w", "density"), '"comfortable"');
+    act(() => window.dispatchEvent(new StorageEvent("storage", {
+      key: displayPreferenceKey("a", "w", "density"),
+    })));
+    rerender({ userId: "a" });
+    expect(result.current.value).toBe("comfortable");
+  });
+
+  it("keeps an explicitly unsaved preference usable when storage is blocked", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { result } = renderHook(() =>
+      useDisplayPreference("u", "w", "density", "comfortable", isDisplayDensity),
+    );
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is blocked", "SecurityError");
+    });
+    act(() => result.current.setValue("compact"));
+    expect(result.current.value).toBe("compact");
+    expect(result.current.error).toContain("could not be saved");
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/atlas/display-preferences.ts
+++ b/src/atlas/display-preferences.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type DisplayDensity = "comfortable" | "compact";
+export type CatalogLayout = "cards" | "table";
+export type DisplayPreferenceName = "density" | "catalog-layout" | "map-inspector-width";
+
+export const isDisplayDensity = (value: unknown): value is DisplayDensity =>
+  value === "comfortable" || value === "compact";
+
+export const isCatalogLayout = (value: unknown): value is CatalogLayout =>
+  value === "cards" || value === "table";
+
+export function displayPreferenceKey(
+  userId: string,
+  workspaceId: string,
+  name: DisplayPreferenceName,
+): string {
+  return ["atlas.display.v1", userId, workspaceId, name]
+    .map(encodeURIComponent)
+    .join(":");
+}
+
+interface PreferenceState<T> {
+  key: string;
+  value: T;
+  error?: string;
+}
+
+function readPreference<T>(
+  key: string,
+  initialValue: T,
+  validate: (value: unknown) => value is T,
+): PreferenceState<T> {
+  if (typeof window === "undefined") return { key, value: initialValue };
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw == null) return { key, value: initialValue };
+    const value: unknown = JSON.parse(raw);
+    if (!validate(value)) throw new Error("Invalid display preference");
+    return { key, value };
+  } catch (error) {
+    console.warn("[atlas] unable to read display preference", error);
+    return {
+      key,
+      value: initialValue,
+      error: "The saved display setting could not be loaded. The default is shown.",
+    };
+  }
+}
+
+export function useDisplayPreference<T>(
+  userId: string,
+  workspaceId: string,
+  name: DisplayPreferenceName,
+  initialValue: T,
+  validate: (value: unknown) => value is T,
+) {
+  const key = displayPreferenceKey(userId, workspaceId, name);
+  const [state, setState] = useState<PreferenceState<T>>(() =>
+    readPreference(key, initialValue, validate),
+  );
+  const current =
+    state.key === key ? state : readPreference(key, initialValue, validate);
+  if (state.key !== key) setState(current);
+
+  useEffect(() => {
+    const receive = (event: StorageEvent) => {
+      if (event.key === key || event.key === null) {
+        setState(readPreference(key, initialValue, validate));
+      }
+    };
+    window.addEventListener("storage", receive);
+    return () => window.removeEventListener("storage", receive);
+  }, [key, initialValue, validate]);
+
+  const setValue = useCallback(
+    (value: T) => {
+      if (!validate(value)) throw new Error("Invalid display preference");
+      let error: string | undefined;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } catch (cause) {
+        console.warn("[atlas] unable to save display preference", cause);
+        error = "This display setting applies now but could not be saved for your next visit.";
+      }
+      setState({ key, value, error });
+    },
+    [key, validate],
+  );
+
+  return { value: current.value, setValue, error: current.error };
+}

--- a/src/atlas/governance-exceptions.spec.ts
+++ b/src/atlas/governance-exceptions.spec.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activeExceptionForFinding,
+  deleteGovernanceException,
+  governanceExceptionStatus,
+  loadGovernanceExceptions,
+  saveGovernanceException,
+} from "./governance-exceptions";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("@/lib/rayfin-client", () => ({
+  getRayfinClient: () => ({
+    data: {
+      GovernanceException: {
+        select: mocks.select,
+        create: mocks.create,
+        update: mocks.update,
+        delete: mocks.delete,
+      },
+    },
+  }),
+}));
+
+const author = {
+  id: "admin-1",
+  name: "Workspace Admin",
+  email: "ADMIN@example.com",
+};
+
+describe("governance exceptions", () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+    const query = {
+      where: mocks.where,
+      orderBy: mocks.orderBy,
+      execute: mocks.execute,
+    };
+    mocks.select.mockReturnValue(query);
+    mocks.where.mockReturnValue(query);
+    mocks.orderBy.mockReturnValue(query);
+    mocks.execute.mockResolvedValue([]);
+    mocks.create.mockImplementation(async (value) => value);
+    mocks.update.mockResolvedValue(undefined);
+    mocks.delete.mockResolvedValue(undefined);
+  });
+
+  it("loads shared workspace exceptions", async () => {
+    mocks.execute.mockResolvedValue([
+      {
+        id: "exception-1",
+        workspace_id: "workspace-1",
+        recordKey: "key",
+        writerEmail: "admin@example.com",
+        findingId: "finding-1",
+        reason: "Accepted until migration completes.",
+        expiresAt: "2026-09-10T12:00:00.000Z",
+        authorId: "admin-1",
+        authorName: "Workspace Admin",
+        authorEmail: "admin@example.com",
+        createdAt: "2026-09-01T12:00:00.000Z",
+        updatedAt: "2026-09-01T12:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      loadGovernanceExceptions(false, "workspace-1"),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        findingId: "finding-1",
+        authorEmail: "admin@example.com",
+      }),
+    ]);
+    expect(mocks.where).toHaveBeenCalledWith({
+      workspace_id: { eq: "workspace-1" },
+    });
+  });
+
+  it("distinguishes active, expired and invalid exceptions", () => {
+    const base = {
+      findingId: "finding-1",
+      expiresAt: "2026-09-05T12:00:00.000Z",
+    };
+    expect(
+      governanceExceptionStatus(base, Date.parse("2026-09-05T11:00:00.000Z")),
+    ).toBe("active");
+    expect(
+      governanceExceptionStatus(base, Date.parse("2026-09-05T13:00:00.000Z")),
+    ).toBe("expired");
+    expect(
+      governanceExceptionStatus({ ...base, expiresAt: "not-a-date" }),
+    ).toBe("invalid");
+    expect(
+      activeExceptionForFinding(
+        [
+          {
+            id: "exception-1",
+            reason: "Temporary",
+            authorId: "admin-1",
+            authorName: "Admin",
+            authorEmail: "admin@example.com",
+            createdAt: "2026-09-01T12:00:00.000Z",
+            updatedAt: "2026-09-01T12:00:00.000Z",
+            ...base,
+          },
+        ],
+        "finding-1",
+        Date.parse("2026-09-05T13:00:00.000Z"),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("requires a real subject, reason and future expiry", async () => {
+    await expect(
+      saveGovernanceException(true, "workspace-1", author, {
+        findingId: " ",
+        reason: "Temporary",
+        expiresAt: "2099-09-05T12:00:00.000Z",
+      }),
+    ).rejects.toThrow(/finding identity/);
+    await expect(
+      saveGovernanceException(true, "workspace-1", author, {
+        findingId: "finding-1",
+        reason: " ",
+        expiresAt: "2099-09-05T12:00:00.000Z",
+      }),
+    ).rejects.toThrow(/reason/);
+    await expect(
+      saveGovernanceException(true, "workspace-1", author, {
+        findingId: "finding-1",
+        reason: "Temporary",
+        expiresAt: "not-a-date",
+      }),
+    ).rejects.toThrow(/expiry/);
+  });
+
+  it("creates, updates and deletes a stable finding exception", async () => {
+    const created = await saveGovernanceException(
+      false,
+      "workspace-1",
+      author,
+      {
+        findingId: "finding-1",
+        reason: "Accepted until the source migration completes.",
+        expiresAt: "2099-09-05T12:00:00.000Z",
+      },
+    );
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace_id: "workspace-1",
+        findingId: "finding-1",
+        authorEmail: "admin@example.com",
+      }),
+    );
+
+    await saveGovernanceException(false, "workspace-1", author, {
+      current: created,
+      findingId: "finding-1",
+      reason: "Extended for the final cutover.",
+      expiresAt: "2099-09-12T12:00:00.000Z",
+    });
+    expect(mocks.update).toHaveBeenCalledWith(
+      { id: created.id },
+      expect.objectContaining({
+        reason: "Extended for the final cutover.",
+      }),
+    );
+
+    await deleteGovernanceException(false, created.id);
+    expect(mocks.delete).toHaveBeenCalledWith({ id: created.id });
+  });
+});

--- a/src/atlas/governance-exceptions.ts
+++ b/src/atlas/governance-exceptions.ts
@@ -1,0 +1,233 @@
+import { getRayfinClient } from "@/lib/rayfin-client";
+
+export type GovernanceExceptionStatus = "active" | "expired" | "invalid";
+
+export interface GovernanceException {
+  id: string;
+  findingId: string;
+  reason: string;
+  expiresAt: string;
+  authorId: string;
+  authorName: string;
+  authorEmail: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GovernanceExceptionRow
+  extends Omit<
+    GovernanceException,
+    "expiresAt" | "createdAt" | "updatedAt"
+  > {
+  workspace_id: string;
+  recordKey: string;
+  writerEmail: string;
+  expiresAt: string | Date;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+const FIELDS = [
+  "id",
+  "workspace_id",
+  "recordKey",
+  "writerEmail",
+  "findingId",
+  "reason",
+  "expiresAt",
+  "authorId",
+  "authorName",
+  "authorEmail",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+function api() {
+  return getRayfinClient().data.GovernanceException;
+}
+
+function normalizedSubject(value: string): string {
+  const subject = value.trim();
+  if (!subject || subject.length > 700) {
+    throw new Error("A valid governance finding identity is required.");
+  }
+  return subject;
+}
+
+function normalizedReason(value: string): string {
+  const reason = value.trim();
+  if (!reason || reason.length > 2000) {
+    throw new Error("An exception reason between 1 and 2000 characters is required.");
+  }
+  return reason;
+}
+
+function expiryIso(value: string | Date, requireFuture: boolean): string {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.valueOf())) {
+    throw new Error("A valid governance exception expiry is required.");
+  }
+  if (requireFuture && parsed.valueOf() <= Date.now()) {
+    throw new Error("Governance exception expiry must be in the future.");
+  }
+  return parsed.toISOString();
+}
+
+function parse(row: GovernanceExceptionRow): GovernanceException {
+  return {
+    id: String(row.id),
+    findingId: String(row.findingId),
+    reason: String(row.reason),
+    expiresAt: expiryIso(row.expiresAt, false),
+    authorId: String(row.authorId),
+    authorName: String(row.authorName),
+    authorEmail: String(row.authorEmail),
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+  };
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function recordKey(
+  workspaceId: string,
+  findingId: string,
+): Promise<string> {
+  return sha256([workspaceId, findingId].join("\u0000"));
+}
+
+async function findExisting(key: string): Promise<GovernanceExceptionRow | undefined> {
+  const rows = await api()
+    .select(FIELDS)
+    .where({ recordKey: { eq: key } })
+    .orderBy({ updatedAt: "desc" })
+    .execute();
+  return rows[0];
+}
+
+export function governanceExceptionStatus(
+  exception: Pick<GovernanceException, "findingId" | "expiresAt">,
+  now = Date.now(),
+): GovernanceExceptionStatus {
+  if (!exception.findingId.trim() || exception.findingId.length > 700) {
+    return "invalid";
+  }
+  const expiresAt = Date.parse(exception.expiresAt);
+  if (!Number.isFinite(expiresAt)) return "invalid";
+  return expiresAt > now ? "active" : "expired";
+}
+
+export function activeExceptionForFinding(
+  exceptions: readonly GovernanceException[],
+  findingId: string,
+  now = Date.now(),
+): GovernanceException | undefined {
+  return exceptions.find(
+    (exception) =>
+      exception.findingId === findingId &&
+      governanceExceptionStatus(exception, now) === "active",
+  );
+}
+
+export async function loadGovernanceExceptions(
+  isPreview: boolean,
+  workspaceId: string,
+): Promise<GovernanceException[]> {
+  if (isPreview) return [];
+  const rows = await api()
+    .select(FIELDS)
+    .where({ workspace_id: { eq: workspaceId } })
+    .orderBy({ expiresAt: "asc" })
+    .execute();
+  return rows.map(parse);
+}
+
+export async function saveGovernanceException(
+  isPreview: boolean,
+  workspaceId: string,
+  author: { id: string; name: string; email?: string },
+  input: {
+    current?: GovernanceException;
+    findingId: string;
+    reason: string;
+    expiresAt: string;
+  },
+): Promise<GovernanceException> {
+  const findingId = normalizedSubject(input.findingId);
+  const reason = normalizedReason(input.reason);
+  const expiresAt = expiryIso(input.expiresAt, true);
+  const authorEmail =
+    author.email?.trim().toLowerCase() ||
+    (isPreview ? "preview@local.invalid" : "");
+  if (!authorEmail) {
+    throw new Error("An authenticated email is required to save an exception.");
+  }
+  const key = await recordKey(workspaceId, findingId);
+  const now = new Date();
+  const values = {
+    reason,
+    expiresAt: new Date(expiresAt),
+    authorId: author.id,
+    authorName: author.name.trim() || authorEmail,
+    authorEmail,
+    updatedAt: now,
+  };
+  if (isPreview) {
+    return parse({
+      id: input.current?.id ?? crypto.randomUUID(),
+      workspace_id: workspaceId,
+      recordKey: key,
+      writerEmail: authorEmail,
+      findingId,
+      createdAt: input.current?.createdAt ?? now,
+      ...values,
+    });
+  }
+  const existing = input.current ?? (await findExisting(key));
+  if (existing) {
+    await api().update({ id: existing.id }, values);
+    return {
+      id: existing.id,
+      findingId,
+      reason,
+      expiresAt,
+      authorId: values.authorId,
+      authorName: values.authorName,
+      authorEmail,
+      createdAt: new Date(existing.createdAt).toISOString(),
+      updatedAt: now.toISOString(),
+    };
+  }
+  try {
+    return parse(
+      await api().create({
+        id: crypto.randomUUID(),
+        workspace_id: workspaceId,
+        recordKey: key,
+        writerEmail: authorEmail,
+        findingId,
+        createdAt: now,
+        ...values,
+      }),
+    );
+  } catch (error) {
+    const concurrent = await findExisting(key);
+    if (!concurrent) throw error;
+    await api().update({ id: concurrent.id }, values);
+    return parse({ ...concurrent, ...values, findingId });
+  }
+}
+
+export async function deleteGovernanceException(
+  isPreview: boolean,
+  id: string,
+): Promise<void> {
+  if (isPreview) return;
+  await api().delete({ id });
+}

--- a/src/atlas/governance-policy.spec.ts
+++ b/src/atlas/governance-policy.spec.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteGovernancePolicy,
+  loadGovernancePolicy,
+  saveGovernancePolicy,
+  validateGovernanceTargets,
+} from "./governance-policy";
+import { POSTURE_TARGETS } from "./posture";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("@/lib/rayfin-client", () => ({
+  getRayfinClient: () => ({
+    data: {
+      GovernancePolicy: {
+        select: mocks.select,
+        create: mocks.create,
+        update: mocks.update,
+        delete: mocks.delete,
+      },
+    },
+  }),
+}));
+
+describe("governance policy persistence", () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+    const query = {
+      where: mocks.where,
+      orderBy: mocks.orderBy,
+      execute: mocks.execute,
+    };
+    mocks.select.mockReturnValue(query);
+    mocks.where.mockReturnValue(query);
+    mocks.orderBy.mockReturnValue(query);
+    mocks.execute.mockResolvedValue([]);
+    mocks.update.mockResolvedValue(undefined);
+    mocks.delete.mockResolvedValue(undefined);
+  });
+
+  it("uses 70 percent defaults only when no workspace row exists", async () => {
+    await expect(
+      loadGovernancePolicy(false, "workspace-1"),
+    ).resolves.toEqual({
+      targets: POSTURE_TARGETS,
+      source: "default",
+    });
+    expect(mocks.where).toHaveBeenCalledWith({
+      workspace_id: { eq: "workspace-1" },
+    });
+  });
+
+  it("rejects out-of-range and fractional targets", () => {
+    expect(() =>
+      validateGovernanceTargets({ ...POSTURE_TARGETS, access: 101 }),
+    ).toThrow(/0 to 100/);
+    expect(() =>
+      validateGovernanceTargets({ ...POSTURE_TARGETS, access: 70.5 }),
+    ).toThrow(/whole number/);
+  });
+
+  it("creates and updates the single workspace policy", async () => {
+    mocks.create.mockImplementation(async (value) => value);
+    const created = await saveGovernancePolicy(
+      false,
+      "workspace-1",
+      { id: "admin-1", name: "Admin", email: "ADMIN@example.com" },
+      { ...POSTURE_TARGETS, lineage: 85 },
+    );
+
+    expect(created).toMatchObject({
+      source: "persisted",
+      targets: { ...POSTURE_TARGETS, lineage: 85 },
+      updatedByEmail: "admin@example.com",
+    });
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace_id: "workspace-1",
+        writerEmail: "admin@example.com",
+        lineageTarget: 85,
+      }),
+    );
+
+    await saveGovernancePolicy(
+      false,
+      "workspace-1",
+      { id: "admin-1", name: "Admin", email: "admin@example.com" },
+      { ...POSTURE_TARGETS, access: 80 },
+      created,
+    );
+    expect(mocks.update).toHaveBeenCalledWith(
+      { id: created.id },
+      expect.objectContaining({ accessTarget: 80 }),
+    );
+
+    await deleteGovernancePolicy(false, created.id);
+    expect(mocks.delete).toHaveBeenCalledWith({ id: created.id });
+  });
+
+  it("surfaces malformed persisted targets instead of masking them as defaults", async () => {
+    mocks.execute.mockResolvedValue([
+      {
+        id: "policy-1",
+        workspace_id: "workspace-1",
+        recordKey: "workspace-1",
+        writerEmail: "admin@example.com",
+        documentationTarget: 70,
+        ownershipTarget: 70,
+        sensitivityTarget: 70,
+        accessTarget: -1,
+        lineageTarget: 70,
+        operationsTarget: 70,
+        updatedById: "admin-1",
+        updatedByName: "Admin",
+        updatedByEmail: "admin@example.com",
+        updatedAt: "2026-09-05T10:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      loadGovernancePolicy(false, "workspace-1"),
+    ).rejects.toThrow(/0 to 100/);
+  });
+});

--- a/src/atlas/governance-policy.ts
+++ b/src/atlas/governance-policy.ts
@@ -1,0 +1,198 @@
+import { getRayfinClient } from "@/lib/rayfin-client";
+import {
+  POSTURE_PILLARS,
+  POSTURE_TARGETS,
+  type PosturePillar,
+} from "./posture";
+
+export type GovernanceTargets = Record<PosturePillar, number>;
+
+export interface GovernancePolicyRecord {
+  id?: string;
+  targets: GovernanceTargets;
+  source: "default" | "persisted";
+  updatedAt?: string;
+  updatedByName?: string;
+  updatedByEmail?: string;
+}
+
+interface GovernancePolicyRow {
+  id: string;
+  workspace_id: string;
+  recordKey: string;
+  writerEmail: string;
+  documentationTarget: number;
+  ownershipTarget: number;
+  sensitivityTarget: number;
+  accessTarget: number;
+  lineageTarget: number;
+  operationsTarget: number;
+  updatedById: string;
+  updatedByName: string;
+  updatedByEmail: string;
+  updatedAt: string | Date;
+}
+
+const FIELDS = [
+  "id",
+  "workspace_id",
+  "recordKey",
+  "writerEmail",
+  "documentationTarget",
+  "ownershipTarget",
+  "sensitivityTarget",
+  "accessTarget",
+  "lineageTarget",
+  "operationsTarget",
+  "updatedById",
+  "updatedByName",
+  "updatedByEmail",
+  "updatedAt",
+] as const;
+
+function api() {
+  return getRayfinClient().data.GovernancePolicy;
+}
+
+function defaultRecord(): GovernancePolicyRecord {
+  return {
+    targets: { ...POSTURE_TARGETS },
+    source: "default",
+  };
+}
+
+function targetField(pillar: PosturePillar): keyof GovernancePolicyRow {
+  return `${pillar}Target` as keyof GovernancePolicyRow;
+}
+
+export function validateGovernanceTargets(
+  values: Record<PosturePillar, number>,
+): GovernanceTargets {
+  const targets = {} as GovernanceTargets;
+  for (const pillar of POSTURE_PILLARS) {
+    const value = values[pillar];
+    if (!Number.isInteger(value) || value < 0 || value > 100) {
+      throw new Error(
+        `${pillar} governance target must be a whole number from 0 to 100.`,
+      );
+    }
+    targets[pillar] = value;
+  }
+  return targets;
+}
+
+function parse(row: GovernancePolicyRow): GovernancePolicyRecord {
+  const values = Object.fromEntries(
+    POSTURE_PILLARS.map((pillar) => [
+      pillar,
+      Number(row[targetField(pillar)]),
+    ]),
+  ) as GovernanceTargets;
+  return {
+    id: String(row.id),
+    targets: validateGovernanceTargets(values),
+    source: "persisted",
+    updatedAt: new Date(row.updatedAt).toISOString(),
+    updatedByName: String(row.updatedByName),
+    updatedByEmail: String(row.updatedByEmail),
+  };
+}
+
+async function findExisting(
+  workspaceId: string,
+): Promise<GovernancePolicyRow | undefined> {
+  const rows = await api()
+    .select(FIELDS)
+    .where({ workspace_id: { eq: workspaceId } })
+    .orderBy({ updatedAt: "desc" })
+    .execute();
+  if (rows.length > 1) {
+    throw new Error(
+      "Multiple governance policy rows exist for this workspace.",
+    );
+  }
+  return rows[0];
+}
+
+export async function loadGovernancePolicy(
+  isPreview: boolean,
+  workspaceId: string,
+): Promise<GovernancePolicyRecord> {
+  if (isPreview) return defaultRecord();
+  const row = await findExisting(workspaceId);
+  return row ? parse(row) : defaultRecord();
+}
+
+export async function saveGovernancePolicy(
+  isPreview: boolean,
+  workspaceId: string,
+  author: { id: string; name: string; email?: string },
+  targets: GovernanceTargets,
+  current?: GovernancePolicyRecord,
+): Promise<GovernancePolicyRecord> {
+  const validated = validateGovernanceTargets(targets);
+  const authorEmail =
+    author.email?.trim().toLowerCase() ||
+    (isPreview ? "preview@local.invalid" : "");
+  if (!authorEmail) {
+    throw new Error("An authenticated email is required to save governance targets.");
+  }
+  const authorName = author.name.trim() || authorEmail;
+  const now = new Date();
+  const values = {
+    documentationTarget: validated.documentation,
+    ownershipTarget: validated.ownership,
+    sensitivityTarget: validated.sensitivity,
+    accessTarget: validated.access,
+    lineageTarget: validated.lineage,
+    operationsTarget: validated.operations,
+    updatedById: author.id,
+    updatedByName: authorName,
+    updatedByEmail: authorEmail,
+    updatedAt: now,
+  };
+  if (isPreview) {
+    return parse({
+      id: current?.id ?? crypto.randomUUID(),
+      workspace_id: workspaceId,
+      recordKey: workspaceId,
+      writerEmail: authorEmail,
+      ...values,
+    });
+  }
+  const existing = current?.id ? current : await findExisting(workspaceId);
+  if (existing?.id) {
+    await api().update({ id: existing.id }, values);
+    return parse({
+      id: existing.id,
+      workspace_id: workspaceId,
+      recordKey: workspaceId,
+      writerEmail: authorEmail,
+      ...values,
+    });
+  }
+  try {
+    return parse(
+      await api().create({
+        id: crypto.randomUUID(),
+        workspace_id: workspaceId,
+        recordKey: workspaceId,
+        writerEmail: authorEmail,
+        ...values,
+      }),
+    );
+  } catch (error) {
+    const concurrent = await findExisting(workspaceId);
+    if (!concurrent) throw error;
+    await api().update({ id: concurrent.id }, values);
+    return parse({ ...concurrent, ...values });
+  }
+}
+
+export async function deleteGovernancePolicy(
+  isPreview: boolean,
+  id: string | undefined,
+): Promise<void> {
+  if (isPreview || !id) return;
+  await api().delete({ id });
+}

--- a/src/atlas/governance.ts
+++ b/src/atlas/governance.ts
@@ -6,6 +6,7 @@ import type {
   Item,
   Principal,
 } from "./model";
+import { isItemMetadataSchemaEntry } from "./item-metadata";
 import { lineageEdgeKey } from "./lineage";
 import { searchJobId } from "./search";
 
@@ -127,11 +128,13 @@ const SEVERITY_RANK: Record<GovernanceSeverity, number> = {
 const SCHEMA_CAPABLE_ITEM_TYPES = new Set<Item["itemType"]>([
   "Lakehouse",
   "Warehouse",
-  "Eventhouse",
   "KQLDatabase",
   "SQLEndpoint",
   "SQLDatabase",
   "SemanticModel",
+  "Ontology",
+  "GraphModel",
+  "DataAgent",
 ]);
 
 function normalize(value: string | undefined): string {
@@ -744,7 +747,9 @@ export function getCoverageDiagnostics(
   const schemaCapableItems = data.items.filter((item) =>
     SCHEMA_CAPABLE_ITEM_TYPES.has(item.itemType),
   );
-  const tables = data.items.flatMap((item) => schema[item.fabricId] ?? []);
+  const tables = data.items
+    .flatMap((item) => schema[item.fabricId] ?? [])
+    .filter((table) => !isItemMetadataSchemaEntry(table));
   const columns = tables.flatMap((table) => table.columns);
   const measures = tables.flatMap((table) => table.measures);
   const ownerEligible = eligibleItems(

--- a/src/atlas/health-summary.spec.ts
+++ b/src/atlas/health-summary.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { summarizeHealth } from "./health-summary";
+
+describe("summarizeHealth", () => {
+  it("separates health from the proportion of assessed items", () => {
+    expect(summarizeHealth([
+      { health: "healthy" },
+      { health: "healthy" },
+      { health: "unknown" },
+      { health: "unknown" },
+    ])).toMatchObject({
+      healthPercentage: 100,
+      coveragePercentage: 50,
+      assessed: 2,
+      total: 4,
+      unknown: 2,
+    });
+  });
+
+  it("does not assign a healthy or failing score when every status is unknown", () => {
+    expect(summarizeHealth([{ health: "unknown" }])).toMatchObject({
+      healthPercentage: null,
+      coveragePercentage: 0,
+    });
+  });
+
+  it("does not turn an empty workspace into zero health", () => {
+    expect(summarizeHealth([])).toMatchObject({
+      healthPercentage: null,
+      coveragePercentage: null,
+    });
+  });
+
+  it("counts known failing and stale states in the health score", () => {
+    expect(summarizeHealth([
+      { health: "healthy" },
+      { health: "stale" },
+      { health: "failing" },
+      { health: "unknown" },
+    ])).toMatchObject({ healthPercentage: 33, coveragePercentage: 75 });
+  });
+});

--- a/src/atlas/health-summary.ts
+++ b/src/atlas/health-summary.ts
@@ -1,0 +1,19 @@
+import type { Health } from "./model";
+
+export function summarizeHealth(items: readonly { health: Health }[]) {
+  const counts: Record<Health, number> = {
+    healthy: 0,
+    stale: 0,
+    failing: 0,
+    unknown: 0,
+  };
+  for (const item of items) counts[item.health] += 1;
+  const assessed = items.length - counts.unknown;
+  return {
+    ...counts,
+    total: items.length,
+    assessed,
+    healthPercentage: assessed ? Math.round((counts.healthy / assessed) * 100) : null,
+    coveragePercentage: items.length ? Math.round((assessed / items.length) * 100) : null,
+  };
+}

--- a/src/atlas/history.spec.ts
+++ b/src/atlas/history.spec.ts
@@ -9,6 +9,7 @@ import {
   summarizeSnapshot,
   type HistoricalSnapshot,
 } from "./history";
+import { parseOntologyMetadata } from "./item-metadata";
 import type { AtlasData, Item } from "./model";
 
 function item(
@@ -300,6 +301,87 @@ describe("snapshot history", () => {
     ).toMatchObject({
       objectType: "view",
       objectName: "ActiveCustomers",
+    });
+  });
+
+  it("classifies ontology changes with stable object identities", () => {
+    const previous = snapshot(
+      "old",
+      "2026-09-01T10:00:00.000Z",
+      data({
+        items: [item("ontology", { itemType: "Ontology" })],
+        itemMetadata: {
+          ontology: parseOntologyMetadata({
+            entities: [
+              {
+                id: "device",
+                name: "Device",
+                properties: [
+                  { id: "status", name: "Status", valueType: "String" },
+                ],
+              },
+              { id: "site", name: "Site", properties: [] },
+            ],
+            relationships: [],
+            bindings: [],
+            contextualizations: [],
+          })!,
+        },
+      }),
+    );
+    const current = snapshot(
+      "new",
+      "2026-09-02T10:00:00.000Z",
+      data({
+        items: [item("ontology", { itemType: "Ontology" })],
+        itemMetadata: {
+          ontology: parseOntologyMetadata({
+            entities: [
+              {
+                id: "device",
+                name: "Device",
+                properties: [
+                  { id: "status", name: "Status", valueType: "Int64" },
+                ],
+              },
+              { id: "site", name: "Site", properties: [] },
+            ],
+            relationships: [
+              {
+                id: "installed-at",
+                name: "Installed at",
+                sourceEntityId: "device",
+                targetEntityId: "site",
+              },
+            ],
+            bindings: [],
+            contextualizations: [],
+          })!,
+        },
+      }),
+    );
+
+    const changes = compareSnapshots(previous, current);
+    expect(
+      changes.find(
+        (change) =>
+          change.type === "schema-object-modified" &&
+          change.objectName === "Status",
+      ),
+    ).toMatchObject({
+      objectType: "ontologyProperty",
+      objectId: "device/status",
+      tableName: "Device",
+    });
+    expect(
+      changes.find(
+        (change) =>
+          change.type === "schema-object-added" &&
+          change.objectName === "Installed at",
+      ),
+    ).toMatchObject({
+      objectType: "ontologyRelationship",
+      objectId: "installed-at",
     });
   });
 

--- a/src/atlas/history.spec.ts
+++ b/src/atlas/history.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAtlasHistory,
+  changeFieldValue,
   compareSnapshots,
+  readableChangeValue,
+  snapshotDataForInspection,
   snapshotFromData,
   summarizeSnapshot,
   type HistoricalSnapshot,
@@ -53,6 +56,40 @@ function snapshot(
 }
 
 describe("snapshot history", () => {
+  it("keeps full expressions and converts validated snapshots for inspection", () => {
+    const historical = snapshot(
+      "old",
+      "2026-08-28T10:00:00.000Z",
+      data({
+        items: [item("model", { itemType: "SemanticModel" })],
+        schema: {
+          model: [
+            {
+              name: "Measures",
+              columns: [],
+              measures: [
+                {
+                  name: "Revenue",
+                  expr: 'CALCULATE(SUM(Sales[Amount]), Sales[Region] = "<West>")',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    const inspected = snapshotDataForInspection(historical);
+    const expression =
+      inspected.schema!.model[0].measures[0].expr;
+
+    expect(inspected.comments).toEqual([]);
+    expect(inspected.syncRuns).toEqual([]);
+    expect(readableChangeValue(expression)).toContain(
+      'Sales[Region] = "<West>"',
+    );
+    expect(changeFieldValue({ expression }, "expression")).toBe(expression);
+  });
+
   it("reports every supported change domain without treating missing jobs as removals", () => {
     const previous = snapshot(
       "old",

--- a/src/atlas/history.ts
+++ b/src/atlas/history.ts
@@ -112,6 +112,40 @@ export interface AtlasHistory {
 export type ChangeRecord = AtlasChange;
 export type SnapshotChange = AtlasChange;
 
+export function snapshotDataForInspection(
+  snapshot: HistoricalSnapshot,
+): AtlasData {
+  return {
+    ...snapshot.catalog,
+    comments: [],
+    syncRuns: [],
+  };
+}
+
+export function readableChangeValue(value: unknown): string {
+  if (value === undefined) return "Not present";
+  if (value === null || value === "") return "None";
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+export function changeFieldValue(
+  value: unknown,
+  field: string,
+): unknown {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[field];
+}
+
 interface SchemaObject {
   key: string;
   itemFabricId: string;

--- a/src/atlas/history.ts
+++ b/src/atlas/history.ts
@@ -4,10 +4,11 @@ import type {
   Grant,
   Item,
   Job,
-  ModelColumn,
-  ModelMeasure,
-  ModelTableSchema,
 } from "./model";
+import {
+  buildCatalogObjects,
+  type AssetObjectKind,
+} from "./catalog-objects";
 
 export type SnapshotCatalog = Omit<AtlasData, "comments" | "syncRuns">;
 
@@ -91,8 +92,9 @@ export interface AtlasChange {
   syncedAt: string;
   label: string;
   itemFabricId?: string;
-  objectType?: "table" | "view" | "column" | "measure";
+  objectType?: AssetObjectKind;
   objectName?: string;
+  objectId?: string;
   tableName?: string;
   before?: unknown;
   after?: unknown;
@@ -149,8 +151,9 @@ export function changeFieldValue(
 interface SchemaObject {
   key: string;
   itemFabricId: string;
-  objectType: "table" | "view" | "column" | "measure";
+  objectType: AssetObjectKind;
   objectName: string;
+  objectId: string;
   tableName?: string;
   label: string;
   value: Record<string, unknown>;
@@ -309,73 +312,18 @@ function itemValue(item: Item): Record<string, unknown> {
 }
 
 function schemaObjects(catalog: SnapshotCatalog): SchemaObject[] {
-  const result: SchemaObject[] = [];
-  for (const [itemFabricId, tables] of Object.entries(catalog.schema ?? {}).sort(
-    ([left], [right]) => left.localeCompare(right),
-  )) {
-    for (const table of [...tables].sort((left, right) =>
-      left.name.localeCompare(right.name),
-    )) {
-      const tableType =
-        normalizedText(table.objectType) === "view" ? "view" : "table";
-      const tableKey = `${itemFabricId}\u0000${tableType}\u0000${table.name}`;
-      result.push({
-        key: tableKey,
-        itemFabricId,
-        objectType: tableType,
-        objectName: table.name,
-        label: table.name,
-        value: {
-          rows: table.rows,
-          objectType: cleanText(table.objectType),
-          source: cleanText(table.source),
-          description: cleanText(table.description),
-          isHidden: !!table.isHidden,
-        },
-      });
-      for (const column of [...table.columns].sort((left, right) =>
-        left.name.localeCompare(right.name),
-      )) {
-        result.push(
-          schemaChild(itemFabricId, table, "column", column, {
-            dataType: cleanText(column.dataType),
-            description: cleanText(column.description),
-            isHidden: !!column.isHidden,
-          }),
-        );
-      }
-      for (const measure of [...table.measures].sort((left, right) =>
-        left.name.localeCompare(right.name),
-      )) {
-        result.push(
-          schemaChild(itemFabricId, table, "measure", measure, {
-            expression: cleanText(measure.expr),
-            description: cleanText(measure.description),
-            isHidden: !!measure.isHidden,
-          }),
-        );
-      }
-    }
-  }
-  return result;
-}
-
-function schemaChild(
-  itemFabricId: string,
-  table: ModelTableSchema,
-  objectType: "column" | "measure",
-  child: ModelColumn | ModelMeasure,
-  value: Record<string, unknown>,
-): SchemaObject {
-  return {
-    key: `${itemFabricId}\u0000${objectType}\u0000${table.name}\u0000${child.name}`,
-    itemFabricId,
-    objectType,
-    objectName: child.name,
-    tableName: table.name,
-    label: `${table.name}.${child.name}`,
-    value,
-  };
+  return buildCatalogObjects(catalog).map((object) => ({
+    key: object.id,
+    itemFabricId: object.itemFabricId,
+    objectType: object.kind,
+    objectName: object.name,
+    objectId: object.objectId,
+    tableName: object.tableName ?? object.parentName,
+    label: object.parentName
+      ? `${object.parentName}.${object.name}`
+      : object.name,
+    value: object.details,
+  }));
 }
 
 function principalForReference(
@@ -585,6 +533,7 @@ export function compareSnapshots(
           itemFabricId: object.itemFabricId,
           objectType: object.objectType,
           objectName: object.objectName,
+          objectId: object.objectId,
           tableName: object.tableName,
           after: object.value,
         }),
@@ -594,6 +543,7 @@ export function compareSnapshots(
           itemFabricId: object.itemFabricId,
           objectType: object.objectType,
           objectName: object.objectName,
+          objectId: object.objectId,
           tableName: object.tableName,
           before: object.value,
         }),
@@ -605,6 +555,7 @@ export function compareSnapshots(
               itemFabricId: after.itemFabricId,
               objectType: after.objectType,
               objectName: after.objectName,
+              objectId: after.objectId,
               tableName: after.tableName,
               before: before.value,
               after: after.value,
@@ -720,7 +671,7 @@ export function compareSnapshots(
 }
 
 export function summarizeSnapshot(snapshot: HistoricalSnapshot): SnapshotSummary {
-  const schema = Object.values(snapshot.catalog.schema ?? {}).flat();
+  const objects = buildCatalogObjects(snapshot.catalog);
   const items = snapshot.catalog.items.length;
   const lineage = snapshot.catalog.edges.length;
   const healthy = snapshot.catalog.items.filter(
@@ -746,15 +697,22 @@ export function summarizeSnapshot(snapshot: HistoricalSnapshot): SnapshotSummary
     (job) => job.status === "failed",
   ).length;
   const brokenEdges = snapshot.catalog.edges.filter((edge) => edge.broken).length;
-  const tables = schema.length;
-  const columns = schema.reduce(
-    (count, table) => count + table.columns.length,
-    0,
-  );
-  const measures = schema.reduce(
-    (count, table) => count + table.measures.length,
-    0,
-  );
+  const tables = objects.filter((object) =>
+    [
+      "table",
+      "view",
+      "sqlTable",
+      "sqlView",
+      "kqlTable",
+      "kqlMaterializedView",
+    ].includes(object.kind),
+  ).length;
+  const columns = objects.filter((object) =>
+    ["column", "sqlColumn", "kqlColumn"].includes(object.kind),
+  ).length;
+  const measures = objects.filter(
+    (object) => object.kind === "measure",
+  ).length;
   return {
     snapshotId: snapshot.snapshotId,
     syncedAt: snapshot.syncedAt,
@@ -811,6 +769,24 @@ export function snapshotCatalogFromData(data: AtlasData): SnapshotCatalog {
         })),
       ]),
     ),
+    itemMetadata: data.itemMetadata
+      ? structuredClone(data.itemMetadata)
+      : undefined,
+    objectEdges: data.objectEdges?.map((edge) => ({
+      ...edge,
+      source: {
+        ...edge.source,
+        parentPath: edge.source.parentPath
+          ? [...edge.source.parentPath]
+          : undefined,
+      },
+      target: {
+        ...edge.target,
+        parentPath: edge.target.parentPath
+          ? [...edge.target.parentPath]
+          : undefined,
+      },
+    })),
   };
 }
 

--- a/src/atlas/item-metadata.spec.ts
+++ b/src/atlas/item-metadata.spec.ts
@@ -1,0 +1,944 @@
+import { describe, expect, it } from "vitest";
+import {
+  ITEM_METADATA_SCHEMA_NAME,
+  MAX_DATA_AGENT_ELEMENTS,
+  MAX_OBJECT_LINEAGE_EDGES,
+  METADATA_OBJECT_TYPES,
+  OPTIONAL_METADATA_SYNC_SECTIONS,
+  isItemMetadataSchemaEntry,
+  itemMetadataFor,
+  itemMetadataFromSchema,
+  metadataItemLineageEdges,
+  metadataObjectLineageEdges,
+  metadataSchemaEntry,
+  projectItemMetadataToSchema,
+  parseDataAgentMetadata,
+  parseGraphModelMetadata,
+  parseKqlDatabaseMetadata,
+  parseObjectLineagePayload,
+  parseOntologyMetadata,
+} from "./item-metadata";
+import type { ModelTableSchema } from "./model";
+
+describe("ontology metadata", () => {
+  it("keeps entities, relationships, and source bindings", () => {
+    const metadata = parseOntologyMetadata({
+      entityTypes: [
+        {
+          id: "customer",
+          name: "Customer",
+          entityIdParts: ["customer-id"],
+          properties: [
+            { id: "customer-id", name: "Customer ID", valueType: "String" },
+          ],
+          timeSeriesProperties: [
+            { id: "seen-at", name: "Seen at", valueType: "DateTime" },
+          ],
+        },
+        {
+          id: "order",
+          name: "Order",
+          properties: [
+            { id: "order-id", name: "Order ID", valueType: "String" },
+          ],
+        },
+      ],
+      relationshipTypes: [
+        {
+          id: "places",
+          name: "places",
+          source: { entityTypeId: "customer" },
+          target: { entityTypeId: "order" },
+          contextualizations: [
+            {
+              id: "places-binding",
+              dataBindingTable: {
+                workspaceId: "workspace",
+                itemId: "lakehouse",
+                sourceType: "LakehouseTable",
+                sourceSchema: "dbo",
+                sourceTableName: "Orders",
+              },
+              sourceKeyRefBindings: [
+                {
+                  sourceColumnName: "CustomerId",
+                  targetPropertyId: "customer-id",
+                },
+              ],
+              targetKeyRefBindings: [
+                {
+                  sourceColumnName: "OrderId",
+                  targetPropertyId: "order-id",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      dataBindings: [
+        {
+          id: "customer-binding",
+          entityId: "customer",
+          dataBindingConfiguration: {
+            dataBindingType: "NonTimeSeries",
+            sourceTableProperties: {
+              sourceType: "LakehouseTable",
+              workspaceId: "workspace",
+              itemId: "lakehouse",
+              sourceSchema: "dbo",
+              sourceTableName: "Customers",
+            },
+            propertyBindings: [
+              {
+                sourceColumnName: "CustomerId",
+                targetPropertyId: "customer-id",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(metadata).toMatchObject({
+      kind: "ontology",
+      entities: [
+        {
+          id: "customer",
+          keyPropertyIds: ["customer-id"],
+          properties: [
+            { id: "customer-id", timeSeries: false },
+            { id: "seen-at", timeSeries: true },
+          ],
+        },
+        { id: "order" },
+      ],
+      relationships: [
+        {
+          id: "places",
+          sourceEntityId: "customer",
+          targetEntityId: "order",
+        },
+      ],
+      bindings: [
+        {
+          entityId: "customer",
+          sourceItemId: "lakehouse",
+          sourceObject: "Customers",
+          propertyBindings: [
+            {
+              sourceColumn: "CustomerId",
+              targetPropertyId: "customer-id",
+            },
+          ],
+        },
+      ],
+      contextualizations: [
+        {
+          id: "places-binding",
+          relationshipId: "places",
+          sourceItemId: "lakehouse",
+          sourceObject: "Orders",
+          sourceKeyBindings: [
+            {
+              sourceColumn: "CustomerId",
+              targetPropertyId: "customer-id",
+            },
+          ],
+          targetKeyBindings: [
+            {
+              sourceColumn: "OrderId",
+              targetPropertyId: "order-id",
+            },
+          ],
+        },
+      ],
+    });
+    expect(metadataObjectLineageEdges("ontology", metadata!)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            itemId: "lakehouse",
+            id: "dbo.Orders.CustomerId",
+          }),
+          target: expect.objectContaining({
+            itemId: "ontology",
+            id: "customer-id",
+            parentId: "customer",
+          }),
+          relation: "binds source key",
+          confidence: "verified",
+        }),
+        expect.objectContaining({
+          source: expect.objectContaining({
+            id: "places",
+            kind: "ontologyRelationship",
+          }),
+          target: expect.objectContaining({
+            id: "order",
+            kind: "ontologyEntity",
+          }),
+          relation: "relationship target",
+          confidence: "verified",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects raw definition payloads and duplicate identifiers", () => {
+    expect(
+      parseOntologyMetadata({
+        entities: [],
+        relationships: [],
+        bindings: [],
+        payload: "base64-definition",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseOntologyMetadata({
+        entities: [
+          { id: "duplicate", name: "One", properties: [] },
+          { id: "duplicate", name: "Two", properties: [] },
+        ],
+        relationships: [],
+        bindings: [],
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("graph model metadata", () => {
+  it("parses graph types and mappings without retaining filter values", () => {
+    const metadata = parseGraphModelMetadata({
+      graphType: {
+        nodeTypes: [
+          {
+            alias: "Customer",
+            labels: ["Customer"],
+            primaryKeyProperties: ["CustomerId"],
+            properties: [{ name: "CustomerId", type: "STRING" }],
+          },
+          {
+            alias: "Product",
+            labels: ["Product"],
+            primaryKeyProperties: ["ProductId"],
+            properties: [{ name: "ProductId", type: "STRING" }],
+          },
+        ],
+        edgeTypes: [
+          {
+            alias: "Purchased",
+            labels: ["PURCHASED"],
+            sourceNodeType: { alias: "Customer" },
+            destinationNodeType: { alias: "Product" },
+            properties: [{ name: "Quantity", type: "INT" }],
+          },
+        ],
+      },
+      dataSources: [
+        {
+          name: "CustomerTable",
+          itemId: "lakehouse",
+          tableName: "Customers",
+          type: "DeltaTable",
+        },
+        {
+          name: "Orders",
+          itemId: "lakehouse",
+          tableName: "Orders",
+          type: "DeltaTable",
+        },
+      ],
+      graphDefinition: {
+        nodeTables: [
+          {
+            id: "customer-map",
+            nodeTypeAlias: "Customer",
+            dataSourceName: "CustomerTable",
+            propertyMappings: [
+              {
+                propertyName: "CustomerId",
+                sourceColumn: "customer_id",
+              },
+            ],
+          },
+        ],
+        edgeTables: [
+          {
+            id: "purchase-map",
+            edgeTypeAlias: "Purchased",
+            dataSourceName: "Orders",
+            sourceNodeKeyColumns: ["customer_id"],
+            destinationNodeKeyColumns: ["product_id"],
+            propertyMappings: [],
+          },
+        ],
+      },
+    });
+
+    expect(metadata).toMatchObject({
+      kind: "graphModel",
+      dataSources: [
+        {
+          name: "CustomerTable",
+          sourceItemId: "lakehouse",
+          sourceObject: "Customers",
+        },
+        {
+          name: "Orders",
+          sourceItemId: "lakehouse",
+          sourceObject: "Orders",
+        },
+      ],
+      edgeTypes: [
+        {
+          alias: "Purchased",
+          sourceNodeType: "Customer",
+          destinationNodeType: "Product",
+        },
+      ],
+      mappings: [
+        {
+          kind: "node",
+          typeAlias: "Customer",
+          sourceItemId: "lakehouse",
+          sourceObject: "Customers",
+        },
+        {
+          kind: "edge",
+          typeAlias: "Purchased",
+          sourceItemId: "lakehouse",
+          sourceObject: "Orders",
+        },
+      ],
+    });
+    expect(metadata?.nodeTypes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ alias: "Customer" }),
+        expect.objectContaining({ alias: "Product" }),
+      ]),
+    );
+  });
+
+  it("rejects graph filters because they may contain business values", () => {
+    expect(
+      parseGraphModelMetadata({
+        nodeTypes: [],
+        edgeTypes: [],
+        nodeTables: [
+          {
+            nodeTypeAlias: "Customer",
+            dataSourceName: "Customers",
+            propertyMappings: [],
+            filter: { columnName: "Region", value: "North" },
+          },
+        ],
+        edgeTables: [],
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("data agent metadata", () => {
+  it("returns only selected source elements and preserves hierarchy", () => {
+    const metadata = parseDataAgentMetadata({
+      sources: [
+        {
+          artifactId: "warehouse",
+          workspaceId: "workspace",
+          displayName: "Sales Warehouse",
+          type: "data_warehouse",
+          elements: [
+            {
+              id: "dbo",
+              display_name: "dbo",
+              type: "warehouse_tables.schema",
+              is_selected: true,
+              children: [
+                {
+                  id: "sales",
+                  display_name: "Sales",
+                  type: "warehouse_tables.table",
+                  is_selected: true,
+                  children: [
+                    {
+                      id: "amount",
+                      display_name: "Amount",
+                      type: "warehouse_tables.column",
+                      data_type: "decimal",
+                      is_selected: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(metadata?.sources[0].selectedElements).toEqual([
+      {
+        id: "sales",
+        displayName: "Sales",
+        elementType: "warehouse_tables.table",
+        sourceArtifactId: "warehouse",
+        dataType: undefined,
+        parentId: "dbo",
+        parentName: "dbo",
+        parentPath: ["dbo"],
+        state: undefined,
+        indexState: undefined,
+      },
+      {
+        id: "amount",
+        displayName: "Amount",
+        elementType: "warehouse_tables.column",
+        sourceArtifactId: "warehouse",
+        dataType: "decimal",
+        parentId: "sales",
+        parentName: "Sales",
+        parentPath: ["dbo", "Sales"],
+        state: undefined,
+        indexState: undefined,
+      },
+    ]);
+    expect(metadata?.sources[0].elements).toMatchObject([
+      {
+        id: "sales",
+        selected: true,
+        sourceArtifactId: "warehouse",
+        parentId: "dbo",
+        parentName: "dbo",
+        parentPath: ["dbo"],
+        children: [
+          {
+            id: "amount",
+            selected: true,
+            sourceArtifactId: "warehouse",
+            parentId: "sales",
+            parentName: "Sales",
+            parentPath: ["dbo", "Sales"],
+          },
+        ],
+      },
+    ]);
+    expect(
+      itemMetadataFromSchema("DataAgent", [
+        metadataSchemaEntry(metadata!),
+      ]),
+    ).toEqual(metadata);
+    const objectEdges = metadataObjectLineageEdges("agent", metadata!);
+    expect(
+      objectEdges.some(
+        (edge) =>
+          edge.source.id === "dbo" ||
+          edge.target.id === "warehouse:dbo",
+      ),
+    ).toBe(false);
+    expect(
+      objectEdges.filter((edge) => edge.relation === "selected by agent"),
+    ).toHaveLength(2);
+  });
+
+  it("rejects agent instructions, few shots, and unbounded element trees", () => {
+    expect(
+      parseDataAgentMetadata({
+        sources: [],
+        aiInstructions: "Answer using private sales details.",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseDataAgentMetadata({
+        sources: [],
+        fewShots: [{ question: "Revenue?", query: "select * from Sales" }],
+      }),
+    ).toBeUndefined();
+    expect(
+      parseDataAgentMetadata({
+        sources: [
+          {
+            artifactId: "warehouse",
+            displayName: "Warehouse",
+            type: "data_warehouse",
+            elements: Array.from(            { length: MAX_DATA_AGENT_ELEMENTS + 1 }, (_, index) => ({
+              id: String(index),
+              displayName: String(index),
+              type: "Table",
+              isSelected: true,
+            })),
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("qualifies repeated field identifiers by their parent path", () => {
+    const metadata = parseDataAgentMetadata({
+      sources: [
+        {
+          artifactId: "kql",
+          displayName: "Telemetry",
+          type: "kusto",
+          elements: [
+            {
+              id: "table-a",
+              display_name: "TableA",
+              type: "kusto.table",
+              is_selected: true,
+              children: [
+                {
+                  id: "Timestamp",
+                  display_name: "Timestamp",
+                  type: "kusto.column",
+                  is_selected: true,
+                },
+              ],
+            },
+            {
+              id: "table-b",
+              display_name: "TableB",
+              type: "kusto.table",
+              is_selected: true,
+              children: [
+                {
+                  id: "Timestamp",
+                  display_name: "Timestamp",
+                  type: "kusto.column",
+                  is_selected: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(metadata).toBeDefined();
+    const timestampEdges = metadataObjectLineageEdges(
+      "agent",
+      metadata!,
+    ).filter(
+      (edge) =>
+        edge.relation === "selected by agent" &&
+        edge.source.name === "Timestamp",
+    );
+    expect(timestampEdges).toHaveLength(2);
+    expect(new Set(timestampEdges.map((edge) => edge.source.id)).size).toBe(2);
+  });
+});
+
+describe("KQL metadata", () => {
+  it("keeps function signatures and materialized-view schemas", () => {
+    expect(
+      parseKqlDatabaseMetadata({
+        functions: [
+          {
+            name: "StationHourlyLoad",
+            folder: "Telemetry",
+            parameters: [{ name: "stationId", type: "string" }],
+            returnType: "table",
+          },
+        ],
+        materializedViews: [
+          {
+            name: "HourlyLoad",
+            sourceTable: "StationTelemetry",
+            columns: [{ name: "Count", dataType: "long" }],
+          },
+        ],
+      }),
+    ).toMatchObject({
+      kind: "kql",
+      functions: [{ name: "StationHourlyLoad" }],
+      materializedViews: [{ name: "HourlyLoad" }],
+    });
+  });
+
+  it("rejects KQL bodies, query text, and raw result rows", () => {
+    expect(
+      parseKqlDatabaseMetadata({
+        functions: [
+          {
+            name: "Unsafe",
+            parameters: [],
+            body: "Sales | take 10",
+          },
+        ],
+        materializedViews: [],
+      }),
+    ).toBeUndefined();
+    expect(
+      parseKqlDatabaseMetadata({
+        functions: [],
+        materializedViews: [],
+        rows: [{ customer: "Ada" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("derives KQL metadata from existing schema rows", () => {
+    const schema: ModelTableSchema[] = [
+      {
+        name: "StationHourlyLoad",
+        objectType: "Function",
+        columns: [{ name: "stationId", dataType: "string" }],
+        measures: [],
+      },
+      {
+        name: "HourlyLoad",
+        objectType: "Materialized view",
+        columns: [{ name: "Count", dataType: "long" }],
+        measures: [],
+      },
+    ];
+
+    expect(itemMetadataFromSchema("KQLDatabase", schema)).toMatchObject({
+      kind: "kql",
+      functions: [{ name: "StationHourlyLoad" }],
+      materializedViews: [{ name: "HourlyLoad" }],
+    });
+  });
+});
+
+describe("schema metadata envelope", () => {
+  it("round-trips through the optional schema extension and old snapshots", () => {
+    const metadata = parseKqlDatabaseMetadata({
+      functions: [{ name: "Health", parameters: [] }],
+      materializedViews: [],
+    })!;
+    const schema = [metadataSchemaEntry(metadata)];
+
+    expect(schema[0]).toMatchObject({
+      name: ITEM_METADATA_SCHEMA_NAME,
+      objectType: "Atlas item metadata",
+      isHidden: true,
+      description: JSON.stringify(metadata),
+    });
+    expect(isItemMetadataSchemaEntry(schema[0])).toBe(true);
+    expect(
+      isItemMetadataSchemaEntry({
+        name: "StationHourlyLoad",
+      }),
+    ).toBe(false);
+    expect(itemMetadataFromSchema("KQLDatabase", schema)).toEqual(metadata);
+    expect(
+      itemMetadataFromSchema("KQLDatabase", [
+        { ...schema[0], metadata: undefined },
+      ]),
+    ).toEqual(metadata);
+    expect(
+      itemMetadataFor(
+        { schema: { database: schema } },
+        "database",
+        "KQLDatabase",
+      ),
+    ).toEqual(metadata);
+    expect(
+      itemMetadataFromSchema("Ontology", [
+        { name: "Legacy", columns: [], measures: [] },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("projects safe metadata into canonical schema object types", () => {
+    const ontology = parseOntologyMetadata({
+      entities: [
+        {
+          id: "customer",
+          name: "Customer",
+          properties: [],
+        },
+        {
+          id: "asset",
+          name: "Asset",
+          properties: [
+            { id: "asset-id", name: "Asset ID", valueType: "String" },
+          ],
+        },
+      ],
+      relationships: [
+        {
+          name: "owns",
+          id: "owns",
+          sourceEntityId: "customer",
+          targetEntityId: "asset",
+        },
+      ],
+      bindings: [],
+    })!;
+
+    expect(projectItemMetadataToSchema(ontology)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Asset",
+          objectType: METADATA_OBJECT_TYPES.ontologyEntity,
+        }),
+        expect.objectContaining({
+          name: "owns",
+          objectType: METADATA_OBJECT_TYPES.ontologyRelationship,
+        }),
+        expect.objectContaining({ name: ITEM_METADATA_SCHEMA_NAME }),
+      ]),
+    );
+    expect(OPTIONAL_METADATA_SYNC_SECTIONS).toEqual([
+      "kqlSchema",
+      "sqlSchema",
+      "definitions",
+    ]);
+  });
+});
+
+describe("metadata lineage", () => {
+  it("emits only declared source item edges", () => {
+    const ontology = parseOntologyMetadata({
+      entities: [
+        {
+          id: "customer",
+          name: "Customer",
+          properties: [
+            { id: "customer-id", name: "CustomerId", valueType: "String" },
+          ],
+        },
+      ],
+      relationships: [],
+      bindings: [
+        {
+          id: "customer-binding",
+          entityId: "customer",
+          sourceItemId: "lakehouse",
+          sourceObject: "Customers",
+          propertyBindings: [
+            {
+              sourceColumn: "customer_id",
+              targetPropertyId: "customer-id",
+            },
+          ],
+        },
+      ],
+      contextualizations: [],
+    })!;
+
+    expect(metadataItemLineageEdges("ontology", ontology)).toEqual([
+      {
+        source: "lakehouse",
+        target: "ontology",
+        relation: "binds ontology",
+      },
+    ]);
+    expect(metadataObjectLineageEdges("ontology", ontology)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            itemId: "lakehouse",
+            id: "Customers.customer_id",
+          }),
+          target: expect.objectContaining({
+            itemId: "ontology",
+            id: "customer-id",
+            parentId: "customer",
+          }),
+          relation: "binds property",
+          confidence: "verified",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps graph mapping and Data Agent element IDs in lineage edges", () => {
+    const graph = parseGraphModelMetadata({
+      dataSources: [
+        {
+          name: "Customers",
+          sourceItemId: "lakehouse",
+          sourceObject: "dbo.Customers",
+        },
+      ],
+      nodeTypes: [
+        {
+          alias: "Customer",
+          labels: ["Customer"],
+          primaryKeyProperties: ["CustomerId"],
+          properties: [{ name: "CustomerId", type: "STRING" }],
+        },
+      ],
+      edgeTypes: [],
+      nodeTables: [
+        {
+          id: "customer-map",
+          nodeTypeAlias: "Customer",
+          dataSourceName: "Customers",
+          propertyMappings: [
+            {
+              propertyName: "CustomerId",
+              sourceColumn: "customer_id",
+            },
+          ],
+        },
+      ],
+      edgeTables: [],
+    })!;
+    expect(metadataItemLineageEdges("graph", graph)).toEqual([
+      {
+        source: "lakehouse",
+        target: "graph",
+        relation: "maps graph",
+      },
+    ]);
+    expect(metadataObjectLineageEdges("graph", graph)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            id: "dbo.Customers.customer_id",
+          }),
+          target: expect.objectContaining({
+            id: "Customer.CustomerId",
+            parentId: "Customer",
+          }),
+        }),
+      ]),
+    );
+
+    const agent = parseDataAgentMetadata({
+      sources: [
+        {
+          artifactId: "graph",
+          displayName: "Customer Graph",
+          type: "graph",
+          elements: [
+            {
+              id: "customer-node",
+              displayName: "Customer",
+              type: "graph.nodeType",
+              isSelected: true,
+            },
+          ],
+        },
+      ],
+    })!;
+    expect(metadataItemLineageEdges("agent", agent)).toEqual([
+      { source: "graph", target: "agent", relation: "grounds" },
+    ]);
+    expect(metadataObjectLineageEdges("agent", agent)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            itemId: "graph",
+            id: "graph.nodeType:customer-node",
+            kind: "sourceElement",
+            parentPath: [],
+          }),
+          target: expect.objectContaining({
+            itemId: "agent",
+            id: "graph:graph.nodeType:customer-node",
+          }),
+          relation: "selected by agent",
+          confidence: "verified",
+        }),
+      ]),
+    );
+  });
+
+  it("accepts bounded verified object-edge payloads under either field name", () => {
+    const edge = {
+      source: {
+        itemId: "lakehouse",
+        kind: "sourceField",
+        id: "dbo.Customers.customer_id",
+        name: "customer_id",
+        parentId: "dbo.Customers",
+        tableName: "Customers",
+      },
+      target: {
+        itemId: "ontology",
+        kind: "ontologyProperty",
+        id: "customer-id",
+        name: "CustomerId",
+        parentId: "customer",
+        tableName: "Customer",
+      },
+      relation: "binds property",
+      confidence: "verified",
+    };
+
+    expect(parseObjectLineagePayload({ objectEdges: [edge] })).toEqual({
+      objectEdges: [edge],
+    });
+    expect(
+      parseObjectLineagePayload({ objectLineage: { edges: [edge] } }),
+    ).toEqual({ objectEdges: [edge] });
+  });
+
+  it("normalizes UDF object-kind aliases", () => {
+    expect(
+      parseObjectLineagePayload({
+        objectEdges: [
+          {
+            source: {
+              itemId: "source",
+              kind: "column",
+              id: "source-column",
+              name: "CustomerId",
+              tableName: "Customers",
+            },
+            target: {
+              itemId: "ontology",
+              kind: "property",
+              id: "ontology-property",
+              name: "Customer ID",
+              tableName: "Customer",
+            },
+            relation: "binds property",
+            confidence: "verified",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      objectEdges: [
+        {
+          source: { kind: "sourceField" },
+          target: { kind: "ontologyProperty" },
+        },
+      ],
+    });
+  });
+
+  it("rejects inferred, malformed, and unbounded object-edge payloads", () => {
+    const inferred = {
+      source: {
+        itemId: "source",
+        kind: "sourceObject",
+        id: "dbo.Source",
+        name: "Source",
+      },
+      target: {
+        itemId: "target",
+        kind: "ontologyEntity",
+        id: "entity-id",
+        name: "Entity",
+      },
+      relation: "guessed from a name",
+      confidence: "inferred",
+    };
+
+    expect(parseObjectLineagePayload({ objectEdges: [inferred] })).toBeUndefined();
+    expect(
+      parseObjectLineagePayload({
+        objectEdges: Array.from(
+          { length: MAX_OBJECT_LINEAGE_EDGES + 1 },
+          () => inferred,
+        ),
+      }),
+    ).toBeUndefined();
+    expect(
+      parseObjectLineagePayload({
+        objectEdges: [
+          {
+            ...inferred,
+            confidence: "verified",
+            source: { ...inferred.source, id: "" },
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/atlas/item-metadata.ts
+++ b/src/atlas/item-metadata.ts
@@ -1,0 +1,2279 @@
+import type { AtlasData, Edge, ItemType, ModelTableSchema } from "./model";
+
+export const ITEM_METADATA_SCHEMA_NAME = "__atlas_item_metadata_v1__";
+
+export const OPTIONAL_METADATA_SYNC_SECTIONS = [
+  "kqlSchema",
+  "sqlSchema",
+  "definitions",
+] as const;
+
+export const METADATA_OBJECT_TYPES = {
+  kqlTable: "KQL table",
+  kqlFunction: "KQL function",
+  kqlMaterializedView: "KQL materialized view",
+  sqlTable: "SQL table",
+  sqlView: "SQL view",
+  ontologyEntity: "Ontology entity",
+  ontologyRelationship: "Ontology relationship",
+  graphNode: "Graph node",
+  graphEdge: "Graph edge",
+  dataAgentSource: "Data Agent source",
+} as const;
+
+export const DATA_AGENT_LINEAGE_ELEMENT_TYPES = [
+  "lakehouse_tables.table",
+  "lakehouse_tables.column",
+  "warehouse_tables.table",
+  "warehouse_tables.column",
+  "semantic_model.table",
+  "semantic_model.column",
+  "semantic_model.measure",
+  "kusto.table",
+  "kusto.column",
+  "kusto.function",
+  "kusto.materializedview",
+  "ontology.entity",
+  "graph.nodetype",
+  "graph.edgetype",
+] as const;
+
+export type OptionalMetadataSyncSection =
+  (typeof OPTIONAL_METADATA_SYNC_SECTIONS)[number];
+
+export type MetadataObjectType =
+  (typeof METADATA_OBJECT_TYPES)[keyof typeof METADATA_OBJECT_TYPES];
+
+export interface OntologyPropertyMetadata {
+  id: string;
+  name: string;
+  valueType: string;
+  timeSeries: boolean;
+}
+
+export interface OntologyEntityMetadata {
+  id: string;
+  name: string;
+  namespace?: string;
+  keyPropertyIds: string[];
+  displayNamePropertyId?: string;
+  properties: OntologyPropertyMetadata[];
+}
+
+export interface OntologyRelationshipMetadata {
+  id: string;
+  name: string;
+  sourceEntityId: string;
+  targetEntityId: string;
+}
+
+export interface OntologyPropertyBindingMetadata {
+  sourceColumn: string;
+  targetPropertyId: string;
+}
+
+export interface OntologyBindingMetadata {
+  id: string;
+  entityId: string;
+  bindingType: string;
+  sourceItemId: string;
+  sourceWorkspaceId?: string;
+  sourceType?: string;
+  sourceSchema?: string;
+  sourceObject: string;
+  sourceObjectId?: string;
+  timestampColumn?: string;
+  propertyBindings: OntologyPropertyBindingMetadata[];
+}
+
+export interface OntologyContextualizationMetadata {
+  id: string;
+  relationshipId: string;
+  sourceItemId: string;
+  sourceWorkspaceId?: string;
+  sourceType?: string;
+  sourceSchema?: string;
+  sourceObject: string;
+  sourceObjectId?: string;
+  sourceKeyBindings: OntologyPropertyBindingMetadata[];
+  targetKeyBindings: OntologyPropertyBindingMetadata[];
+}
+
+export interface OntologyMetadata {
+  kind: "ontology";
+  entities: OntologyEntityMetadata[];
+  relationships: OntologyRelationshipMetadata[];
+  bindings: OntologyBindingMetadata[];
+  contextualizations: OntologyContextualizationMetadata[];
+}
+
+export interface GraphPropertyMetadata {
+  name: string;
+  dataType: string;
+}
+
+export interface GraphNodeTypeMetadata {
+  alias: string;
+  labels: string[];
+  primaryKeyProperties: string[];
+  properties: GraphPropertyMetadata[];
+}
+
+export interface GraphEdgeTypeMetadata {
+  alias: string;
+  labels: string[];
+  sourceNodeType: string;
+  destinationNodeType: string;
+  properties: GraphPropertyMetadata[];
+}
+
+export interface GraphPropertyMappingMetadata {
+  propertyName: string;
+  sourceColumn: string;
+}
+
+export interface GraphDataSourceMetadata {
+  name: string;
+  sourceItemId: string;
+  sourceWorkspaceId?: string;
+  sourceObject: string;
+  sourceObjectId?: string;
+  sourceType?: string;
+}
+
+export interface GraphMappingMetadata {
+  id: string;
+  kind: "node" | "edge";
+  typeAlias: string;
+  dataSourceName: string;
+  sourceItemId: string;
+  sourceWorkspaceId?: string;
+  sourceObject: string;
+  sourceObjectId?: string;
+  propertyMappings: GraphPropertyMappingMetadata[];
+  sourceNodeKeyColumns?: string[];
+  destinationNodeKeyColumns?: string[];
+}
+
+type ParsedGraphMappingMetadata = Omit<
+  GraphMappingMetadata,
+  "sourceItemId" | "sourceObject"
+> & {
+  sourceItemId?: string;
+  sourceObject?: string;
+};
+
+function isCompleteGraphMapping(
+  mapping: ParsedGraphMappingMetadata,
+): mapping is GraphMappingMetadata {
+  return !!mapping.sourceItemId && !!mapping.sourceObject;
+}
+
+export interface GraphModelMetadata {
+  kind: "graphModel";
+  dataSources: GraphDataSourceMetadata[];
+  nodeTypes: GraphNodeTypeMetadata[];
+  edgeTypes: GraphEdgeTypeMetadata[];
+  mappings: GraphMappingMetadata[];
+}
+
+export interface DataAgentElementMetadata {
+  id: string;
+  displayName: string;
+  elementType: string;
+  selected: boolean;
+  sourceArtifactId: string;
+  dataType?: string;
+  parentId?: string;
+  parentName?: string;
+  parentPath: string[];
+  state?: string;
+  indexState?: string;
+  children: DataAgentElementMetadata[];
+}
+
+export interface DataAgentSelectedElementMetadata {
+  id: string;
+  displayName: string;
+  elementType: string;
+  sourceArtifactId: string;
+  dataType?: string;
+  parentId?: string;
+  parentName?: string;
+  parentPath: string[];
+  state?: string;
+  indexState?: string;
+}
+
+export interface DataAgentSourceMetadata {
+  artifactId: string;
+  workspaceId?: string;
+  displayName: string;
+  sourceType: string;
+  elements: DataAgentElementMetadata[];
+  selectedElements: DataAgentSelectedElementMetadata[];
+}
+
+export interface DataAgentMetadata {
+  kind: "dataAgent";
+  sources: DataAgentSourceMetadata[];
+}
+
+export interface KqlFunctionParameterMetadata {
+  name: string;
+  dataType: string;
+}
+
+export interface KqlFunctionMetadata {
+  name: string;
+  folder?: string;
+  description?: string;
+  parameters: KqlFunctionParameterMetadata[];
+  returnType?: string;
+}
+
+export interface KqlColumnMetadata {
+  name: string;
+  dataType: string;
+}
+
+export interface KqlMaterializedViewMetadata {
+  name: string;
+  sourceTable?: string;
+  description?: string;
+  columns: KqlColumnMetadata[];
+}
+
+export interface KqlDatabaseMetadata {
+  kind: "kql";
+  functions: KqlFunctionMetadata[];
+  materializedViews: KqlMaterializedViewMetadata[];
+}
+
+export type FabricItemMetadata =
+  | OntologyMetadata
+  | GraphModelMetadata
+  | DataAgentMetadata
+  | KqlDatabaseMetadata;
+
+export type MetadataObjectKind =
+  | "sourceObject"
+  | "sourceField"
+  | "sourceElement"
+  | "ontologyEntity"
+  | "ontologyProperty"
+  | "ontologyRelationship"
+  | "ontologyContextualization"
+  | "graphNode"
+  | "graphEdge"
+  | "graphProperty"
+  | "dataAgentSource"
+  | "dataAgentElement"
+  | "kqlFunction"
+  | "kqlMaterializedView";
+
+export interface MetadataObjectRef {
+  itemId: string;
+  kind: MetadataObjectKind;
+  id: string;
+  name: string;
+  parentId?: string;
+  parentPath?: string[];
+  tableName?: string;
+}
+
+export interface MetadataObjectLineageEdge {
+  source: MetadataObjectRef;
+  target: MetadataObjectRef;
+  relation: string;
+  confidence: "verified";
+}
+
+export interface ObjectLineagePayload {
+  objectEdges: MetadataObjectLineageEdge[];
+}
+
+const MAX_NAME_LENGTH = 256;
+const MAX_DESCRIPTION_LENGTH = 512;
+const MAX_COLLECTION_SIZE = 512;
+export const MAX_DATA_AGENT_ELEMENTS = 2_048;
+const MAX_NESTING_DEPTH = 16;
+const MAX_VISITED_VALUES = 10_000;
+const MAX_SERIALIZED_METADATA_LENGTH = 1_000_000;
+export const MAX_OBJECT_LINEAGE_EDGES = 1_000;
+
+const FORBIDDEN_CONTENT_KEYS = new Set([
+  "aiinstructions",
+  "body",
+  "content",
+  "data",
+  "datasourceinstructions",
+  "definition",
+  "expression",
+  "fewshots",
+  "filter",
+  "filters",
+  "instances",
+  "payload",
+  "prompt",
+  "prompts",
+  "queries",
+  "query",
+  "question",
+  "questions",
+  "records",
+  "rows",
+  "sampledata",
+  "script",
+  "values",
+]);
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizedKey(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function containsUnsafeContent(value: unknown): boolean {
+  const ancestors = new WeakSet<object>();
+  let visited = 0;
+
+  const walk = (candidate: unknown, depth: number): boolean => {
+    visited += 1;
+    if (visited > MAX_VISITED_VALUES || depth > MAX_NESTING_DEPTH) return true;
+    if (!candidate || typeof candidate !== "object") return false;
+    if (ancestors.has(candidate)) return true;
+    ancestors.add(candidate);
+
+    if (Array.isArray(candidate)) {
+      if (candidate.length > MAX_DATA_AGENT_ELEMENTS) return true;
+      const unsafe = candidate.some((entry) => walk(entry, depth + 1));
+      ancestors.delete(candidate);
+      return unsafe;
+    }
+
+    const unsafe = Object.entries(candidate).some(
+      ([key, entry]) =>
+        FORBIDDEN_CONTENT_KEYS.has(normalizedKey(key)) ||
+        walk(entry, depth + 1),
+    );
+    ancestors.delete(candidate);
+    return unsafe;
+  };
+
+  return walk(value, 0);
+}
+
+function text(
+  value: unknown,
+  maxLength = MAX_NAME_LENGTH,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  const hasControlCharacter = [...normalized].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+  if (
+    !normalized ||
+    normalized.length > maxLength ||
+    hasControlCharacter
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function optionalText(
+  value: unknown,
+  maxLength = MAX_NAME_LENGTH,
+): string | undefined | null {
+  if (value == null || value === "") return undefined;
+  return text(value, maxLength) ?? null;
+}
+
+function firstText(
+  value: UnknownRecord,
+  keys: string[],
+  maxLength = MAX_NAME_LENGTH,
+): string | undefined {
+  for (const key of keys) {
+    const parsed = text(value[key], maxLength);
+    if (parsed) return parsed;
+  }
+  return undefined;
+}
+
+function firstRecord(
+  value: UnknownRecord,
+  keys: string[],
+): UnknownRecord | undefined {
+  for (const key of keys) {
+    if (isRecord(value[key])) return value[key];
+  }
+  return undefined;
+}
+
+function array(
+  value: UnknownRecord,
+  keys: string[],
+  maxLength = MAX_COLLECTION_SIZE,
+): unknown[] | undefined {
+  for (const key of keys) {
+    if (!(key in value)) continue;
+    const entries = value[key];
+    return Array.isArray(entries) && entries.length <= maxLength
+      ? entries
+      : undefined;
+  }
+  return [];
+}
+
+function stringArray(
+  value: unknown,
+  maxLength = MAX_COLLECTION_SIZE,
+): string[] | undefined {
+  if (!Array.isArray(value) || value.length > maxLength) return undefined;
+  const parsed = value.map((entry) => text(entry));
+  return parsed.every((entry): entry is string => !!entry)
+    ? parsed
+    : undefined;
+}
+
+function uniqueBy<T>(
+  values: T[],
+  key: (value: T) => string,
+): T[] | undefined {
+  const keys = values.map(key);
+  return new Set(keys).size === keys.length ? values : undefined;
+}
+
+function parseList<T>(
+  values: unknown[] | undefined,
+  parser: (value: unknown) => T | undefined,
+): T[] | undefined {
+  if (!values) return undefined;
+  const parsed = values.map(parser);
+  return parsed.every((entry): entry is T => !!entry) ? parsed : undefined;
+}
+
+function parseOntologyProperty(
+  value: unknown,
+  timeSeries: boolean,
+): OntologyPropertyMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "displayName"]);
+  const valueType = firstText(value, ["valueType", "dataType", "type"]);
+  const id = firstText(value, ["id", "propertyId"]);
+  if (!id || !name || !valueType) return undefined;
+  return { id, name, valueType, timeSeries };
+}
+
+function parseOntologyEntity(
+  value: unknown,
+): OntologyEntityMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const id = firstText(value, ["id", "entityTypeId"]);
+  const name = firstText(value, ["name", "displayName"]);
+  const properties = parseList(
+    array(value, ["properties"]),
+    (entry) => parseOntologyProperty(entry, false),
+  );
+  const timeSeriesProperties = parseList(
+    array(value, ["timeSeriesProperties", "timeseriesProperties"]),
+    (entry) => parseOntologyProperty(entry, true),
+  );
+  const keyPropertyIds = stringArray(
+    value.keyPropertyIds ?? value.entityIdParts ?? [],
+  );
+  const namespace = optionalText(value.namespace);
+  const displayNamePropertyId = optionalText(value.displayNamePropertyId);
+  if (
+    !id ||
+    !name ||
+    !properties ||
+    !timeSeriesProperties ||
+    !keyPropertyIds ||
+    namespace === null ||
+    displayNamePropertyId === null
+  ) {
+    return undefined;
+  }
+  const allProperties = uniqueBy(
+    [...properties, ...timeSeriesProperties],
+    (property) => property.id,
+  );
+  return allProperties
+    ? {
+        id,
+        name,
+        namespace,
+        keyPropertyIds,
+        displayNamePropertyId,
+        properties: allProperties,
+      }
+    : undefined;
+}
+
+function entityReference(value: unknown): string | undefined {
+  if (typeof value === "string") return text(value);
+  return isRecord(value)
+    ? firstText(value, ["entityTypeId", "entityId", "id"])
+    : undefined;
+}
+
+function parseOntologyRelationship(
+  value: unknown,
+): OntologyRelationshipMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const sourceEntityId =
+    firstText(value, ["sourceEntityId"]) ?? entityReference(value.source);
+  const targetEntityId =
+    firstText(value, ["targetEntityId"]) ?? entityReference(value.target);
+  const name = firstText(value, ["name", "displayName"]);
+  const id = firstText(value, ["id", "relationshipId"]);
+  if (!sourceEntityId || !targetEntityId || !name || !id) {
+    return undefined;
+  }
+  return { id, name, sourceEntityId, targetEntityId };
+}
+
+function parseOntologyPropertyBinding(
+  value: unknown,
+): OntologyPropertyBindingMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const sourceColumn = firstText(value, [
+    "sourceColumn",
+    "sourceColumnName",
+  ]);
+  const targetPropertyId = firstText(value, [
+    "targetPropertyId",
+    "propertyId",
+  ]);
+  return sourceColumn && targetPropertyId
+    ? { sourceColumn, targetPropertyId }
+    : undefined;
+}
+
+function parseOntologyBinding(
+  value: unknown,
+): OntologyBindingMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const configuration =
+    firstRecord(value, ["dataBindingConfiguration", "configuration"]) ?? value;
+  const source =
+    firstRecord(configuration, [
+      "source",
+      "sourceTableProperties",
+      "sourceProperties",
+    ]) ?? configuration;
+  const entityId = firstText(value, [
+    "entityId",
+    "entityTypeId",
+    "targetEntityTypeId",
+  ]);
+  const bindingType =
+    firstText(configuration, ["bindingType", "dataBindingType"]) ?? "Table";
+  const sourceItemId = firstText(source, ["sourceItemId", "itemId", "artifactId"]);
+  const sourceObject = firstText(source, [
+    "sourceObject",
+    "sourceTableName",
+    "tableName",
+    "objectName",
+  ]);
+  const propertyBindings = parseList(
+    array(configuration, ["propertyBindings", "propertyMappings"]),
+    parseOntologyPropertyBinding,
+  );
+  const id = firstText(value, ["id", "bindingId"]);
+  const sourceWorkspaceId = optionalText(
+    source.sourceWorkspaceId ?? source.workspaceId,
+  );
+  const sourceType = optionalText(source.sourceType);
+  const sourceSchema = optionalText(
+    source.sourceSchema ?? source.schemaName,
+  );
+  const sourceObjectId = optionalText(
+    source.sourceObjectId ?? source.tableId ?? source.objectId,
+  );
+  const timestampColumn = optionalText(
+    configuration.timestampColumn ?? configuration.timestampColumnName,
+  );
+  if (
+    !entityId ||
+    !sourceItemId ||
+    !sourceObject ||
+    !propertyBindings ||
+    !id ||
+    sourceWorkspaceId === null ||
+    sourceType === null ||
+    sourceSchema === null ||
+    sourceObjectId === null ||
+    timestampColumn === null
+  ) {
+    return undefined;
+  }
+  return {
+    id,
+    entityId,
+    bindingType,
+    sourceItemId,
+    sourceWorkspaceId,
+    sourceType,
+    sourceSchema,
+    sourceObject,
+    sourceObjectId,
+    timestampColumn,
+    propertyBindings,
+  };
+}
+
+function parseOntologyContextualization(
+  value: unknown,
+  inheritedRelationshipId?: string,
+): OntologyContextualizationMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const source =
+    firstRecord(value, ["dataBindingTable", "source", "sourceTableProperties"]) ??
+    value;
+  const id = firstText(value, ["id", "contextualizationId"]);
+  const relationshipId =
+    firstText(value, ["relationshipId", "relationshipTypeId"]) ??
+    inheritedRelationshipId;
+  const sourceItemId = firstText(source, [
+    "sourceItemId",
+    "itemId",
+    "artifactId",
+  ]);
+  const sourceObject = firstText(source, [
+    "sourceObject",
+    "sourceTableName",
+    "tableName",
+    "objectName",
+  ]);
+  const sourceKeyBindings = parseList(
+    array(value, ["sourceKeyBindings", "sourceKeyRefBindings"]),
+    parseOntologyPropertyBinding,
+  );
+  const targetKeyBindings = parseList(
+    array(value, ["targetKeyBindings", "targetKeyRefBindings"]),
+    parseOntologyPropertyBinding,
+  );
+  const sourceWorkspaceId = optionalText(
+    source.sourceWorkspaceId ?? source.workspaceId,
+  );
+  const sourceType = optionalText(source.sourceType);
+  const sourceSchema = optionalText(
+    source.sourceSchema ?? source.schemaName,
+  );
+  const sourceObjectId = optionalText(
+    source.sourceObjectId ?? source.tableId ?? source.objectId,
+  );
+  if (
+    !id ||
+    !relationshipId ||
+    !sourceItemId ||
+    !sourceObject ||
+    !sourceKeyBindings ||
+    !targetKeyBindings ||
+    sourceWorkspaceId === null ||
+    sourceType === null ||
+    sourceSchema === null ||
+    sourceObjectId === null
+  ) {
+    return undefined;
+  }
+  return {
+    id,
+    relationshipId,
+    sourceItemId,
+    sourceWorkspaceId,
+    sourceType,
+    sourceSchema,
+    sourceObject,
+    sourceObjectId,
+    sourceKeyBindings,
+    targetKeyBindings,
+  };
+}
+
+export function parseOntologyMetadata(
+  value: unknown,
+): OntologyMetadata | undefined {
+  if (!isRecord(value) || containsUnsafeContent(value)) return undefined;
+  const entities = parseList(
+    array(value, ["entities", "entityTypes"]),
+    parseOntologyEntity,
+  );
+  const relationships = parseList(
+    array(value, ["relationships", "relationshipTypes"]),
+    parseOntologyRelationship,
+  );
+  const bindings = parseList(
+    array(value, ["bindings", "dataBindings"]),
+    parseOntologyBinding,
+  );
+  const contextualizations = parseList(
+    array(value, ["contextualizations"]),
+    (entry) => parseOntologyContextualization(entry),
+  );
+  if (!entities || !relationships || !bindings || !contextualizations) {
+    return undefined;
+  }
+  for (const rawRelationship of array(
+    value,
+    ["relationships", "relationshipTypes"],
+  ) ?? []) {
+    if (!isRecord(rawRelationship)) return undefined;
+    const relationshipId = firstText(rawRelationship, [
+      "id",
+      "relationshipId",
+    ]);
+    const nested = array(rawRelationship, ["contextualizations"]);
+    if (!relationshipId || !nested) return undefined;
+    for (const entry of nested) {
+      const parsed = parseOntologyContextualization(entry, relationshipId);
+      if (!parsed) return undefined;
+      contextualizations.push(parsed);
+    }
+  }
+  const uniqueEntities = uniqueBy(entities, (entity) => entity.id);
+  const uniqueRelationships = uniqueBy(
+    relationships,
+    (relationship) => relationship.id,
+  );
+  const uniqueBindings = uniqueBy(
+    bindings,
+    (binding) =>
+      binding.id ??
+      `${binding.entityId}\u0000${binding.sourceItemId}\u0000${binding.sourceObject}`,
+  );
+  const uniqueContextualizations = uniqueBy(
+    contextualizations,
+    (contextualization) => contextualization.id,
+  );
+  if (
+    !uniqueEntities ||
+    !uniqueRelationships ||
+    !uniqueBindings ||
+    !uniqueContextualizations
+  ) {
+    return undefined;
+  }
+  const entityById = new Map(
+    uniqueEntities.map((entity) => [entity.id, entity]),
+  );
+  const propertyIds = (entityId: string) =>
+    new Set(
+      entityById
+        .get(entityId)
+        ?.properties.map((property) => property.id) ?? [],
+    );
+  if (
+    uniqueEntities.some((entity) => {
+      const ids = propertyIds(entity.id);
+      return (
+        entity.keyPropertyIds.some((id) => !ids.has(id)) ||
+        (!!entity.displayNamePropertyId &&
+          !ids.has(entity.displayNamePropertyId))
+      );
+    }) ||
+    uniqueRelationships.some(
+      (relationship) =>
+        !entityById.has(relationship.sourceEntityId) ||
+        !entityById.has(relationship.targetEntityId),
+    ) ||
+    uniqueBindings.some(
+      (binding) =>
+        !entityById.has(binding.entityId) ||
+        binding.propertyBindings.some(
+          (property) =>
+            !propertyIds(binding.entityId).has(property.targetPropertyId),
+        ),
+    )
+  ) {
+    return undefined;
+  }
+  const relationshipById = new Map(
+    uniqueRelationships.map((relationship) => [
+      relationship.id,
+      relationship,
+    ]),
+  );
+  if (
+    uniqueContextualizations.some((contextualization) => {
+      const relationship = relationshipById.get(
+        contextualization.relationshipId,
+      );
+      return (
+        !relationship ||
+        contextualization.sourceKeyBindings.some(
+          (binding) =>
+            !propertyIds(relationship.sourceEntityId).has(
+              binding.targetPropertyId,
+            ),
+        ) ||
+        contextualization.targetKeyBindings.some(
+          (binding) =>
+            !propertyIds(relationship.targetEntityId).has(
+              binding.targetPropertyId,
+            ),
+        )
+      );
+    })
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "ontology",
+    entities: uniqueEntities,
+    relationships: uniqueRelationships,
+    bindings: uniqueBindings,
+    contextualizations: uniqueContextualizations,
+  };
+}
+
+function parseGraphProperty(
+  value: unknown,
+): GraphPropertyMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "propertyName"]);
+  const dataType = firstText(value, ["dataType", "type"]);
+  return name && dataType ? { name, dataType } : undefined;
+}
+
+function parseGraphNodeType(
+  value: unknown,
+): GraphNodeTypeMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const alias = firstText(value, ["alias", "name"]);
+  const labels = stringArray(value.labels ?? []);
+  const primaryKeyProperties = stringArray(
+    value.primaryKeyProperties ?? value.keys ?? [],
+  );
+  const properties = parseList(
+    array(value, ["properties"]),
+    parseGraphProperty,
+  );
+  return alias && labels && primaryKeyProperties && properties
+    ? { alias, labels, primaryKeyProperties, properties }
+    : undefined;
+}
+
+function graphNodeReference(value: unknown): string | undefined {
+  if (typeof value === "string") return text(value);
+  return isRecord(value) ? firstText(value, ["alias", "name"]) : undefined;
+}
+
+function parseGraphEdgeType(
+  value: unknown,
+): GraphEdgeTypeMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const alias = firstText(value, ["alias", "name"]);
+  const labels = stringArray(value.labels ?? []);
+  const sourceNodeType =
+    firstText(value, ["sourceNodeTypeAlias"]) ??
+    graphNodeReference(value.sourceNodeType ?? value.source);
+  const destinationNodeType =
+    firstText(value, ["destinationNodeTypeAlias", "targetNodeTypeAlias"]) ??
+    graphNodeReference(
+      value.destinationNodeType ?? value.targetNodeType ?? value.target,
+    );
+  const properties = parseList(
+    array(value, ["properties"]),
+    parseGraphProperty,
+  );
+  return alias &&
+    labels &&
+    sourceNodeType &&
+    destinationNodeType &&
+    properties
+    ? {
+        alias,
+        labels,
+        sourceNodeType,
+        destinationNodeType,
+        properties,
+      }
+    : undefined;
+}
+
+function parseGraphPropertyMapping(
+  value: unknown,
+): GraphPropertyMappingMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const propertyName = firstText(value, ["propertyName", "targetProperty"]);
+  const sourceColumn = firstText(value, ["sourceColumn", "sourceColumnName"]);
+  return propertyName && sourceColumn
+    ? { propertyName, sourceColumn }
+    : undefined;
+}
+
+function parseGraphDataSource(
+  value: unknown,
+): GraphDataSourceMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const properties = firstRecord(value, ["properties"]) ?? value;
+  const name = firstText(value, ["name", "dataSourceName"]);
+  const sourceItemId = firstText(value, [
+    "sourceItemId",
+    "itemId",
+    "artifactId",
+  ]);
+  const sourceObject = firstText(value, [
+    "sourceObject",
+    "tableName",
+    "sourceTableName",
+  ]) ?? firstText(properties, ["sourceObject", "tableName", "sourceTableName"]);
+  const sourceWorkspaceId = optionalText(
+    value.sourceWorkspaceId ?? value.workspaceId,
+  );
+  const sourceType = optionalText(value.sourceType ?? value.type);
+  const sourceObjectId = optionalText(
+    value.sourceObjectId ?? value.tableId ?? value.objectId,
+  );
+  if (
+    !name ||
+    !sourceItemId ||
+    !sourceObject ||
+    sourceWorkspaceId === null ||
+    sourceType === null ||
+    sourceObjectId === null
+  ) {
+    return undefined;
+  }
+  return {
+    name,
+    sourceItemId,
+    sourceWorkspaceId,
+    sourceObject,
+    sourceObjectId,
+    sourceType,
+  };
+}
+
+function parseGraphMapping(
+  value: unknown,
+  kind: GraphMappingMetadata["kind"],
+): ParsedGraphMappingMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const typeAlias = firstText(
+    value,
+    kind === "node"
+      ? ["typeAlias", "nodeTypeAlias"]
+      : ["typeAlias", "edgeTypeAlias"],
+  );
+  const dataSourceName = firstText(value, [
+    "dataSourceName",
+    "sourceName",
+  ]);
+  const propertyMappings = parseList(
+    array(value, ["propertyMappings"]),
+    parseGraphPropertyMapping,
+  );
+  const id = firstText(value, ["id", "mappingId"]);
+  const sourceItemId = optionalText(
+    value.sourceItemId ?? value.itemId ?? value.artifactId,
+  );
+  const sourceWorkspaceId = optionalText(
+    value.sourceWorkspaceId ?? value.workspaceId,
+  );
+  const sourceObject = optionalText(
+    value.sourceObject ?? value.tableName ?? value.sourceTableName,
+  );
+  const sourceObjectId = optionalText(
+    value.sourceObjectId ?? value.tableId ?? value.objectId,
+  );
+  const sourceNodeKeyColumns =
+    kind === "edge"
+      ? stringArray(value.sourceNodeKeyColumns ?? [])
+      : undefined;
+  const destinationNodeKeyColumns =
+    kind === "edge"
+      ? stringArray(
+          value.destinationNodeKeyColumns ??
+            value.targetNodeKeyColumns ??
+            [],
+        )
+      : undefined;
+  if (
+    !typeAlias ||
+    !dataSourceName ||
+    !propertyMappings ||
+    !id ||
+    sourceItemId === null ||
+    sourceWorkspaceId === null ||
+    sourceObject === null ||
+    sourceObjectId === null ||
+    (kind === "edge" &&
+      (!sourceNodeKeyColumns || !destinationNodeKeyColumns))
+  ) {
+    return undefined;
+  }
+  return {
+    id,
+    kind,
+    typeAlias,
+    dataSourceName,
+    sourceItemId,
+    sourceWorkspaceId,
+    sourceObject,
+    sourceObjectId,
+    propertyMappings,
+    sourceNodeKeyColumns,
+    destinationNodeKeyColumns,
+  };
+}
+
+export function parseGraphModelMetadata(
+  value: unknown,
+): GraphModelMetadata | undefined {
+  if (!isRecord(value) || containsUnsafeContent(value)) return undefined;
+  const graphType = firstRecord(value, ["graphType"]) ?? value;
+  const graphDefinition = firstRecord(value, ["graphDefinition"]) ?? value;
+  const dataSources = parseList(
+    array(value, ["dataSources"]),
+    parseGraphDataSource,
+  );
+  const nodeTypes = parseList(
+    array(graphType, ["nodeTypes"]),
+    parseGraphNodeType,
+  );
+  const edgeTypes = parseList(
+    array(graphType, ["edgeTypes"]),
+    parseGraphEdgeType,
+  );
+  const nodeMappings = parseList(
+    array(graphDefinition, ["nodeMappings", "nodeTables"]),
+    (entry) => parseGraphMapping(entry, "node"),
+  );
+  const edgeMappings = parseList(
+    array(graphDefinition, ["edgeMappings", "edgeTables"]),
+    (entry) => parseGraphMapping(entry, "edge"),
+  );
+  if (
+    !dataSources ||
+    !nodeTypes ||
+    !edgeTypes ||
+    !nodeMappings ||
+    !edgeMappings
+  ) {
+    return undefined;
+  }
+  const uniqueDataSources = uniqueBy(dataSources, (source) => source.name);
+  if (!uniqueDataSources) return undefined;
+  const dataSourceByName = new Map(
+    uniqueDataSources.map((source) => [source.name, source]),
+  );
+  const resolvedMappings: ParsedGraphMappingMetadata[] = [
+    ...nodeMappings,
+    ...edgeMappings,
+  ].map((mapping) => {
+    const source = dataSourceByName.get(mapping.dataSourceName);
+    return {
+      ...mapping,
+      sourceItemId: mapping.sourceItemId ?? source?.sourceItemId,
+      sourceWorkspaceId:
+        mapping.sourceWorkspaceId ?? source?.sourceWorkspaceId,
+      sourceObject: mapping.sourceObject ?? source?.sourceObject,
+      sourceObjectId:
+        mapping.sourceObjectId ?? source?.sourceObjectId,
+    };
+  });
+  const completeMappings = resolvedMappings.filter(isCompleteGraphMapping);
+  if (completeMappings.length !== resolvedMappings.length) return undefined;
+  const uniqueNodes = uniqueBy(nodeTypes, (node) => node.alias);
+  const uniqueEdges = uniqueBy(edgeTypes, (edge) => edge.alias);
+  const mappings = uniqueBy(
+    completeMappings,
+    (mapping) => mapping.id ?? `${mapping.kind}\u0000${mapping.typeAlias}`,
+  );
+  if (!uniqueNodes || !uniqueEdges || !mappings) return undefined;
+  const nodeByAlias = new Map(
+    uniqueNodes.map((node) => [node.alias, node]),
+  );
+  const edgeByAlias = new Map(
+    uniqueEdges.map((edge) => [edge.alias, edge]),
+  );
+  if (
+    uniqueEdges.some(
+      (edge) =>
+      !nodeByAlias.has(edge.sourceNodeType) ||
+      !nodeByAlias.has(edge.destinationNodeType),
+    ) ||
+    mappings.some((mapping) => {
+      const properties =
+      mapping.kind === "node"
+        ? nodeByAlias.get(mapping.typeAlias)?.properties
+        : edgeByAlias.get(mapping.typeAlias)?.properties;
+      const propertyNames = new Set(
+      properties?.map((property) => property.name) ?? [],
+      );
+      return (
+      !properties ||
+      mapping.propertyMappings.some(
+        (property) => !propertyNames.has(property.propertyName),
+      )
+      );
+    })
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "graphModel",
+    dataSources: uniqueDataSources,
+    nodeTypes: uniqueNodes,
+    edgeTypes: uniqueEdges,
+    mappings,
+  };
+}
+
+interface SelectedElementBudget {
+  count: number;
+}
+
+const DATA_AGENT_LINEAGE_ELEMENT_TYPE_SET = new Set<string>(
+  DATA_AGENT_LINEAGE_ELEMENT_TYPES,
+);
+
+function parseDataAgentElementTree(
+  value: unknown,
+  sourceArtifactId: string,
+  parentId: string | undefined,
+  parentName: string | undefined,
+  parentPath: string[],
+  depth: number,
+  budget: SelectedElementBudget,
+  selectedByContainer: boolean,
+): DataAgentElementMetadata[] | undefined {
+  if (!isRecord(value) || depth > MAX_NESTING_DEPTH) return undefined;
+  budget.count += 1;
+  if (budget.count > MAX_DATA_AGENT_ELEMENTS) return undefined;
+  const id = firstText(value, ["id"]);
+  const displayName = firstText(value, ["displayName", "display_name", "name"]);
+  const elementType = firstText(value, ["elementType", "type"]);
+  const selected =
+    value.isSelected ??
+    value.is_selected ??
+    value.selected ??
+    selectedByContainer;
+  const effectiveParentId =
+    firstText(value, ["parentId"]) ?? parentId;
+  const effectiveParentName =
+    firstText(value, ["parentName"]) ?? parentName;
+  const suppliedParentPath = stringArray(
+    value.parentPath,
+    MAX_NESTING_DEPTH,
+  );
+  const effectiveParentPath =
+    suppliedParentPath ?? parentPath;
+  if (
+    !id ||
+    !displayName ||
+    !elementType ||
+    (selected != null && typeof selected !== "boolean")
+  ) {
+    return undefined;
+  }
+  const dataType = optionalText(value.dataType ?? value.data_type);
+  const state = optionalText(value.state);
+  const indexState = optionalText(value.indexState ?? value.index_state);
+  if (dataType === null || state === null || indexState === null) {
+    return undefined;
+  }
+  const children = array(value, ["children"], MAX_DATA_AGENT_ELEMENTS);
+  if (!children) return undefined;
+  const parsedChildren: DataAgentElementMetadata[] = [];
+  for (const child of children) {
+    const parsed = parseDataAgentElementTree(
+      child,
+      sourceArtifactId,
+      id,
+      displayName,
+      [...effectiveParentPath, displayName],
+      depth + 1,
+      budget,
+      selectedByContainer,
+    );
+    if (!parsed) return undefined;
+    parsedChildren.push(...parsed);
+  }
+  const supported = DATA_AGENT_LINEAGE_ELEMENT_TYPE_SET.has(
+    elementType.toLowerCase(),
+  );
+  if (!selected || !supported) return parsedChildren;
+  return [
+    {
+      id,
+      displayName,
+      elementType,
+      selected: true,
+      sourceArtifactId,
+      dataType,
+      parentId: effectiveParentId,
+      parentName: effectiveParentName,
+      parentPath: effectiveParentPath,
+      state,
+      indexState,
+      children: parsedChildren,
+    },
+  ];
+}
+
+function flattenSelectedElements(
+  elements: DataAgentElementMetadata[],
+): DataAgentSelectedElementMetadata[] {
+  return elements.flatMap((element) => [
+    ...(element.selected
+      ? [
+          {
+            id: element.id,
+            displayName: element.displayName,
+            elementType: element.elementType,
+            sourceArtifactId: element.sourceArtifactId,
+            dataType: element.dataType,
+            parentId: element.parentId,
+            parentName: element.parentName,
+            parentPath: element.parentPath,
+            state: element.state,
+            indexState: element.indexState,
+          },
+        ]
+      : []),
+    ...flattenSelectedElements(element.children),
+  ]);
+}
+
+function allDataAgentElements(
+  elements: DataAgentElementMetadata[],
+): DataAgentElementMetadata[] {
+  return elements.flatMap((element) => [
+    element,
+    ...allDataAgentElements(element.children),
+  ]);
+}
+
+function dataAgentElementStableId(
+  element: Pick<
+    DataAgentSelectedElementMetadata,
+    "id" | "elementType" | "parentPath"
+  >,
+): string {
+  return [...element.parentPath, `${element.elementType}:${element.id}`].join(
+    "/",
+  );
+}
+
+function parseDataAgentSource(
+  value: unknown,
+): DataAgentSourceMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const artifactId = firstText(value, [
+    "artifactId",
+    "itemId",
+    "sourceItemId",
+  ]);
+  const workspaceId = optionalText(
+    value.workspaceId ?? value.sourceWorkspaceId,
+  );
+  const displayName = firstText(value, ["displayName", "name"]);
+  const sourceType = firstText(value, ["sourceType", "type"]);
+  const selectedByContainer =
+    !("elements" in value) && "selectedElements" in value;
+  const elements = array(
+    value,
+    selectedByContainer ? ["selectedElements"] : ["elements"],
+    MAX_DATA_AGENT_ELEMENTS,
+  );
+  if (
+    !artifactId ||
+    !displayName ||
+    !sourceType ||
+    !elements ||
+    workspaceId === null
+  ) {
+    return undefined;
+  }
+  const elementTree: DataAgentElementMetadata[] = [];
+  const budget = { count: 0 };
+  for (const element of elements) {
+    const parsed = parseDataAgentElementTree(
+      element,
+      artifactId,
+      undefined,
+      undefined,
+      [],
+      0,
+      budget,
+      selectedByContainer,
+    );
+    if (!parsed) return undefined;
+    elementTree.push(...parsed);
+  }
+  if (
+    !uniqueBy(allDataAgentElements(elementTree), dataAgentElementStableId)
+  ) {
+    return undefined;
+  }
+  const selectedElements = flattenSelectedElements(elementTree);
+  const uniqueElements = uniqueBy(
+    selectedElements,
+    dataAgentElementStableId,
+  );
+  return uniqueElements
+    ? {
+        artifactId,
+        workspaceId,
+        displayName,
+        sourceType,
+        elements: elementTree,
+        selectedElements: uniqueElements,
+      }
+    : undefined;
+}
+
+export function parseDataAgentMetadata(
+  value: unknown,
+): DataAgentMetadata | undefined {
+  if (!isRecord(value) || containsUnsafeContent(value)) return undefined;
+  const sources = parseList(
+    array(value, ["sources", "dataSources"]),
+    parseDataAgentSource,
+  );
+  const uniqueSources = sources
+    ? uniqueBy(sources, (source) => source.artifactId)
+    : undefined;
+  return uniqueSources ? { kind: "dataAgent", sources: uniqueSources } : undefined;
+}
+
+function parseKqlParameter(
+  value: unknown,
+): KqlFunctionParameterMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "parameterName"]);
+  const dataType = firstText(value, ["dataType", "type"]);
+  return name && dataType ? { name, dataType } : undefined;
+}
+
+function parseKqlFunction(
+  value: unknown,
+): KqlFunctionMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "displayName"]);
+  const parameters = parseList(
+    array(value, ["parameters"]),
+    parseKqlParameter,
+  );
+  const folder = optionalText(value.folder);
+  const description = optionalText(
+    value.description ?? value.docString,
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const returnType = optionalText(value.returnType);
+  if (
+    !name ||
+    !parameters ||
+    folder === null ||
+    description === null ||
+    returnType === null
+  ) {
+    return undefined;
+  }
+  return { name, folder, description, parameters, returnType };
+}
+
+function parseKqlColumn(value: unknown): KqlColumnMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "displayName"]);
+  const dataType = firstText(value, ["dataType", "type"]);
+  return name && dataType ? { name, dataType } : undefined;
+}
+
+function parseKqlMaterializedView(
+  value: unknown,
+): KqlMaterializedViewMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = firstText(value, ["name", "displayName"]);
+  const sourceTable = optionalText(
+    value.sourceTable ?? value.sourceTableName,
+  );
+  const description = optionalText(value.description, MAX_DESCRIPTION_LENGTH);
+  const columns = parseList(array(value, ["columns"]), parseKqlColumn);
+  if (
+    !name ||
+    !columns ||
+    sourceTable === null ||
+    description === null
+  ) {
+    return undefined;
+  }
+  return { name, sourceTable, description, columns };
+}
+
+export function parseKqlDatabaseMetadata(
+  value: unknown,
+): KqlDatabaseMetadata | undefined {
+  if (!isRecord(value) || containsUnsafeContent(value)) return undefined;
+  const functions = parseList(
+    array(value, ["functions"]),
+    parseKqlFunction,
+  );
+  const materializedViews = parseList(
+    array(value, ["materializedViews"]),
+    parseKqlMaterializedView,
+  );
+  if (!functions || !materializedViews) return undefined;
+  const uniqueFunctions = uniqueBy(functions, (fn) => fn.name);
+  const uniqueViews = uniqueBy(materializedViews, (view) => view.name);
+  return uniqueFunctions && uniqueViews
+    ? {
+        kind: "kql",
+        functions: uniqueFunctions,
+        materializedViews: uniqueViews,
+      }
+    : undefined;
+}
+
+export function parseFabricItemMetadata(
+  itemType: ItemType | string,
+  value: unknown,
+): FabricItemMetadata | undefined {
+  switch (itemType) {
+    case "Ontology":
+      return parseOntologyMetadata(value);
+    case "GraphModel":
+      return parseGraphModelMetadata(value);
+    case "DataAgent":
+      return parseDataAgentMetadata(value);
+    case "KQLDatabase":
+      return parseKqlDatabaseMetadata(value);
+    default:
+      return undefined;
+  }
+}
+
+export function metadataSchemaEntry(
+  metadata: FabricItemMetadata,
+): ModelTableSchema {
+  const itemTypeByKind: Record<FabricItemMetadata["kind"], ItemType> = {
+    ontology: "Ontology",
+    graphModel: "GraphModel",
+    dataAgent: "DataAgent",
+    kql: "KQLDatabase",
+  };
+  const parsed = parseFabricItemMetadata(
+    itemTypeByKind[metadata.kind],
+    metadata,
+  );
+  if (!parsed) throw new TypeError("Invalid Fabric item metadata");
+  const serialized = JSON.stringify(parsed);
+  if (serialized.length > MAX_SERIALIZED_METADATA_LENGTH) {
+    throw new RangeError("Fabric item metadata exceeds the safe size limit");
+  }
+  return {
+    name: ITEM_METADATA_SCHEMA_NAME,
+    objectType: "Atlas item metadata",
+    description: serialized,
+    isHidden: true,
+    columns: [],
+    measures: [],
+    metadata: parsed,
+  };
+}
+
+export function isItemMetadataSchemaEntry(
+  table: Pick<ModelTableSchema, "name">,
+): boolean {
+  return table.name === ITEM_METADATA_SCHEMA_NAME;
+}
+
+export function projectItemMetadataToSchema(
+  metadata: FabricItemMetadata,
+): ModelTableSchema[] {
+  const envelope = metadataSchemaEntry(metadata);
+  switch (metadata.kind) {
+    case "ontology":
+      return [
+        ...metadata.entities.map((entity) => ({
+          name: entity.name,
+          objectType: METADATA_OBJECT_TYPES.ontologyEntity,
+          source: entity.namespace,
+          columns: entity.properties.map((property) => ({
+            name: property.name,
+            dataType: property.valueType,
+            description: property.timeSeries
+              ? "Time-series property"
+              : undefined,
+          })),
+          measures: [],
+        })),
+        ...metadata.relationships.map((relationship) => ({
+          name: relationship.name,
+          objectType: METADATA_OBJECT_TYPES.ontologyRelationship,
+          source: `${relationship.sourceEntityId} -> ${relationship.targetEntityId}`,
+          columns: [],
+          measures: [],
+        })),
+        envelope,
+      ];
+    case "graphModel":
+      return [
+        ...metadata.nodeTypes.map((node) => ({
+          name: node.alias,
+          objectType: METADATA_OBJECT_TYPES.graphNode,
+          description: node.labels.join(", ") || undefined,
+          columns: node.properties.map((property) => ({
+            name: property.name,
+            dataType: property.dataType,
+            description: node.primaryKeyProperties.includes(property.name)
+              ? "Primary key"
+              : undefined,
+          })),
+          measures: [],
+        })),
+        ...metadata.edgeTypes.map((edge) => ({
+          name: edge.alias,
+          objectType: METADATA_OBJECT_TYPES.graphEdge,
+          source: `${edge.sourceNodeType} -> ${edge.destinationNodeType}`,
+          description: edge.labels.join(", ") || undefined,
+          columns: edge.properties.map((property) => ({
+            name: property.name,
+            dataType: property.dataType,
+          })),
+          measures: [],
+        })),
+        envelope,
+      ];
+    case "dataAgent":
+      return [
+        ...metadata.sources.map((source) => ({
+          name: source.displayName,
+          objectType: METADATA_OBJECT_TYPES.dataAgentSource,
+          source: source.artifactId,
+          description: source.sourceType,
+          columns: source.selectedElements.map((element) => ({
+            name: element.displayName,
+            dataType: element.dataType ?? element.elementType,
+            description: element.elementType,
+          })),
+          measures: [],
+        })),
+        envelope,
+      ];
+    case "kql":
+      return [
+        ...metadata.functions.map((fn) => ({
+          name: fn.name,
+          objectType: METADATA_OBJECT_TYPES.kqlFunction,
+          description: fn.description,
+          columns: fn.parameters.map((parameter) => ({
+            name: parameter.name,
+            dataType: parameter.dataType,
+          })),
+          measures: [],
+        })),
+        ...metadata.materializedViews.map((view) => ({
+          name: view.name,
+          objectType: METADATA_OBJECT_TYPES.kqlMaterializedView,
+          source: view.sourceTable,
+          description: view.description,
+          columns: view.columns.map((column) => ({
+            name: column.name,
+            dataType: column.dataType,
+          })),
+          measures: [],
+        })),
+        envelope,
+      ];
+  }
+}
+
+function kqlMetadataFromSchema(
+  tables: ModelTableSchema[],
+): KqlDatabaseMetadata | undefined {
+  const functions: KqlFunctionMetadata[] = [];
+  const materializedViews: KqlMaterializedViewMetadata[] = [];
+  for (const table of tables) {
+    const objectType = table.objectType?.trim().toLowerCase();
+    if (
+      objectType === "function" ||
+      objectType === "stored function" ||
+      objectType === METADATA_OBJECT_TYPES.kqlFunction.toLowerCase()
+    ) {
+      functions.push({
+        name: table.name,
+        description: table.description,
+        parameters: table.columns.map((column) => ({
+          name: column.name,
+          dataType: column.dataType,
+        })),
+      });
+    } else if (
+      objectType === "materialized view" ||
+      objectType === "materializedview" ||
+      objectType ===
+        METADATA_OBJECT_TYPES.kqlMaterializedView.toLowerCase()
+    ) {
+      materializedViews.push({
+        name: table.name,
+        description: table.description,
+        columns: table.columns.map((column) => ({
+          name: column.name,
+          dataType: column.dataType,
+        })),
+      });
+    }
+  }
+  return functions.length || materializedViews.length
+    ? parseKqlDatabaseMetadata({ functions, materializedViews })
+    : undefined;
+}
+
+export function itemMetadataFromSchema(
+  itemType: ItemType | string,
+  tables: ModelTableSchema[] | undefined,
+): FabricItemMetadata | undefined {
+  if (!tables) return undefined;
+  for (const table of tables) {
+    if (!isItemMetadataSchemaEntry(table)) continue;
+    if (table.metadata) {
+      return parseFabricItemMetadata(itemType, table.metadata);
+    }
+    if (
+      !table.description ||
+      table.description.length > MAX_SERIALIZED_METADATA_LENGTH
+    ) {
+      return undefined;
+    }
+    try {
+      return parseFabricItemMetadata(
+        itemType,
+        JSON.parse(table.description) as unknown,
+      );
+    } catch (error) {
+      if (error instanceof SyntaxError) return undefined;
+      throw error;
+    }
+  }
+  return itemType === "KQLDatabase"
+    ? kqlMetadataFromSchema(tables)
+    : undefined;
+}
+
+export function itemMetadataFor(
+  data: Pick<AtlasData, "itemMetadata" | "schema">,
+  itemId: string,
+  itemType: ItemType | string,
+): FabricItemMetadata | undefined {
+  const direct = data.itemMetadata?.[itemId];
+  return direct
+    ? parseFabricItemMetadata(itemType, direct)
+    : itemMetadataFromSchema(itemType, data.schema?.[itemId]);
+}
+
+function uniqueItemEdges(edges: Edge[]): Edge[] {
+  const seen = new Set<string>();
+  return edges.filter((edge) => {
+    const key = `${edge.source}\u0000${edge.target}\u0000${edge.relation}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function metadataItemLineageEdges(
+  itemId: string,
+  metadata: FabricItemMetadata,
+): Edge[] {
+  const sources =
+    metadata.kind === "ontology"
+      ? [
+          ...metadata.bindings.map((binding) => binding.sourceItemId),
+          ...metadata.contextualizations.map(
+            (contextualization) => contextualization.sourceItemId,
+          ),
+        ]
+      : metadata.kind === "graphModel"
+        ? metadata.mappings.map((mapping) => mapping.sourceItemId)
+        : metadata.kind === "dataAgent"
+          ? metadata.sources.map((source) => source.artifactId)
+          : [];
+  const relation =
+    metadata.kind === "ontology"
+      ? "binds ontology"
+      : metadata.kind === "graphModel"
+        ? "maps graph"
+        : "grounds";
+  return uniqueItemEdges(
+    sources
+      .filter((sourceItemId) => sourceItemId !== itemId)
+      .map((sourceItemId) => ({
+        source: sourceItemId,
+        target: itemId,
+        relation,
+      })),
+  );
+}
+
+function metadataObjectEdgeKey(edge: MetadataObjectLineageEdge): string {
+  return [
+    edge.source.itemId,
+    edge.source.kind,
+    edge.source.id,
+    edge.target.itemId,
+    edge.target.kind,
+    edge.target.id,
+    edge.relation,
+  ].join("\u0000");
+}
+
+type MetadataObjectLineageCandidate = Omit<
+  MetadataObjectLineageEdge,
+  "confidence"
+>;
+
+function uniqueObjectEdges(
+  edges: MetadataObjectLineageCandidate[],
+): MetadataObjectLineageEdge[] {
+  const seen = new Set<string>();
+  const verified: MetadataObjectLineageEdge[] = [];
+  for (const edge of edges) {
+    const next = { ...edge, confidence: "verified" as const };
+    const key = metadataObjectEdgeKey(next);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    verified.push(next);
+  }
+  return verified;
+}
+
+function sourceObjectRef(
+  itemId: string,
+  objectId: string,
+  objectName: string,
+): MetadataObjectRef {
+  return {
+    itemId,
+    kind: "sourceObject",
+    id: objectId,
+    name: objectName,
+    tableName: objectName,
+  };
+}
+
+function sourceFieldRef(
+  itemId: string,
+  objectId: string,
+  objectName: string,
+  fieldName: string,
+): MetadataObjectRef {
+  return {
+    itemId,
+    kind: "sourceField",
+    id: `${objectId}.${fieldName}`,
+    name: fieldName,
+    parentId: objectId,
+    tableName: objectName,
+  };
+}
+
+function sourceObjectStableId(
+  sourceObject: string,
+  sourceSchema?: string,
+  sourceObjectId?: string,
+): string {
+  return sourceObjectId ??
+    (sourceSchema ? `${sourceSchema}.${sourceObject}` : sourceObject);
+}
+
+function ontologyObjectLineageEdges(
+  itemId: string,
+  metadata: OntologyMetadata,
+): MetadataObjectLineageCandidate[] {
+  const edges: MetadataObjectLineageCandidate[] = [];
+  const entityById = new Map(
+    metadata.entities.map((entity) => [entity.id, entity]),
+  );
+  const relationshipById = new Map(
+    metadata.relationships.map((relationship) => [
+      relationship.id,
+      relationship,
+    ]),
+  );
+  const entityRef = (entityId: string): MetadataObjectRef => ({
+    itemId,
+    kind: "ontologyEntity",
+    id: entityId,
+    name: entityById.get(entityId)?.name ?? entityId,
+  });
+  const propertyRef = (
+    entityId: string,
+    propertyId: string,
+  ): MetadataObjectRef => ({
+    itemId,
+    kind: "ontologyProperty",
+    id: propertyId,
+    name:
+      entityById
+        .get(entityId)
+        ?.properties.find((property) => property.id === propertyId)?.name ??
+      propertyId,
+    parentId: entityId,
+    tableName: entityById.get(entityId)?.name,
+  });
+
+  for (const relationship of metadata.relationships) {
+    const relationshipRef: MetadataObjectRef = {
+      itemId,
+      kind: "ontologyRelationship",
+      id: relationship.id,
+      name: relationship.name,
+    };
+    edges.push(
+      {
+        source: entityRef(relationship.sourceEntityId),
+        target: relationshipRef,
+        relation: "relationship source",
+      },
+      {
+        source: relationshipRef,
+        target: entityRef(relationship.targetEntityId),
+        relation: "relationship target",
+      },
+    );
+  }
+
+  for (const binding of metadata.bindings) {
+    const sourceObjectId = sourceObjectStableId(
+      binding.sourceObject,
+      binding.sourceSchema,
+      binding.sourceObjectId,
+    );
+    edges.push({
+      source: sourceObjectRef(
+        binding.sourceItemId,
+        sourceObjectId,
+        binding.sourceObject,
+      ),
+      target: entityRef(binding.entityId),
+      relation: "binds entity",
+    });
+    for (const property of binding.propertyBindings) {
+      edges.push({
+        source: sourceFieldRef(
+          binding.sourceItemId,
+          sourceObjectId,
+          binding.sourceObject,
+          property.sourceColumn,
+        ),
+        target: propertyRef(binding.entityId, property.targetPropertyId),
+        relation: "binds property",
+      });
+    }
+  }
+
+  for (const contextualization of metadata.contextualizations) {
+    const sourceObjectId = sourceObjectStableId(
+      contextualization.sourceObject,
+      contextualization.sourceSchema,
+      contextualization.sourceObjectId,
+    );
+    const relationship = relationshipById.get(
+      contextualization.relationshipId,
+    );
+    const contextualizationRef: MetadataObjectRef = {
+      itemId,
+      kind: "ontologyContextualization",
+      id: contextualization.id,
+      name: contextualization.sourceObject,
+      parentId: contextualization.relationshipId,
+    };
+    edges.push(
+      {
+        source: sourceObjectRef(
+          contextualization.sourceItemId,
+          sourceObjectId,
+          contextualization.sourceObject,
+        ),
+        target: contextualizationRef,
+        relation: "contextualizes relationship",
+      },
+      {
+        source: contextualizationRef,
+        target: {
+          itemId,
+          kind: "ontologyRelationship",
+          id: contextualization.relationshipId,
+          name:
+            relationship?.name ?? contextualization.relationshipId,
+        },
+        relation: "binds relationship",
+      },
+    );
+    if (!relationship) continue;
+    for (const binding of contextualization.sourceKeyBindings) {
+      edges.push({
+        source: sourceFieldRef(
+          contextualization.sourceItemId,
+          sourceObjectId,
+          contextualization.sourceObject,
+          binding.sourceColumn,
+        ),
+        target: propertyRef(
+          relationship.sourceEntityId,
+          binding.targetPropertyId,
+        ),
+        relation: "binds source key",
+      });
+    }
+    for (const binding of contextualization.targetKeyBindings) {
+      edges.push({
+        source: sourceFieldRef(
+          contextualization.sourceItemId,
+          sourceObjectId,
+          contextualization.sourceObject,
+          binding.sourceColumn,
+        ),
+        target: propertyRef(
+          relationship.targetEntityId,
+          binding.targetPropertyId,
+        ),
+        relation: "binds target key",
+      });
+    }
+  }
+  return edges;
+}
+
+function graphObjectLineageEdges(
+  itemId: string,
+  metadata: GraphModelMetadata,
+): MetadataObjectLineageCandidate[] {
+  const edges: MetadataObjectLineageCandidate[] = [];
+  const nodeByAlias = new Map(
+    metadata.nodeTypes.map((node) => [node.alias, node]),
+  );
+  const edgeByAlias = new Map(
+    metadata.edgeTypes.map((edge) => [edge.alias, edge]),
+  );
+  const nodeRef = (alias: string): MetadataObjectRef => ({
+    itemId,
+    kind: "graphNode",
+    id: alias,
+    name: alias,
+  });
+  const edgeRef = (alias: string): MetadataObjectRef => ({
+    itemId,
+    kind: "graphEdge",
+    id: alias,
+    name: alias,
+  });
+  for (const edge of metadata.edgeTypes) {
+    edges.push(
+      {
+        source: nodeRef(edge.sourceNodeType),
+        target: edgeRef(edge.alias),
+        relation: "edge source",
+      },
+      {
+        source: edgeRef(edge.alias),
+        target: nodeRef(edge.destinationNodeType),
+        relation: "edge destination",
+      },
+    );
+  }
+  for (const mapping of metadata.mappings) {
+    const sourceObjectId = sourceObjectStableId(
+      mapping.sourceObject,
+      undefined,
+      mapping.sourceObjectId,
+    );
+    const target =
+      mapping.kind === "node"
+        ? nodeRef(mapping.typeAlias)
+        : edgeRef(mapping.typeAlias);
+    edges.push({
+      source: sourceObjectRef(
+        mapping.sourceItemId,
+        sourceObjectId,
+        mapping.sourceObject,
+      ),
+      target,
+      relation: mapping.kind === "node" ? "maps node" : "maps edge",
+    });
+    const properties =
+      mapping.kind === "node"
+        ? nodeByAlias.get(mapping.typeAlias)?.properties
+        : edgeByAlias.get(mapping.typeAlias)?.properties;
+    for (const property of mapping.propertyMappings) {
+      edges.push({
+        source: sourceFieldRef(
+          mapping.sourceItemId,
+          sourceObjectId,
+          mapping.sourceObject,
+          property.sourceColumn,
+        ),
+        target: {
+          itemId,
+          kind: "graphProperty",
+          id: `${mapping.typeAlias}.${property.propertyName}`,
+          name:
+            properties?.find(
+              (candidate) => candidate.name === property.propertyName,
+            )?.name ?? property.propertyName,
+          parentId: mapping.typeAlias,
+          tableName: mapping.typeAlias,
+        },
+        relation: "maps property",
+      });
+    }
+  }
+  return edges;
+}
+
+function dataAgentObjectLineageEdges(
+  itemId: string,
+  metadata: DataAgentMetadata,
+): MetadataObjectLineageCandidate[] {
+  const edges: MetadataObjectLineageCandidate[] = [];
+  const visit = (source: DataAgentSourceMetadata) => {
+    const selectedById = new Map(
+      source.selectedElements.map((element) => [element.id, element]),
+    );
+    const elements = allDataAgentElements(source.elements);
+    for (const element of elements) {
+      const stableId = dataAgentElementStableId(element);
+      const tableName =
+        element.elementType.toLowerCase().endsWith(".table") ||
+        element.elementType.toLowerCase() === "ontology.entity"
+          ? element.displayName
+          : element.parentName;
+      const target: MetadataObjectRef = {
+        itemId,
+        kind: "dataAgentElement",
+        id: `${source.artifactId}:${stableId}`,
+        name: element.displayName,
+        parentId: element.parentId
+          ? `${source.artifactId}:${element.parentId}`
+          : source.artifactId,
+        tableName,
+      };
+      edges.push({
+        source: {
+          itemId: source.artifactId,
+          kind: "sourceElement",
+          id: stableId,
+          name: element.displayName,
+          parentId: element.parentId,
+          parentPath: element.parentPath,
+          tableName,
+        },
+        target,
+        relation: "selected by agent",
+      });
+      const parent = element.parentId
+        ? selectedById.get(element.parentId)
+        : undefined;
+      if (parent) {
+        edges.push({
+          source: {
+            itemId,
+            kind: "dataAgentElement",
+            id: `${source.artifactId}:${dataAgentElementStableId(parent)}`,
+            name: parent.displayName,
+            parentId: source.artifactId,
+            tableName: element.parentName,
+          },
+          target,
+          relation: "contains",
+        });
+      }
+    }
+  };
+  for (const source of metadata.sources) {
+    const sourceRef: MetadataObjectRef = {
+      itemId,
+      kind: "dataAgentSource",
+      id: source.artifactId,
+      name: source.displayName,
+    };
+    edges.push({
+      source: sourceObjectRef(
+        source.artifactId,
+        source.artifactId,
+        source.displayName,
+      ),
+      target: sourceRef,
+      relation: "agent source",
+    });
+    visit(source);
+  }
+  return edges;
+}
+
+export function metadataObjectLineageEdges(
+  itemId: string,
+  metadata: FabricItemMetadata,
+): MetadataObjectLineageEdge[] {
+  const edges =
+    metadata.kind === "ontology"
+      ? ontologyObjectLineageEdges(itemId, metadata)
+      : metadata.kind === "graphModel"
+        ? graphObjectLineageEdges(itemId, metadata)
+        : metadata.kind === "dataAgent"
+          ? dataAgentObjectLineageEdges(itemId, metadata)
+          : metadata.materializedViews.flatMap((view) =>
+              view.sourceTable
+                ? [
+                    {
+                      source: sourceObjectRef(
+                        itemId,
+                        view.sourceTable,
+                        view.sourceTable,
+                      ),
+                      target: {
+                        itemId,
+                        kind: "kqlMaterializedView" as const,
+                        id: view.name,
+                        name: view.name,
+                      },
+                      relation: "materializes",
+                    },
+                  ]
+                : [],
+            );
+  return uniqueObjectEdges(edges);
+}
+
+const METADATA_OBJECT_KINDS = new Set<MetadataObjectKind>([
+  "sourceObject",
+  "sourceField",
+  "sourceElement",
+  "ontologyEntity",
+  "ontologyProperty",
+  "ontologyRelationship",
+  "ontologyContextualization",
+  "graphNode",
+  "graphEdge",
+  "graphProperty",
+  "dataAgentSource",
+  "dataAgentElement",
+  "kqlFunction",
+  "kqlMaterializedView",
+]);
+
+const METADATA_OBJECT_KIND_ALIASES: Record<string, MetadataObjectKind> = {
+  table: "sourceObject",
+  view: "sourceObject",
+  column: "sourceField",
+  measure: "sourceField",
+  function: "kqlFunction",
+  materializedView: "kqlMaterializedView",
+  entityType: "ontologyEntity",
+  property: "ontologyProperty",
+  timeSeriesProperty: "ontologyProperty",
+  relationshipType: "ontologyRelationship",
+  nodeType: "graphNode",
+  edgeType: "graphEdge",
+  dataSource: "dataAgentSource",
+  selectedElement: "dataAgentElement",
+};
+
+function parseMetadataObjectRef(
+  value: unknown,
+): MetadataObjectRef | undefined {
+  if (!isRecord(value)) return undefined;
+  const itemId = firstText(value, ["itemId"]);
+  const rawKind = firstText(value, ["kind"]);
+  const kind = rawKind
+    ? METADATA_OBJECT_KIND_ALIASES[rawKind] ??
+      (rawKind as MetadataObjectKind)
+    : undefined;
+  const id = firstText(value, ["id"]);
+  const name = firstText(value, ["name"]);
+  const parentId = optionalText(value.parentId);
+  const parentPath =
+    value.parentPath == null
+      ? undefined
+      : stringArray(value.parentPath, MAX_NESTING_DEPTH);
+  const tableName = optionalText(value.tableName);
+  if (
+    !itemId ||
+    !kind ||
+    !METADATA_OBJECT_KINDS.has(kind) ||
+    !id ||
+    !name ||
+    parentId === null ||
+    (value.parentPath != null && !parentPath) ||
+    tableName === null
+  ) {
+    return undefined;
+  }
+  return {
+    itemId,
+    kind,
+    id,
+    name,
+    parentId,
+    parentPath,
+    tableName,
+  };
+}
+
+function objectLineageEntries(value: unknown): unknown[] | undefined {
+  if (Array.isArray(value)) {
+    return value.length <= MAX_OBJECT_LINEAGE_EDGES ? value : undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  const direct = value.objectEdges;
+  if (Array.isArray(direct)) {
+    return direct.length <= MAX_OBJECT_LINEAGE_EDGES
+      ? direct
+      : undefined;
+  }
+  const lineage = value.objectLineage;
+  if (Array.isArray(lineage)) {
+    return lineage.length <= MAX_OBJECT_LINEAGE_EDGES
+      ? lineage
+      : undefined;
+  }
+  if (isRecord(lineage) && Array.isArray(lineage.edges)) {
+    return lineage.edges.length <= MAX_OBJECT_LINEAGE_EDGES
+      ? lineage.edges
+      : undefined;
+  }
+  return undefined;
+}
+
+export function parseObjectLineagePayload(
+  value: unknown,
+): ObjectLineagePayload | undefined {
+  if (containsUnsafeContent(value)) return undefined;
+  const entries = objectLineageEntries(value);
+  if (!entries) return undefined;
+  const edges: MetadataObjectLineageEdge[] = [];
+  for (const entry of entries) {
+    if (!isRecord(entry) || entry.confidence !== "verified") {
+      return undefined;
+    }
+    const source = parseMetadataObjectRef(entry.source);
+    const target = parseMetadataObjectRef(entry.target);
+    const relation = text(entry.relation);
+    if (
+      !source ||
+      !target ||
+      !relation ||
+      (source.itemId === target.itemId &&
+        source.kind === target.kind &&
+        source.id === target.id)
+    ) {
+      return undefined;
+    }
+    edges.push({ source, target, relation, confidence: "verified" });
+  }
+  return { objectEdges: uniqueObjectEdges(edges) };
+}

--- a/src/atlas/lineage.spec.ts
+++ b/src/atlas/lineage.spec.ts
@@ -286,9 +286,16 @@ describe("staged layout", () => {
     expect(itemStage("DataPipeline")).toBe(0);
     expect(itemStage("Notebook")).toBe(1);
     expect(itemStage("Lakehouse")).toBe(2);
+    expect(itemStage("Eventhouse")).toBe(2);
     expect(itemStage("SQLEndpoint")).toBe(3);
+    expect(itemStage("KQLDatabase")).toBe(3);
     expect(itemStage("SemanticModel")).toBe(4);
+    expect(itemStage("Ontology")).toBe(4);
+    expect(itemStage("GraphModel")).toBe(4);
     expect(itemStage("Report")).toBe(5);
+    expect(itemStage("DataAgent")).toBe(5);
+    expect(itemStage("KQLQueryset")).toBe(5);
+    expect(itemStage("KQLDashboard")).toBe(5);
   });
 
   it("positions later lifecycle stages farther right", () => {
@@ -422,5 +429,92 @@ describe("normalizeLineageEdges", () => {
         broken: undefined,
       },
     ]);
+  });
+
+  it("orients supported IQ and KQL relations from source to consumer", () => {
+    const items = [
+      item("eventhouse", "Eventhouse"),
+      item("database", "KQLDatabase"),
+      item("lakehouse", "Lakehouse"),
+      item("ontology", "Ontology"),
+      item("graph", "GraphModel"),
+      item("agent-a", "DataAgent"),
+      item("agent-b", "DataAgent"),
+      item("queryset", "KQLQueryset"),
+      item("dashboard", "KQLDashboard"),
+    ];
+
+    expect(
+      normalizeLineageEdges(items, [
+        { source: "database", target: "eventhouse", relation: "contains" },
+        { source: "ontology", target: "lakehouse", relation: "source" },
+        { source: "graph", target: "lakehouse", relation: "source" },
+        { source: "agent-a", target: "ontology", relation: "semantic model" },
+        { source: "agent-b", target: "graph", relation: "source" },
+        { source: "queryset", target: "database", relation: "source" },
+        { source: "dashboard", target: "database", relation: "source" },
+      ]),
+    ).toEqual([
+      {
+        source: "eventhouse",
+        target: "database",
+        relation: "database",
+        broken: undefined,
+      },
+      {
+        source: "lakehouse",
+        target: "ontology",
+        relation: "binds ontology",
+        broken: undefined,
+      },
+      {
+        source: "lakehouse",
+        target: "graph",
+        relation: "maps graph",
+        broken: undefined,
+      },
+      {
+        source: "ontology",
+        target: "agent-a",
+        relation: "grounds",
+        broken: undefined,
+      },
+      {
+        source: "graph",
+        target: "agent-b",
+        relation: "grounds",
+        broken: undefined,
+      },
+      {
+        source: "database",
+        target: "queryset",
+        relation: "queries",
+        broken: undefined,
+      },
+      {
+        source: "database",
+        target: "dashboard",
+        relation: "visualizes",
+        broken: undefined,
+      },
+    ]);
+  });
+
+  it("keeps normalized IQ and KQL relations stable without adding edges", () => {
+    const items = [
+      item("lakehouse", "Lakehouse"),
+      item("ontology", "Ontology"),
+      item("agent", "DataAgent"),
+      item("unrelated", "Report"),
+    ];
+    const input = [
+      { source: "agent", target: "ontology", relation: "uses" },
+      { source: "ontology", target: "lakehouse", relation: "source" },
+    ];
+    const once = normalizeLineageEdges(items, input);
+
+    expect(normalizeLineageEdges(items, once)).toEqual(once);
+    expect(once).toHaveLength(input.length);
+    expect(once.some((edge) => edge.source === "unrelated")).toBe(false);
   });
 });

--- a/src/atlas/lineage.ts
+++ b/src/atlas/lineage.ts
@@ -117,8 +117,13 @@ const ITEM_STAGE: Partial<Record<ItemType, number>> = {
   SQLEndpoint: 3,
   KQLDatabase: 3,
   SemanticModel: 4,
+  Ontology: 4,
+  GraphModel: 4,
   Report: 5,
   Dashboard: 5,
+  DataAgent: 5,
+  KQLQueryset: 5,
+  KQLDashboard: 5,
 };
 
 const AUTHORITATIVE_DIRECTION_RELATIONS = new Set([
@@ -554,8 +559,46 @@ export function getSchemaObjectImpactReport(
 
 export const buildSchemaObjectImpactReport = getSchemaObjectImpactReport;
 
-export function itemStage(type: ItemType): number {
-  return ITEM_STAGE[type] ?? 0;
+export function itemStage(type: ItemType | string | null | undefined): number {
+  return type ? ITEM_STAGE[type as ItemType] ?? 0 : 0;
+}
+
+const MODEL_INPUT_TYPES = new Set<ItemType>([
+  "Lakehouse",
+  "Warehouse",
+  "Eventhouse",
+  "KQLDatabase",
+  "SQLEndpoint",
+  "SQLDatabase",
+  "Datamart",
+  "MirroredDatabase",
+  "SemanticModel",
+]);
+
+function isPreferredSourceConsumerPair(source: Item, target: Item): boolean {
+  if (
+    source.itemType === "Eventhouse" &&
+    target.itemType === "KQLDatabase"
+  ) {
+    return true;
+  }
+  if (
+    MODEL_INPUT_TYPES.has(source.itemType) &&
+    (target.itemType === "Ontology" || target.itemType === "GraphModel")
+  ) {
+    return true;
+  }
+  if (
+    (source.itemType === "Ontology" || source.itemType === "GraphModel") &&
+    target.itemType === "DataAgent"
+  ) {
+    return true;
+  }
+  return (
+    source.itemType === "KQLDatabase" &&
+    (target.itemType === "KQLQueryset" ||
+      target.itemType === "KQLDashboard")
+  );
 }
 
 function normalizedRelation(source: Item, target: Item, relation: string): string {
@@ -589,6 +632,36 @@ function normalizedRelation(source: Item, target: Item, relation: string): strin
   ) {
     return "database";
   }
+  if (
+    MODEL_INPUT_TYPES.has(source.itemType) &&
+    target.itemType === "Ontology"
+  ) {
+    return "binds ontology";
+  }
+  if (
+    MODEL_INPUT_TYPES.has(source.itemType) &&
+    target.itemType === "GraphModel"
+  ) {
+    return "maps graph";
+  }
+  if (
+    (source.itemType === "Ontology" || source.itemType === "GraphModel") &&
+    target.itemType === "DataAgent"
+  ) {
+    return "grounds";
+  }
+  if (
+    source.itemType === "KQLDatabase" &&
+    target.itemType === "KQLQueryset"
+  ) {
+    return "queries";
+  }
+  if (
+    source.itemType === "KQLDatabase" &&
+    target.itemType === "KQLDashboard"
+  ) {
+    return "visualizes";
+  }
   return relation || "depends on";
 }
 
@@ -605,14 +678,23 @@ export function normalizeLineageEdges(items: Item[], edges: Edge[]): Edge[] {
     const authoritativeDirection = AUTHORITATIVE_DIRECTION_RELATIONS.has(
       edge.relation.trim().toLowerCase(),
     );
+    const preferredDirection = isPreferredSourceConsumerPair(source, target);
+    const preferredReverseDirection = isPreferredSourceConsumerPair(
+      target,
+      source,
+    );
     const reverseByStage =
+      !preferredDirection &&
+      !preferredReverseDirection &&
       !authoritativeDirection &&
       itemStage(source.itemType) > itemStage(target.itemType);
     const reversePipeline =
+      !preferredDirection &&
+      !preferredReverseDirection &&
       !authoritativeDirection &&
       source.itemType === "Notebook" &&
       target.itemType === "DataPipeline";
-    if (reverseByStage || reversePipeline) {
+    if (preferredReverseDirection || reverseByStage || reversePipeline) {
       [source, target] = [target, source];
     }
 

--- a/src/atlas/live-sync.spec.ts
+++ b/src/atlas/live-sync.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   accountMatchesIdentity,
+  buildSyncRequestBody,
   mapSyncToAtlas,
   normalizeFabricTimestamp,
   parseSyncResponseText,
@@ -30,6 +31,21 @@ function completeSync(): RawSync {
 describe("validateRawSync", () => {
   it("accepts a complete authoritative result", () => {
     expect(() => validateRawSync(completeSync(), workspaceId)).not.toThrow();
+  });
+
+  describe("sync request metadata tokens", () => {
+    it("passes available audience tokens without manufacturing missing values", () => {
+      expect(
+        buildSyncRequestBody(workspaceId, {
+          fabricToken: "fabric-token",
+          kustoToken: "kusto-token",
+        }),
+      ).toEqual({
+        workspaceId,
+        fabricToken: "fabric-token",
+        kustoToken: "kusto-token",
+      });
+    });
   });
 
   describe("sync response parsing", () => {
@@ -90,6 +106,7 @@ describe("validateRawSync", () => {
       sensitivity: { status: "complete" },
       tags: { status: "complete" },
       ownership: { status: "complete", code: "type-specific" },
+      kqlSchema: { status: "failed", code: "kusto-token-unavailable" },
     };
     raw.itemMetadata = {
       "item-1": { scannerMatched: true },
@@ -265,6 +282,7 @@ describe("validateRawSync", () => {
       sensitivity: { status: "complete" },
       tags: { status: "complete" },
       ownership: { status: "complete", code: "type-specific" },
+      kqlSchema: { status: "failed", code: "kusto-token-unavailable" },
     };
     raw.syncedAt = "2026-08-30T09:00:00";
     raw.itemMetadata = {
@@ -315,6 +333,10 @@ describe("validateRawSync", () => {
         metadataOwnership: {
           status: "complete",
           code: "type-specific",
+        },
+        metadataKqlSchema: {
+          status: "failed",
+          code: "kusto-token-unavailable",
         },
       },
     });

--- a/src/atlas/live-sync.ts
+++ b/src/atlas/live-sync.ts
@@ -6,6 +6,17 @@
 import { ATLAS_CONFIG, getUdfUrl } from "./config";
 import { normalizeLineageEdges } from "./lineage";
 import {
+  MAX_OBJECT_LINEAGE_EDGES,
+  itemMetadataFromSchema,
+  metadataItemLineageEdges,
+  metadataObjectLineageEdges,
+  parseFabricItemMetadata,
+  parseObjectLineagePayload,
+  projectItemMetadataToSchema,
+  type FabricItemMetadata,
+  type MetadataObjectLineageEdge,
+} from "./item-metadata";
+import {
   type AtlasData,
   type Item,
   type ItemType,
@@ -122,19 +133,28 @@ export function selectMsalAccount(
   );
 }
 
-function tokenForIdentity(result: MsalResult, identity: SyncIdentity): string {
+function tokenForIdentity(
+  result: MsalResult,
+  identity: SyncIdentity,
+  purpose: string,
+): string {
   if (
     !result.account ||
     !selectMsalAccount([result.account], identity, ATLAS_CONFIG.tenantId)
   ) {
     throw new Error(
-      "The Power BI sign-in did not match the current Fabric user. The previous snapshot was preserved.",
+      `The ${purpose} sign-in did not match the current Fabric user. The previous snapshot was preserved.`,
     );
   }
   return result.accessToken;
 }
 
-async function acquireToken(identity: SyncIdentity): Promise<string> {
+async function acquireToken(
+  identity: SyncIdentity,
+  scopes: string[],
+  purpose: string,
+  allowPopup: boolean,
+): Promise<string> {
   if (!identity.id && !identity.email) {
     throw new Error(
       "The current Fabric user could not be identified. The previous snapshot was preserved.",
@@ -162,7 +182,6 @@ async function acquireToken(identity: SyncIdentity): Promise<string> {
     msalInitPromise = null;
     throw error;
   }
-  const scopes = [ATLAS_CONFIG.scope];
   const account = selectMsalAccount(
     msalApp!.getAllAccounts(),
     identity,
@@ -172,8 +191,9 @@ async function acquireToken(identity: SyncIdentity): Promise<string> {
     const res = account
       ? await msalApp!.acquireTokenSilent({ scopes, account })
       : await msalApp!.ssoSilent({ scopes, loginHint: identity.email });
-    return tokenForIdentity(res, identity);
-  } catch {
+    return tokenForIdentity(res, identity, purpose);
+  } catch (error) {
+    if (!allowPopup) throw error;
     // Silent SSO can be blocked inside the Fabric iframe (3rd-party cookies);
     // force an explicit account choice rather than reusing another user's cache.
     const res = await msalApp!.acquireTokenPopup({
@@ -181,8 +201,71 @@ async function acquireToken(identity: SyncIdentity): Promise<string> {
       loginHint: identity.email,
       prompt: "select_account",
     });
-    return tokenForIdentity(res, identity);
+    return tokenForIdentity(res, identity, purpose);
   }
+}
+
+const OPTIONAL_METADATA_TOKEN_SCOPES = {
+  kustoToken: {
+    scope: "https://kusto.kusto.windows.net/.default",
+    purpose: "KQL metadata",
+  },
+  sqlToken: {
+    scope: "https://database.windows.net/.default",
+    purpose: "SQL metadata",
+  },
+  storageToken: {
+    scope: "https://storage.azure.com/.default",
+    purpose: "OneLake metadata",
+  },
+} as const;
+
+export interface SyncRequestTokens {
+  fabricToken: string;
+  kustoToken?: string;
+  sqlToken?: string;
+  storageToken?: string;
+}
+
+export function buildSyncRequestBody(
+  workspaceId: string,
+  tokens: SyncRequestTokens,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries({ workspaceId, ...tokens }).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].length > 0,
+    ),
+  );
+}
+
+async function acquireOptionalMetadataTokens(
+  identity: SyncIdentity,
+): Promise<Omit<SyncRequestTokens, "fabricToken">> {
+  const tokens: Omit<SyncRequestTokens, "fabricToken"> = {};
+  for (const [name, request] of Object.entries(
+    OPTIONAL_METADATA_TOKEN_SCOPES,
+  ) as Array<
+    [
+      keyof Omit<SyncRequestTokens, "fabricToken">,
+      (typeof OPTIONAL_METADATA_TOKEN_SCOPES)[keyof typeof OPTIONAL_METADATA_TOKEN_SCOPES],
+    ]
+  >) {
+    try {
+      tokens[name] = await acquireToken(
+        identity,
+        [request.scope],
+        request.purpose,
+        false,
+      );
+    } catch (error) {
+      console.warn(
+        `[atlas] ${request.purpose} token unavailable`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+  return tokens;
 }
 
 /* ----------------------------- UDF invoke ------------------------------ */
@@ -213,7 +296,7 @@ export interface RawSync {
     }
   >;
   capabilities?: Record<
-    "endorsement" | "sensitivity" | "tags" | "ownership",
+    string,
     {
       status?: "complete" | "unsupported" | "failed";
       code?: string;
@@ -245,8 +328,12 @@ export interface RawSync {
         id?: string;
         displayName?: string;
       }>;
+      artifactMetadata?: unknown;
     }
   >;
+  artifactMetadata?: Record<string, unknown>;
+  objectEdges?: unknown;
+  objectLineage?: unknown;
   syncedAt?: string;
   schema?: Record<
     string,
@@ -260,6 +347,7 @@ export interface RawSync {
       columns?: Array<{
         name?: string;
         dataType?: string;
+        objectType?: string;
         description?: string;
         isHidden?: boolean;
       }>;
@@ -270,6 +358,7 @@ export interface RawSync {
         description?: string;
         isHidden?: boolean;
       }>;
+      metadata?: unknown;
     }>
   >;
   errors?: string[];
@@ -678,6 +767,36 @@ export function validateRawSync(
     raw.itemMetadata,
     new Set(itemIds.filter((id): id is string => !!id)),
   );
+  const itemTypeById = new Map(
+    raw.items.map((item) => [
+      realText(item.id) ?? "",
+      realText(item.type) ?? "",
+    ]),
+  );
+  if (raw.artifactMetadata != null) {
+    if (!isRecord(raw.artifactMetadata)) {
+      throw new Error(
+        "The sync result contained invalid artifact metadata. The previous snapshot was preserved.",
+      );
+    }
+    for (const [itemId, metadata] of Object.entries(raw.artifactMetadata)) {
+      const itemType = itemTypeById.get(itemId);
+      if (!itemType || !parseFabricItemMetadata(itemType, metadata)) {
+        throw new Error(
+          "The sync result contained invalid artifact metadata. The previous snapshot was preserved.",
+        );
+      }
+    }
+  }
+  const rawObjectLineage = raw.objectEdges ?? raw.objectLineage;
+  if (
+    rawObjectLineage != null &&
+    !parseObjectLineagePayload(rawObjectLineage)
+  ) {
+    throw new Error(
+      "The sync result contained invalid object lineage. The previous snapshot was preserved.",
+    );
+  }
   if (
     raw.schemaVersion === 2 &&
     (!raw.itemMetadata ||
@@ -728,6 +847,7 @@ export function validateRawSync(
             !isRecord(column) ||
             !realText(column.name) ||
             !optionalText(column.dataType) ||
+            !optionalText(column.objectType) ||
             !optionalText(column.description) ||
             (column.isHidden != null &&
               typeof column.isHidden !== "boolean"),
@@ -773,14 +893,25 @@ export async function invokeSyncAll(
     );
   }
   const url = retargetToSyncAll(raw);
-  const token = await acquireToken(identity);
+  const fabricToken = await acquireToken(
+    identity,
+    [ATLAS_CONFIG.scope],
+    "Power BI",
+    true,
+  );
+  const metadataTokens = await acquireOptionalMetadataTokens(identity);
   const resp = await fetch(url, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${fabricToken}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ fabricToken: token, workspaceId }),
+    body: JSON.stringify(
+      buildSyncRequestBody(workspaceId, {
+        fabricToken,
+        ...metadataTokens,
+      }),
+    ),
   });
   if (!resp.ok) {
     console.warn("[atlas] UDF invocation failed", resp.status);
@@ -1090,7 +1221,7 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
     }
   }
 
-  // Real lineage is computed server-side from Fabric and Power BI identifiers.
+  // Real lineage is computed from Fabric identifiers and sanitized definitions.
   // An absent edge is safer than inferring a relationship from display names.
   const edges: Edge[] = [];
   if (Array.isArray(raw.lineage) && raw.lineage.length) {
@@ -1111,8 +1242,10 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
     }));
 
   const schema: Record<string, ModelTableSchema[]> = {};
+  const itemsById = new Map(items.map((item) => [item.fabricId, item]));
   for (const [id, tables] of Object.entries(raw.schema ?? {})) {
     if (!itemIds.has(id) || !Array.isArray(tables)) continue;
+    const item = itemsById.get(id);
     schema[id] = tables.map((t) => ({
       name: String(t.name ?? ""),
       rows: finiteRowCount(t.rows),
@@ -1123,6 +1256,7 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
       columns: (t.columns ?? []).map((c) => ({
         name: String(c.name ?? ""),
         dataType: String(c.dataType ?? "column"),
+        objectType: c.objectType,
         description: c.description,
         isHidden: c.isHidden,
       })),
@@ -1132,8 +1266,79 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
         description: m.description,
         isHidden: m.isHidden,
       })),
+      metadata:
+        item && t.metadata != null
+          ? parseFabricItemMetadata(item.itemType, t.metadata)
+          : undefined,
     }));
   }
+
+  const itemMetadata: Record<string, FabricItemMetadata> = {};
+  const derivedObjectEdges: MetadataObjectLineageEdge[] = [];
+  for (const item of items) {
+    const nestedMetadata =
+      raw.itemMetadata?.[item.fabricId]?.artifactMetadata;
+    const rawMetadata =
+      raw.artifactMetadata?.[item.fabricId] ?? nestedMetadata;
+    const metadata =
+      rawMetadata != null
+        ? parseFabricItemMetadata(item.itemType, rawMetadata)
+        : itemMetadataFromSchema(item.itemType, schema[item.fabricId]);
+    if (!metadata) continue;
+    itemMetadata[item.fabricId] = metadata;
+    const existing = schema[item.fabricId] ?? [];
+    const merged = new Map(
+      existing.map((table) => [
+        `${table.name}\u0000${table.objectType ?? ""}`,
+        table,
+      ]),
+    );
+    for (const table of projectItemMetadataToSchema(metadata)) {
+      merged.set(`${table.name}\u0000${table.objectType ?? ""}`, table);
+    }
+    schema[item.fabricId] = [...merged.values()];
+    edges.push(
+      ...metadataItemLineageEdges(item.fabricId, metadata).filter(
+        (edge) => itemIds.has(edge.source) && itemIds.has(edge.target),
+      ),
+    );
+    derivedObjectEdges.push(
+      ...metadataObjectLineageEdges(item.fabricId, metadata),
+    );
+  }
+  const suppliedObjectEdges =
+    parseObjectLineagePayload(raw.objectEdges ?? raw.objectLineage)
+      ?.objectEdges ?? [];
+  const allObjectEdges = [...suppliedObjectEdges, ...derivedObjectEdges]
+    .sort((left, right) =>
+      [
+        left.source.itemId,
+        left.source.kind,
+        left.source.id,
+        left.target.itemId,
+        left.target.kind,
+        left.target.id,
+        left.relation,
+      ]
+        .join("\u0000")
+        .localeCompare(
+          [
+            right.source.itemId,
+            right.source.kind,
+            right.source.id,
+            right.target.itemId,
+            right.target.kind,
+            right.target.id,
+            right.relation,
+          ].join("\u0000"),
+        ),
+    )
+    .filter(
+      (edge, index, values) =>
+        index === 0 ||
+        JSON.stringify(edge) !== JSON.stringify(values[index - 1]),
+    );
+  const objectEdges = allObjectEdges.slice(0, MAX_OBJECT_LINEAGE_EDGES);
 
   const ws = (raw.workspace ?? {}) as Record<string, unknown>;
   const workspace: WorkspaceInfo = {
@@ -1150,6 +1355,14 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
           status,
         ]),
       ),
+      ...(allObjectEdges.length > objectEdges.length
+        ? {
+            metadataObjectLineage: {
+              status: "failed" as const,
+              code: "object-edge-limit",
+            },
+          }
+        : {}),
     },
   };
 
@@ -1162,6 +1375,8 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
     jobs,
     config,
     schema,
+    itemMetadata,
+    objectEdges,
     comments: [],
     syncRuns: [],
   };

--- a/src/atlas/live-sync.ts
+++ b/src/atlas/live-sync.ts
@@ -207,18 +207,24 @@ async function acquireToken(
 
 const OPTIONAL_METADATA_TOKEN_SCOPES = {
   kustoToken: {
-    scope: "https://kusto.kusto.windows.net/.default",
+    scope: "https://kusto.kusto.windows.net/user_impersonation",
     purpose: "KQL metadata",
   },
   sqlToken: {
-    scope: "https://database.windows.net/.default",
+    scope: "https://database.windows.net/user_impersonation",
     purpose: "SQL metadata",
   },
-  storageToken: {
-    scope: "https://storage.azure.com/.default",
-    purpose: "OneLake metadata",
-  },
 } as const;
+
+const FABRIC_DISCOVERY_SCOPES = [
+  "https://analysis.windows.net/powerbi/api/UserDataFunction.Execute.All",
+  "https://analysis.windows.net/powerbi/api/Workspace.Read.All",
+  "https://analysis.windows.net/powerbi/api/Item.Read.All",
+  "https://analysis.windows.net/powerbi/api/Item.ReadWrite.All",
+  "https://analysis.windows.net/powerbi/api/Dataset.Read.All",
+  "https://analysis.windows.net/powerbi/api/Report.Read.All",
+  "https://analysis.windows.net/powerbi/api/Tenant.Read.All",
+];
 
 export interface SyncRequestTokens {
   fabricToken: string;
@@ -256,7 +262,7 @@ async function acquireOptionalMetadataTokens(
         identity,
         [request.scope],
         request.purpose,
-        false,
+        true,
       );
     } catch (error) {
       console.warn(
@@ -264,8 +270,33 @@ async function acquireOptionalMetadataTokens(
         error instanceof Error ? error.message : String(error),
       );
     }
+
   }
   return tokens;
+}
+
+async function acquireFabricSyncToken(
+  identity: SyncIdentity,
+): Promise<string> {
+  try {
+    return await acquireToken(
+      identity,
+      FABRIC_DISCOVERY_SCOPES,
+      "Fabric metadata",
+      true,
+    );
+  } catch (error) {
+    console.warn(
+      "[atlas] advanced Fabric definition permission unavailable; using the standard metadata scope",
+      error instanceof Error ? error.message : String(error),
+    );
+    return acquireToken(
+      identity,
+      [ATLAS_CONFIG.scope],
+      "Power BI",
+      true,
+    );
+  }
 }
 
 /* ----------------------------- UDF invoke ------------------------------ */
@@ -893,12 +924,7 @@ export async function invokeSyncAll(
     );
   }
   const url = retargetToSyncAll(raw);
-  const fabricToken = await acquireToken(
-    identity,
-    [ATLAS_CONFIG.scope],
-    "Power BI",
-    true,
-  );
+  const fabricToken = await acquireFabricSyncToken(identity);
   const metadataTokens = await acquireOptionalMetadataTokens(identity);
   const resp = await fetch(url, {
     method: "POST",

--- a/src/atlas/map-inspector.spec.ts
+++ b/src/atlas/map-inspector.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAP_INSPECTOR_MAX_WIDTH,
+  MAP_INSPECTOR_MIN_WIDTH,
+  clampMapInspectorWidth,
+  isMapInspectorWidth,
+  mapInspectorMaxWidth,
+} from "./map-inspector";
+
+describe("map inspector sizing", () => {
+  it("validates only supported persisted widths", () => {
+    expect(isMapInspectorWidth(MAP_INSPECTOR_MIN_WIDTH)).toBe(true);
+    expect(isMapInspectorWidth(MAP_INSPECTOR_MAX_WIDTH)).toBe(true);
+    expect(isMapInspectorWidth(MAP_INSPECTOR_MIN_WIDTH - 1)).toBe(false);
+    expect(isMapInspectorWidth(MAP_INSPECTOR_MAX_WIDTH + 1)).toBe(false);
+    expect(isMapInspectorWidth("360")).toBe(false);
+  });
+
+  it("preserves useful graph space when the viewport narrows", () => {
+    expect(mapInspectorMaxWidth(1600)).toBe(MAP_INSPECTOR_MAX_WIDTH);
+    expect(mapInspectorMaxWidth(1100)).toBe(620);
+    expect(mapInspectorMaxWidth(600)).toBe(MAP_INSPECTOR_MIN_WIDTH);
+    expect(clampMapInspectorWidth(700, 1100)).toBe(620);
+    expect(clampMapInspectorWidth(200, 1600)).toBe(MAP_INSPECTOR_MIN_WIDTH);
+  });
+});

--- a/src/atlas/map-inspector.ts
+++ b/src/atlas/map-inspector.ts
@@ -1,0 +1,30 @@
+export const MAP_INSPECTOR_DEFAULT_WIDTH = 360;
+export const MAP_INSPECTOR_MIN_WIDTH = 320;
+export const MAP_INSPECTOR_MAX_WIDTH = 760;
+export const MAP_INSPECTOR_KEYBOARD_STEP = 16;
+
+const MAP_MIN_CANVAS_WIDTH = 480;
+
+export const isMapInspectorWidth = (value: unknown): value is number =>
+  typeof value === "number" &&
+  Number.isFinite(value) &&
+  value >= MAP_INSPECTOR_MIN_WIDTH &&
+  value <= MAP_INSPECTOR_MAX_WIDTH;
+
+export function mapInspectorMaxWidth(viewportWidth: number): number {
+  if (!Number.isFinite(viewportWidth)) return MAP_INSPECTOR_MAX_WIDTH;
+  return Math.min(
+    MAP_INSPECTOR_MAX_WIDTH,
+    Math.max(MAP_INSPECTOR_MIN_WIDTH, Math.floor(viewportWidth - MAP_MIN_CANVAS_WIDTH)),
+  );
+}
+
+export function clampMapInspectorWidth(
+  width: number,
+  viewportWidth: number,
+): number {
+  return Math.min(
+    mapInspectorMaxWidth(viewportWidth),
+    Math.max(MAP_INSPECTOR_MIN_WIDTH, Math.round(width)),
+  );
+}

--- a/src/atlas/metadata-object-graph.ts
+++ b/src/atlas/metadata-object-graph.ts
@@ -1,0 +1,233 @@
+import {
+  metadataObjectKindLabel,
+  metadataObjectRefKey,
+  verifiedMetadataEdgesForItem,
+} from "./catalog-objects";
+import type {
+  MetadataObjectKind,
+  MetadataObjectLineageEdge,
+  MetadataObjectRef,
+} from "./item-metadata";
+import type { Item } from "./model";
+
+const OBJECT_ROW_GAP = 100;
+export const MAX_VISIBLE_OBJECT_EDGES = 250;
+
+export interface ObjectGraphNode {
+  id: string;
+  label: string;
+  subtitle: string;
+  code: string;
+  color: string;
+  table?: string;
+  itemId?: string;
+  kind: "source" | "table" | "field" | "owner" | "consumer" | "metadata";
+  metadataRef?: MetadataObjectRef;
+  x: number;
+  y: number;
+}
+
+export interface ObjectGraphEdge {
+  source: string;
+  target: string;
+  relation: string;
+  structural?: boolean;
+}
+
+export interface ObjectGraph {
+  nodes: ObjectGraphNode[];
+  edges: ObjectGraphEdge[];
+  width: number;
+  height: number;
+  table?: string;
+  stageLabels: string[];
+  verifiedMetadata: boolean;
+  truncated: boolean;
+}
+
+export interface MetadataObjectGraphFilters {
+  query?: string;
+  sourceItemId?: string;
+  tableName?: string;
+  objectKind?: MetadataObjectKind | "all";
+}
+
+function metadataNodeStyle(kind: MetadataObjectKind): {
+  code: string;
+  color: string;
+} {
+  if (kind === "sourceObject" || kind === "sourceElement") {
+    return { code: "SO", color: "var(--color-object-source)" };
+  }
+  if (kind === "sourceField") {
+    return { code: "SF", color: "var(--color-object-column)" };
+  }
+  if (kind === "ontologyRelationship" || kind === "graphEdge") {
+    return { code: "RL", color: "var(--color-lineage-downstream)" };
+  }
+  if (
+    kind === "ontologyProperty" ||
+    kind === "graphProperty" ||
+    kind === "dataAgentElement"
+  ) {
+    return { code: "PR", color: "var(--color-object-column)" };
+  }
+  if (kind === "dataAgentSource") {
+    return { code: "DA", color: "var(--color-primary)" };
+  }
+  if (kind === "kqlFunction") {
+    return { code: "FN", color: "var(--color-primary)" };
+  }
+  if (kind === "kqlMaterializedView") {
+    return { code: "MV", color: "var(--color-lineage-upstream)" };
+  }
+  if (kind === "graphNode") {
+    return { code: "GN", color: "var(--color-primary)" };
+  }
+  if (kind === "ontologyContextualization") {
+    return { code: "CX", color: "var(--color-status-warning)" };
+  }
+  return { code: "EN", color: "var(--color-primary)" };
+}
+
+export function buildMetadataObjectGraph(
+  edges: readonly MetadataObjectLineageEdge[],
+  selectedItemId: string,
+  itemById: ReadonlyMap<string, Item>,
+  filters: MetadataObjectGraphFilters = {},
+): ObjectGraph {
+  const selectedEdges = verifiedMetadataEdgesForItem(edges, selectedItemId);
+  const query = filters.query?.trim().toLowerCase() ?? "";
+  const sourceItemId = filters.sourceItemId ?? "all";
+  const tableName = filters.tableName ?? "all";
+  const objectKind = filters.objectKind ?? "all";
+  const queryMatches = (reference: MetadataObjectRef) =>
+    !query ||
+    reference.name.toLowerCase().includes(query) ||
+    reference.id.toLowerCase().includes(query) ||
+    metadataObjectKindLabel(reference.kind).toLowerCase().includes(query) ||
+    (reference.tableName ?? "").toLowerCase().includes(query) ||
+    (reference.parentPath ?? []).some((part) =>
+      part.toLowerCase().includes(query),
+    );
+  const filtered = selectedEdges.filter((edge) => {
+    const refs = [edge.source, edge.target];
+    return (
+      (sourceItemId === "all" ||
+        refs.some((reference) => reference.itemId === sourceItemId)) &&
+      (tableName === "all" ||
+        refs.some((reference) => reference.tableName === tableName)) &&
+      (objectKind === "all" ||
+        refs.some((reference) => reference.kind === objectKind)) &&
+      (!query || refs.some(queryMatches))
+    );
+  });
+  const ordered = [...filtered].sort((left, right) =>
+    [
+      metadataObjectRefKey(left.source),
+      metadataObjectRefKey(left.target),
+      left.relation,
+    ]
+      .join("\u0001")
+      .localeCompare(
+        [
+          metadataObjectRefKey(right.source),
+          metadataObjectRefKey(right.target),
+          right.relation,
+        ].join("\u0001"),
+      ),
+  );
+  const visibleEdges = ordered.slice(0, MAX_VISIBLE_OBJECT_EDGES);
+  const refs = new Map<string, MetadataObjectRef>();
+  const graphEdges: ObjectGraphEdge[] = [];
+  for (const edge of visibleEdges) {
+    const source = metadataObjectRefKey(edge.source);
+    const target = metadataObjectRefKey(edge.target);
+    refs.set(source, edge.source);
+    refs.set(target, edge.target);
+    graphEdges.push({ source, target, relation: edge.relation });
+  }
+
+  const incomingCount = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  for (const id of refs.keys()) incomingCount.set(id, 0);
+  for (const edge of graphEdges) {
+    outgoing.set(edge.source, [
+      ...(outgoing.get(edge.source) ?? []),
+      edge.target,
+    ]);
+    incomingCount.set(edge.target, (incomingCount.get(edge.target) ?? 0) + 1);
+  }
+  const rank = new Map<string, number>();
+  const queue = [...refs.keys()]
+    .filter((id) => (incomingCount.get(id) ?? 0) === 0)
+    .sort();
+  for (const id of queue) rank.set(id, 0);
+  for (let head = 0; head < queue.length; head += 1) {
+    const current = queue[head];
+    for (const target of [...(outgoing.get(current) ?? [])].sort()) {
+      rank.set(
+        target,
+        Math.max(rank.get(target) ?? 0, (rank.get(current) ?? 0) + 1),
+      );
+      incomingCount.set(target, (incomingCount.get(target) ?? 1) - 1);
+      if (incomingCount.get(target) === 0) queue.push(target);
+    }
+  }
+  for (const id of refs.keys()) {
+    if (!rank.has(id)) rank.set(id, 0);
+  }
+  const byRank = new Map<number, string[]>();
+  for (const id of refs.keys()) {
+    const value = rank.get(id) ?? 0;
+    byRank.set(value, [...(byRank.get(value) ?? []), id]);
+  }
+  for (const ids of byRank.values()) ids.sort();
+  const maxRank = Math.max(0, ...rank.values());
+  const nodes = [...refs.entries()].map(([id, reference]) => {
+    const column = rank.get(id) ?? 0;
+    const row = byRank.get(column)?.indexOf(id) ?? 0;
+    const style = metadataNodeStyle(reference.kind);
+    const context = [
+      metadataObjectKindLabel(reference.kind),
+      reference.tableName,
+      itemById.get(reference.itemId)?.displayName ?? reference.itemId,
+    ].filter(Boolean);
+    return {
+      id,
+      label: reference.name,
+      subtitle: context.join(" · "),
+      code: style.code,
+      color: style.color,
+      table: reference.tableName,
+      itemId: reference.itemId,
+      kind: "metadata" as const,
+      metadataRef: reference,
+      x: 24 + column * 282,
+      y: 58 + row * OBJECT_ROW_GAP,
+    };
+  });
+  const maxRows = Math.max(
+    1,
+    ...[...byRank.values()].map((ids) => ids.length),
+  );
+  const defaultLabels = [
+    "Physical sources",
+    "Bindings and fields",
+    "Discovered objects",
+    "Consumers",
+  ];
+  return {
+    nodes,
+    edges: graphEdges,
+    width: Math.max(1080, 48 + (maxRank + 1) * 282),
+    height: Math.max(520, 110 + maxRows * OBJECT_ROW_GAP),
+    table: tableName === "all" ? undefined : tableName,
+    stageLabels: Array.from(
+      { length: maxRank + 1 },
+      (_, index) => defaultLabels[index] ?? `Stage ${index + 1}`,
+    ),
+    verifiedMetadata: selectedEdges.length > 0,
+    truncated: ordered.length > visibleEdges.length,
+  };
+}

--- a/src/atlas/model.spec.ts
+++ b/src/atlas/model.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { ITEM_TYPES, typeMeta } from "./model";
+
+describe("item type metadata", () => {
+  it("defines the newer Fabric discovery item types", () => {
+    expect(ITEM_TYPES.Ontology).toMatchObject({
+      label: "Ontology",
+      code: "ON",
+    });
+    expect(ITEM_TYPES.GraphModel).toMatchObject({
+      label: "Graph model",
+      code: "GM",
+    });
+    expect(ITEM_TYPES.DataAgent).toMatchObject({
+      label: "Data agent",
+      code: "DA",
+    });
+    expect(ITEM_TYPES.KQLQueryset).toMatchObject({
+      label: "KQL queryset",
+      code: "QS",
+    });
+    expect(ITEM_TYPES.KQLDashboard).toMatchObject({
+      label: "KQL dashboard",
+      code: "KD",
+    });
+  });
+
+  it("renders unknown forward-compatible item types with neutral metadata", () => {
+    expect(typeMeta("FutureFabricArtifact")).toEqual({
+      label: "FutureFabricArtifact",
+      code: "··",
+      color: "#8b95a5",
+      icon: "Box",
+    });
+    expect(typeMeta(undefined).label).toBe("Item");
+  });
+});

--- a/src/atlas/model.ts
+++ b/src/atlas/model.ts
@@ -4,11 +4,19 @@
 // app is deployed and a live Sync runs, these shapes are replaced by the real
 // workspace read from the Fabric APIs.
 
+import {
+  ITEM_METADATA_SCHEMA_NAME,
+  type FabricItemMetadata,
+  type MetadataObjectLineageEdge,
+} from "./item-metadata";
+
 export type ItemType =
   | "Lakehouse"
   | "Warehouse"
   | "Eventhouse"
   | "KQLDatabase"
+  | "KQLQueryset"
+  | "KQLDashboard"
   | "SQLEndpoint"
   | "SQLDatabase"
   | "Notebook"
@@ -20,6 +28,9 @@ export type ItemType =
   | "Dashboard"
   | "Eventstream"
   | "MirroredDatabase"
+  | "Ontology"
+  | "GraphModel"
+  | "DataAgent"
   | "UserDataFunction"
   | "AppBackend";
 
@@ -48,6 +59,8 @@ export const ITEM_TYPES: Record<ItemType, TypeMeta> = {
   Warehouse: { label: "Warehouse", code: "DW", color: "#3b82f6", icon: "Warehouse" },
   Eventhouse: { label: "Eventhouse", code: "EH", color: "#0ea5b7", icon: "Zap" },
   KQLDatabase: { label: "KQL Database", code: "KQ", color: "#14b8a6", icon: "Table2" },
+  KQLQueryset: { label: "KQL queryset", code: "QS", color: "#0d9488", icon: "Braces" },
+  KQLDashboard: { label: "KQL dashboard", code: "KD", color: "#f59e0b", icon: "LayoutDashboard" },
   SQLEndpoint: { label: "SQL endpoint", code: "SE", color: "#0f6cbd", icon: "Table2" },
   Notebook: { label: "Notebook", code: "NB", color: "#ef7a45", icon: "NotebookText" },
   DataPipeline: { label: "Data pipeline", code: "PL", color: "#7c5cff", icon: "Workflow" },
@@ -59,6 +72,9 @@ export const ITEM_TYPES: Record<ItemType, TypeMeta> = {
   SQLDatabase: { label: "SQL database", code: "DB", color: "#2563eb", icon: "Database" },
   Eventstream: { label: "Eventstream", code: "ES", color: "#06b6d4", icon: "Radio" },
   MirroredDatabase: { label: "Mirrored DB", code: "MD", color: "#8b5cf6", icon: "Copy" },
+  Ontology: { label: "Ontology", code: "ON", color: "#0f766e", icon: "Network" },
+  GraphModel: { label: "Graph model", code: "GM", color: "#7c3aed", icon: "Waypoints" },
+  DataAgent: { label: "Data agent", code: "DA", color: "#4f46e5", icon: "Bot" },
   UserDataFunction: { label: "User data function", code: "Fn", color: "#64748b", icon: "FunctionSquare" },
   AppBackend: { label: "Fabric app", code: "AP", color: "#0ea5b7", icon: "AppWindow" },
 };
@@ -198,6 +214,8 @@ export interface AtlasData {
   // id, populated by live Fabric/Power BI metadata. Report pages stay in config
   // because the Asset Catalog's schema shape is intentionally tabular.
   schema?: Record<string, ModelTableSchema[]>;
+  itemMetadata?: Record<string, FabricItemMetadata>;
+  objectEdges?: MetadataObjectLineageEdge[];
 }
 
 // ---------- helpers ----------
@@ -261,6 +279,7 @@ const KQL_EVENTS = "10000000-0000-4000-8000-000000000014";
 export interface ModelColumn {
   name: string;
   dataType: string;
+  objectType?: string;
   description?: string;
   isHidden?: boolean;
 }
@@ -279,6 +298,7 @@ export interface ModelTableSchema {
   isHidden?: boolean;
   columns: ModelColumn[];
   measures: ModelMeasure[];
+  metadata?: FabricItemMetadata;
 }
 
 const AR_TABLES: ModelTableSchema[] = [
@@ -404,7 +424,8 @@ export function schemaFor(
   data: { schema?: Record<string, ModelTableSchema[]> },
   id: string,
 ): ModelTableSchema[] | undefined {
-  return data.schema?.[id] ?? MODEL_SCHEMA[id];
+  const tables = data.schema?.[id] ?? MODEL_SCHEMA[id];
+  return tables?.filter((table) => table.name !== ITEM_METADATA_SCHEMA_NAME);
 }
 
 export const SAMPLE_DATA: AtlasData = {

--- a/src/atlas/navigation.spec.ts
+++ b/src/atlas/navigation.spec.ts
@@ -45,6 +45,33 @@ describe("Atlas navigation", () => {
     });
   });
 
+  it("maps discovered metadata objects to their exact catalog identity", () => {
+    expect(
+      navigationForSearch(
+        result(
+          {
+            kind: "item",
+            itemId: "ontology",
+            tableName: "Device",
+            objectName: "Device ID",
+            objectId: "device/device-id",
+            objectKind: "ontologyProperty",
+          },
+          "Device ID",
+        ),
+      ),
+    ).toMatchObject({
+      tab: "assets",
+      focus: {
+        itemId: "ontology",
+        tableName: "Device",
+        objectName: "Device ID",
+        objectId: "device/device-id",
+        objectKind: "ontologyProperty",
+      },
+    });
+  });
+
   it("opens comments in Workspace Hub notes", () => {
     expect(
       navigationForSearch(

--- a/src/atlas/navigation.ts
+++ b/src/atlas/navigation.ts
@@ -1,5 +1,6 @@
 import type { SavedViewFilters, SavedViewSection } from "./saved-views";
-import type { SearchResult, SearchTarget } from "./search";
+import type { SearchResult } from "./search";
+import type { AssetObjectKind } from "./catalog-objects";
 
 export type Tab =
   | "overview"
@@ -27,7 +28,8 @@ export interface AtlasFocusRequest {
   jobId?: string;
   tableName?: string;
   objectName?: string;
-  objectKind?: SearchTarget["kind"];
+  objectId?: string;
+  objectKind?: AssetObjectKind;
   workspaceSection?: "configuration" | "notes";
   governanceSection?: GovernanceSection;
   query?: string;
@@ -47,6 +49,19 @@ function request(
 
 export function navigationForSearch(result: SearchResult): AtlasNavigation {
   const target = result.target;
+  if (target.objectKind) {
+    return {
+      tab: "assets",
+      focus: request({
+        itemId: target.itemId,
+        tableName: target.tableName,
+        objectName: target.objectName ?? result.title,
+        objectId: target.objectId,
+        objectKind: target.objectKind,
+        query: result.title,
+      }),
+    };
+  }
   switch (target.kind) {
     case "workspace":
       return { tab: "overview" };
@@ -65,7 +80,7 @@ export function navigationForSearch(result: SearchResult): AtlasNavigation {
           itemId: target.itemId,
           tableName: target.tableName,
           objectName: target.objectName ?? result.title,
-          objectKind: target.kind,
+          objectKind: target.kind as AssetObjectKind,
           query: result.title,
         }),
       };

--- a/src/atlas/posture.spec.ts
+++ b/src/atlas/posture.spec.ts
@@ -1,10 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { snapshotCatalogFromData } from "./history";
 import { SAMPLE_DATA } from "./model";
-import { scorePosture } from "./posture";
+import { POSTURE_TARGETS, scorePosture } from "./posture";
 import type { SnapshotCatalog } from "./history";
 
 describe("scorePosture", () => {
+  it("defaults all six governance pillars to 70 percent", () => {
+    expect(Object.keys(POSTURE_TARGETS)).toHaveLength(6);
+    expect(Object.values(POSTURE_TARGETS)).toEqual([
+      70,
+      70,
+      70,
+      70,
+      70,
+      70,
+    ]);
+  });
+
   it("excludes not-applicable metrics instead of counting zero", () => {
     const catalog = snapshotCatalogFromData(structuredClone(SAMPLE_DATA));
     catalog.schema = {};

--- a/src/atlas/posture.ts
+++ b/src/atlas/posture.ts
@@ -32,16 +32,7 @@ export interface PostureScore {
 }
 
 export const POSTURE_ALGORITHM_VERSION = 1;
-export const POSTURE_TARGETS: Record<PosturePillar, number> = {
-  documentation: 80,
-  ownership: 95,
-  sensitivity: 90,
-  access: 90,
-  lineage: 95,
-  operations: 95,
-};
-
-const PILLAR_ORDER: PosturePillar[] = [
+export const POSTURE_PILLARS: readonly PosturePillar[] = [
   "documentation",
   "ownership",
   "sensitivity",
@@ -49,6 +40,17 @@ const PILLAR_ORDER: PosturePillar[] = [
   "lineage",
   "operations",
 ];
+export const DEFAULT_POSTURE_TARGETS = {
+  documentation: 70,
+  ownership: 70,
+  sensitivity: 70,
+  access: 70,
+  lineage: 70,
+  operations: 70,
+} as const satisfies Record<PosturePillar, number>;
+export const POSTURE_TARGETS: Record<PosturePillar, number> = {
+  ...DEFAULT_POSTURE_TARGETS,
+};
 const DOCUMENTATION_WEIGHTS: Partial<Record<CoverageMetricId, number>> = {
   descriptions: 25,
   endorsement: 10,
@@ -179,7 +181,7 @@ export function scorePosture(
       category: "operations",
     },
   ];
-  const pillars = PILLAR_ORDER.map((pillar) => {
+  const pillars = POSTURE_PILLARS.map((pillar) => {
     const definition = definitions.find((value) => value.pillar === pillar)!;
     return {
       pillar,

--- a/src/atlas/posture.ts
+++ b/src/atlas/posture.ts
@@ -69,11 +69,13 @@ const SEVERITY_WEIGHT: Record<GovernanceSeverity, number> = {
 const SCHEMA_CAPABLE_TYPES = new Set<Item["itemType"]>([
   "Lakehouse",
   "Warehouse",
-  "Eventhouse",
   "KQLDatabase",
   "SQLEndpoint",
   "SQLDatabase",
   "SemanticModel",
+  "Ontology",
+  "GraphModel",
+  "DataAgent",
 ]);
 
 function clamp(value: number, minimum = 0, maximum = 100): number {

--- a/src/atlas/routing.spec.ts
+++ b/src/atlas/routing.spec.ts
@@ -118,6 +118,39 @@ describe("Atlas routing", () => {
     });
   });
 
+  it("round-trips new object kinds and stable object IDs", () => {
+    const url = urlForNavigation(
+      { pathname: "/", search: "?ctid=tenant" },
+      {
+        tab: "assets",
+        focus: {
+          requestId: "ignored",
+          itemId: "graph",
+          tableName: "Device",
+          objectName: "Device ID",
+          objectId: "Device/DeviceId",
+          objectKind: "graphProperty",
+          filters: { kind: "graphProperty" },
+        },
+      },
+    );
+
+    expect(
+      parseAtlasLocation({
+        hash: "#assets",
+        search: url.slice(url.indexOf("?"), url.indexOf("#")),
+      }),
+    ).toMatchObject({
+      tab: "assets",
+      focus: {
+        itemId: "graph",
+        objectId: "Device/DeviceId",
+        objectKind: "graphProperty",
+        filters: { kind: "graphProperty" },
+      },
+    });
+  });
+
   it("round-trips posture filters", () => {
     const url = urlForNavigation(
       { pathname: "/", search: "" },

--- a/src/atlas/routing.ts
+++ b/src/atlas/routing.ts
@@ -6,6 +6,7 @@ import type {
 } from "./navigation";
 import type { SavedViewFilters } from "./saved-views";
 import { ITEM_TYPES } from "./model";
+import { ASSET_OBJECT_KINDS } from "./catalog-objects";
 
 interface AtlasLocation {
   hash: string;
@@ -33,6 +34,8 @@ const KNOWN_KEYS = new Set([
   "health",
   "impact",
   "table",
+  "source",
+  "objectKind",
   "inspector",
 ]);
 const KNOWN_PREFIXES = [
@@ -43,7 +46,7 @@ const KNOWN_PREFIXES = [
   "jobs.",
   "workspace.",
 ];
-const ASSET_KINDS = new Set(["table", "view", "column", "measure"]);
+const ASSET_KINDS = new Set<string>(ASSET_OBJECT_KINDS);
 const GOVERNANCE_SECTIONS = new Set([
   "findings",
   "changes",
@@ -177,6 +180,8 @@ export function parseAtlasLocation(
       "health",
       "impact",
       "table",
+      "source",
+      "objectKind",
       "inspector",
     ].some((key) => params.has(key));
     return {
@@ -223,6 +228,7 @@ export function parseAtlasLocation(
         itemId: value(params, "assets.item"),
         tableName: value(params, "assets.table"),
         objectName,
+        objectId: value(params, "assets.objectId"),
         objectKind: objectName
           ? (objectKind as AtlasFocusRequest["objectKind"] | undefined)
           : undefined,
@@ -383,6 +389,7 @@ export function urlForNavigation(
     set(params, "assets.item", focus?.itemId);
     set(params, "assets.table", focus?.tableName);
     set(params, "assets.object", focus?.objectName);
+    set(params, "assets.objectId", focus?.objectId);
   } else if (navigation.tab === "governance") {
     set(
       params,

--- a/src/atlas/search.spec.ts
+++ b/src/atlas/search.spec.ts
@@ -5,6 +5,10 @@ import {
   searchAtlas,
   searchIndex,
 } from "./search";
+import {
+  parseKqlDatabaseMetadata,
+  parseOntologyMetadata,
+} from "./item-metadata";
 import type { AtlasData } from "./model";
 
 function data(): AtlasData {
@@ -186,5 +190,68 @@ describe("global search", () => {
     expect(kinds).not.toEqual(
       expect.arrayContaining(["table", "view", "column", "measure"]),
     );
+  });
+
+  it("indexes new object kinds with exact Asset Catalog targets", () => {
+    const value = data();
+    value.items.push(
+      {
+        fabricId: "ontology",
+        displayName: "Operations ontology",
+        itemType: "Ontology",
+        health: "healthy",
+        endorsement: "none",
+        tags: [],
+      },
+      {
+        fabricId: "telemetry",
+        displayName: "Telemetry database",
+        itemType: "KQLDatabase",
+        health: "healthy",
+        endorsement: "none",
+        tags: [],
+      },
+    );
+    value.itemMetadata = {
+      ontology: parseOntologyMetadata({
+        entities: [
+          {
+            id: "device",
+            name: "Device",
+            properties: [
+              { id: "device-id", name: "Device ID", valueType: "String" },
+            ],
+          },
+        ],
+        relationships: [],
+        bindings: [],
+        contextualizations: [],
+      })!,
+      telemetry: parseKqlDatabaseMetadata({
+        functions: [
+          {
+            name: "RecentDevices",
+            parameters: [{ name: "window", type: "timespan" }],
+          },
+        ],
+        materializedViews: [],
+      })!,
+    };
+
+    expect(searchAtlas(value, "Device ID")[0]).toMatchObject({
+      target: {
+        itemId: "ontology",
+        objectId: "device/device-id",
+        objectKind: "ontologyProperty",
+        tableName: "Device",
+      },
+    });
+    expect(searchAtlas(value, "RecentDevices")[0]).toMatchObject({
+      target: {
+        itemId: "telemetry",
+        objectId: "RecentDevices",
+        objectKind: "kqlFunction",
+      },
+    });
   });
 });

--- a/src/atlas/search.ts
+++ b/src/atlas/search.ts
@@ -1,4 +1,10 @@
-import type { AtlasData, ModelTableSchema } from "./model";
+import {
+  assetObjectKindLabel,
+  buildCatalogObjects,
+  type AssetObjectKind,
+  type CatalogObject,
+} from "./catalog-objects";
+import type { AtlasData } from "./model";
 
 export type SearchTargetKind =
   | "workspace"
@@ -22,6 +28,8 @@ export interface SearchTarget {
   section?: string;
   tableName?: string;
   objectName?: string;
+  objectId?: string;
+  objectKind?: AssetObjectKind;
 }
 
 export interface SearchIndexEntry {
@@ -96,10 +104,30 @@ function entry(
   };
 }
 
-function tableKind(table: ModelTableSchema): "table" | "view" {
-  return normalizeSearchText(table.objectType ?? "") === "view"
-    ? "view"
-    : "table";
+function searchKindForObject(object: CatalogObject): SearchTargetKind {
+  if (object.kind === "view" || object.kind === "sqlView") return "view";
+  if (
+    object.kind === "table" ||
+    object.kind === "sqlTable" ||
+    object.kind === "kqlTable" ||
+    object.kind === "kqlMaterializedView"
+  ) {
+    return "table";
+  }
+  if (
+    object.kind === "column" ||
+    object.kind === "sqlColumn" ||
+    object.kind === "kqlColumn" ||
+    object.kind === "kqlFunctionParameter" ||
+    object.kind === "ontologyProperty" ||
+    object.kind === "ontologyTimeSeriesProperty" ||
+    object.kind === "graphProperty" ||
+    object.kind === "dataAgentElement"
+  ) {
+    return "column";
+  }
+  if (object.kind === "measure") return "measure";
+  return "item";
 }
 
 export function searchJobId(
@@ -168,90 +196,39 @@ export function buildSearchIndex(data: AtlasData): SearchIndexEntry[] {
     );
   }
 
-  const schemaEntries = Object.entries(data.schema ?? {}).sort(
-    ([left], [right]) => compareText(left, right),
-  );
-  for (const [itemId, itemSchema] of schemaEntries) {
-    const item = data.items.find((candidate) => candidate.fabricId === itemId);
-    const itemName = item?.displayName ?? itemId;
-    for (const table of itemSchema) {
-      const kind = tableKind(table);
-      const tableId = [
-        "schema",
-        stablePart(itemId),
+  for (const object of buildCatalogObjects(data)) {
+    const kind = searchKindForObject(object);
+    const label = assetObjectKindLabel(object.kind);
+    entries.push(
+      entry(
+        `asset:${object.id}`,
         kind,
-        stablePart(table.name),
-      ].join(":");
-      entries.push(
-        entry(
-          tableId,
+        object.name,
+        `${label}${object.parentName ? ` in ${object.parentName}` : ""} · ${object.itemName}`,
+        {
           kind,
-          table.name,
-          `${kind === "view" ? "View" : "Table"} in ${itemName}`,
-          {
-            kind,
-            itemId,
-            tableName: table.name,
-          },
-          [
-            itemName,
-            item?.itemType,
-            table.description,
-            table.objectType,
-            table.source,
-            typeof table.rows === "number" ? String(table.rows) : "",
-          ],
-        ),
-      );
-
-      for (const column of table.columns) {
-        entries.push(
-          entry(
-            `${tableId}:column:${stablePart(column.name)}`,
-            "column",
-            column.name,
-            `Column in ${table.name} · ${itemName}`,
-            {
-              kind: "column",
-              itemId,
-              tableName: table.name,
-              objectName: column.name,
-            },
-            [
-              table.name,
-              itemName,
-              column.dataType,
-              column.description,
-              column.isHidden ? "hidden" : "",
-            ],
-          ),
-        );
-      }
-
-      for (const measure of table.measures) {
-        entries.push(
-          entry(
-            `${tableId}:measure:${stablePart(measure.name)}`,
-            "measure",
-            measure.name,
-            `Measure in ${table.name} · ${itemName}`,
-            {
-              kind: "measure",
-              itemId,
-              tableName: table.name,
-              objectName: measure.name,
-            },
-            [
-              table.name,
-              itemName,
-              measure.description,
-              measure.expr,
-              measure.isHidden ? "hidden" : "",
-            ],
-          ),
-        );
-      }
-    }
+          itemId: object.itemFabricId,
+          tableName: object.tableName ?? object.parentName,
+          objectName: object.name,
+          objectId: object.objectId,
+          objectKind: object.kind,
+        },
+        [
+          label,
+          object.itemName,
+          object.itemType,
+          object.parentName,
+          object.tableName,
+          object.dataType,
+          object.source,
+          object.sourceItemName,
+          object.description,
+          object.expression,
+          JSON.stringify(object.details),
+          object.isHidden ? "hidden" : "",
+        ],
+      ),
+    );
   }
 
   for (const principal of data.principals) {

--- a/src/atlas/store.spec.tsx
+++ b/src/atlas/store.spec.tsx
@@ -28,6 +28,16 @@ const findingAckBackend = vi.hoisted(() => ({
   saveFindingAck: vi.fn(),
   deleteFindingAck: vi.fn(),
 }));
+const governancePolicyBackend = vi.hoisted(() => ({
+  loadGovernancePolicy: vi.fn(),
+  saveGovernancePolicy: vi.fn(),
+  deleteGovernancePolicy: vi.fn(),
+}));
+const governanceExceptionBackend = vi.hoisted(() => ({
+  loadGovernanceExceptions: vi.fn(),
+  saveGovernanceException: vi.fn(),
+  deleteGovernanceException: vi.fn(),
+}));
 const currentUser = {
   id: "user-1",
   name: "admin@example.com",
@@ -37,6 +47,8 @@ const currentUser = {
 vi.mock("./backend", () => backend);
 vi.mock("./saved-views", () => savedViewBackend);
 vi.mock("./finding-acks", () => findingAckBackend);
+vi.mock("./governance-policy", () => governancePolicyBackend);
+vi.mock("./governance-exceptions", () => governanceExceptionBackend);
 
 function Harness() {
   const atlas = useAtlas();
@@ -80,6 +92,29 @@ function Harness() {
       >
         Mute finding
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          void atlas.saveGovernanceTargets({
+            ...atlas.governanceTargets,
+            access: 85,
+          }).catch(() => undefined)
+        }
+      >
+        Save governance targets
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void atlas.saveGovernanceException({
+            findingId: "finding-shared",
+            reason: "Accepted until the migration completes.",
+            expiresAt: "2099-09-05T12:00:00.000Z",
+          }).catch(() => undefined)
+        }
+      >
+        Save governance exception
+      </button>
       <span data-testid="hydrating">{String(atlas.hydrating)}</span>
       <span data-testid="history-loading">{String(atlas.historyLoading)}</span>
       <span data-testid="history-count">{atlas.history.snapshots.length}</span>
@@ -99,6 +134,21 @@ function Harness() {
       </span>
       <span data-testid="finding-ack-pending">
         {String(atlas.findingAckPendingIds.has("finding-queue"))}
+      </span>
+      <span data-testid="governance-target-access">
+        {atlas.governanceTargets.access}
+      </span>
+      <span data-testid="governance-policy-loading">
+        {String(atlas.governancePolicyLoading)}
+      </span>
+      <span data-testid="governance-policy-error">
+        {atlas.governancePolicyError ?? ""}
+      </span>
+      <span data-testid="governance-exception-count">
+        {atlas.governanceExceptions.length}
+      </span>
+      <span data-testid="governance-exception-error">
+        {atlas.governanceExceptionsError ?? ""}
       </span>
       <span data-testid="has-data">{String(atlas.hasData)}</span>
       <span data-testid="syncing">{String(atlas.syncing)}</span>
@@ -145,6 +195,60 @@ describe("AtlasProvider synchronization", () => {
       }),
     );
     findingAckBackend.deleteFindingAck.mockReset();
+    governancePolicyBackend.loadGovernancePolicy.mockReset().mockResolvedValue({
+      targets: {
+        documentation: 70,
+        ownership: 70,
+        sensitivity: 70,
+        access: 70,
+        lineage: 70,
+        operations: 70,
+      },
+      source: "default",
+    });
+    governancePolicyBackend.saveGovernancePolicy.mockReset().mockImplementation(
+      async (
+        _preview: boolean,
+        _workspaceId: string,
+        _user: unknown,
+        targets: Record<string, number>,
+      ) => ({
+        id: "policy-1",
+        targets,
+        source: "persisted",
+      }),
+    );
+    governancePolicyBackend.deleteGovernancePolicy
+      .mockReset()
+      .mockResolvedValue(undefined);
+    governanceExceptionBackend.loadGovernanceExceptions
+      .mockReset()
+      .mockResolvedValue([]);
+    governanceExceptionBackend.saveGovernanceException
+      .mockReset()
+      .mockImplementation(
+        async (
+          _preview: boolean,
+          _workspaceId: string,
+          _user: unknown,
+          input: {
+            findingId: string;
+            reason: string;
+            expiresAt: string;
+          },
+        ) => ({
+          id: "exception-1",
+          ...input,
+          authorId: "user-1",
+          authorName: "Admin",
+          authorEmail: "admin@example.com",
+          createdAt: "2026-09-05T12:00:00.000Z",
+          updatedAt: "2026-09-05T12:00:00.000Z",
+        }),
+      );
+    governanceExceptionBackend.deleteGovernanceException
+      .mockReset()
+      .mockResolvedValue(undefined);
     backend.loadHistoryFromDb.mockImplementation(
       async (_isPreview: boolean, current: typeof SAMPLE_DATA) =>
         buildAtlasHistory([
@@ -309,6 +413,122 @@ describe("AtlasProvider synchronization", () => {
       false,
       expect.any(String),
       currentUser.id,
+    );
+  });
+
+  it("hydrates shared governance targets and exceptions by workspace", async () => {
+    governancePolicyBackend.loadGovernancePolicy.mockResolvedValue({
+      id: "policy-1",
+      targets: {
+        documentation: 75,
+        ownership: 76,
+        sensitivity: 77,
+        access: 78,
+        lineage: 79,
+        operations: 80,
+      },
+      source: "persisted",
+    });
+    governanceExceptionBackend.loadGovernanceExceptions.mockResolvedValue([
+      {
+        id: "exception-1",
+        findingId: "finding-1",
+        reason: "Temporary",
+        expiresAt: "2099-09-05T12:00:00.000Z",
+        authorId: "admin-1",
+        authorName: "Admin",
+        authorEmail: "admin@example.com",
+        createdAt: "2026-09-05T12:00:00.000Z",
+        updatedAt: "2026-09-05T12:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <AtlasProvider isPreview={false} currentUser={currentUser}>
+        <Harness />
+      </AtlasProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("governance-target-access")).toHaveTextContent(
+        "78",
+      ),
+    );
+    expect(screen.getByTestId("governance-exception-count")).toHaveTextContent(
+      "1",
+    );
+    expect(
+      governancePolicyBackend.loadGovernancePolicy,
+    ).toHaveBeenCalledWith(false, expect.any(String));
+    expect(
+      governanceExceptionBackend.loadGovernanceExceptions,
+    ).toHaveBeenCalledWith(false, expect.any(String));
+  });
+
+  it("surfaces policy load failures instead of presenting defaults as loaded", async () => {
+    governancePolicyBackend.loadGovernancePolicy.mockRejectedValue(
+      new Error("policy unavailable"),
+    );
+
+    render(
+      <AtlasProvider isPreview={false} currentUser={currentUser}>
+        <Harness />
+      </AtlasProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("governance-policy-loading")).toHaveTextContent(
+        "false",
+      ),
+    );
+    expect(screen.getByTestId("governance-policy-error")).toHaveTextContent(
+      "policy unavailable",
+    );
+  });
+
+  it("saves shared targets and exceptions through the administrator path", async () => {
+    render(
+      <AtlasProvider isPreview={false} currentUser={currentUser}>
+        <Harness />
+      </AtlasProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("governance-policy-loading")).toHaveTextContent(
+        "false",
+      ),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save governance targets" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("governance-target-access")).toHaveTextContent(
+        "85",
+      ),
+    );
+    expect(governancePolicyBackend.saveGovernancePolicy).toHaveBeenCalledWith(
+      false,
+      expect.any(String),
+      currentUser,
+      expect.objectContaining({ access: 85 }),
+      expect.objectContaining({ source: "default" }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save governance exception" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("governance-exception-count")).toHaveTextContent(
+        "1",
+      ),
+    );
+    expect(
+      governanceExceptionBackend.saveGovernanceException,
+    ).toHaveBeenCalledWith(
+      false,
+      expect.any(String),
+      currentUser,
+      expect.objectContaining({ findingId: "finding-shared" }),
     );
   });
 

--- a/src/atlas/store.tsx
+++ b/src/atlas/store.tsx
@@ -41,6 +41,20 @@ import {
   type FindingAcknowledgement,
   type FindingAckStatus,
 } from "./finding-acks";
+import {
+  deleteGovernancePolicy,
+  loadGovernancePolicy,
+  saveGovernancePolicy,
+  type GovernancePolicyRecord,
+  type GovernanceTargets,
+} from "./governance-policy";
+import {
+  deleteGovernanceException,
+  loadGovernanceExceptions,
+  saveGovernanceException,
+  type GovernanceException,
+} from "./governance-exceptions";
+import { POSTURE_TARGETS } from "./posture";
 
 export interface CurrentUser {
   id: string;
@@ -62,6 +76,13 @@ export interface AtlasContextValue {
   findingAcksLoading: boolean;
   findingAcksError?: string;
   findingAckPendingIds: Set<string>;
+  governanceTargets: GovernanceTargets;
+  governancePolicyLoading: boolean;
+  governancePolicyError?: string;
+  governanceExceptions: GovernanceException[];
+  governanceExceptionsLoading: boolean;
+  governanceExceptionsError?: string;
+  governanceExceptionPendingIds: Set<string>;
   syncing: boolean;
   syncProgress: number;
   syncStage: string;
@@ -88,6 +109,16 @@ export interface AtlasContextValue {
     note?: string;
   }) => Promise<void>;
   removeFindingAcknowledgement: (id: string) => Promise<void>;
+  reloadGovernancePolicy: () => Promise<void>;
+  saveGovernanceTargets: (targets: GovernanceTargets) => Promise<void>;
+  resetGovernanceTargets: () => Promise<void>;
+  reloadGovernanceExceptions: () => Promise<void>;
+  saveGovernanceException: (input: {
+    findingId: string;
+    reason: string;
+    expiresAt: string;
+  }) => Promise<void>;
+  removeGovernanceException: (id: string) => Promise<void>;
   loadHistorySnapshot: (snapshotId: string) => Promise<void>;
 }
 
@@ -194,6 +225,26 @@ export function AtlasProvider({
   const [findingAckPendingIds, setFindingAckPendingIds] = useState(
     new Set<string>(),
   );
+  const [governancePolicy, setGovernancePolicy] =
+    useState<GovernancePolicyRecord>({
+      targets: { ...POSTURE_TARGETS },
+      source: "default",
+    });
+  const [governancePolicyLoading, setGovernancePolicyLoading] =
+    useState(!isPreview);
+  const [governancePolicyError, setGovernancePolicyError] = useState<
+    string | undefined
+  >();
+  const [governanceExceptions, setGovernanceExceptions] = useState<
+    GovernanceException[]
+  >([]);
+  const [governanceExceptionsLoading, setGovernanceExceptionsLoading] =
+    useState(!isPreview);
+  const [governanceExceptionsError, setGovernanceExceptionsError] = useState<
+    string | undefined
+  >();
+  const [governanceExceptionPendingIds, setGovernanceExceptionPendingIds] =
+    useState(new Set<string>());
   const [syncing, setSyncing] = useState(false);
   const [syncProgress, setSyncProgress] = useState(0);
   const [syncStage, setSyncStage] = useState("Ready to sync");
@@ -220,6 +271,12 @@ export function AtlasProvider({
   const findingAckQueues = useRef(new Map<string, Promise<void>>());
   const findingAckGeneration = useRef(0);
   const findingAcksLoadingRef = useRef(findingAcksLoading);
+  const governancePolicyGeneration = useRef(0);
+  const governancePolicyLoadingRef = useRef(governancePolicyLoading);
+  const governanceExceptionGeneration = useRef(0);
+  const governanceExceptionsLoadingRef = useRef(
+    governanceExceptionsLoading,
+  );
 
   useEffect(() => {
     dataRef.current = data;
@@ -236,6 +293,14 @@ export function AtlasProvider({
   useEffect(() => {
     findingAcksLoadingRef.current = findingAcksLoading;
   }, [findingAcksLoading]);
+
+  useEffect(() => {
+    governancePolicyLoadingRef.current = governancePolicyLoading;
+  }, [governancePolicyLoading]);
+
+  useEffect(() => {
+    governanceExceptionsLoadingRef.current = governanceExceptionsLoading;
+  }, [governanceExceptionsLoading]);
 
   useEffect(
     () => () => {
@@ -271,6 +336,94 @@ export function AtlasProvider({
       alive = false;
     };
   }, [currentUser.id, data.workspace.fabricId, isPreview]);
+
+  const reloadGovernancePolicy = useCallback(async () => {
+    const generation = governancePolicyGeneration.current + 1;
+    governancePolicyGeneration.current = generation;
+    governancePolicyLoadingRef.current = true;
+    setGovernancePolicy({
+      targets: { ...POSTURE_TARGETS },
+      source: "default",
+    });
+    setGovernancePolicyLoading(true);
+    setGovernancePolicyError(undefined);
+    try {
+      const policy = await loadGovernancePolicy(
+        isPreview,
+        data.workspace.fabricId,
+      );
+      if (governancePolicyGeneration.current === generation) {
+        setGovernancePolicy(policy);
+      }
+    } catch (error) {
+      if (governancePolicyGeneration.current === generation) {
+        setGovernancePolicyError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      throw error;
+    } finally {
+      if (governancePolicyGeneration.current === generation) {
+        governancePolicyLoadingRef.current = false;
+        setGovernancePolicyLoading(false);
+      }
+    }
+  }, [data.workspace.fabricId, isPreview]);
+
+  useEffect(() => {
+    if (isPreview) return;
+    let alive = true;
+    window.queueMicrotask(() => {
+      if (alive) void reloadGovernancePolicy().catch(() => undefined);
+    });
+    return () => {
+      alive = false;
+      governancePolicyGeneration.current += 1;
+    };
+  }, [isPreview, reloadGovernancePolicy]);
+
+  const reloadGovernanceExceptions = useCallback(async () => {
+    const generation = governanceExceptionGeneration.current + 1;
+    governanceExceptionGeneration.current = generation;
+    governanceExceptionsLoadingRef.current = true;
+    setGovernanceExceptions([]);
+    setGovernanceExceptionPendingIds(new Set());
+    setGovernanceExceptionsLoading(true);
+    setGovernanceExceptionsError(undefined);
+    try {
+      const exceptions = await loadGovernanceExceptions(
+        isPreview,
+        data.workspace.fabricId,
+      );
+      if (governanceExceptionGeneration.current === generation) {
+        setGovernanceExceptions(exceptions);
+      }
+    } catch (error) {
+      if (governanceExceptionGeneration.current === generation) {
+        setGovernanceExceptionsError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      throw error;
+    } finally {
+      if (governanceExceptionGeneration.current === generation) {
+        governanceExceptionsLoadingRef.current = false;
+        setGovernanceExceptionsLoading(false);
+      }
+    }
+  }, [data.workspace.fabricId, isPreview]);
+
+  useEffect(() => {
+    if (isPreview) return;
+    let alive = true;
+    window.queueMicrotask(() => {
+      if (alive) void reloadGovernanceExceptions().catch(() => undefined);
+    });
+    return () => {
+      alive = false;
+      governanceExceptionGeneration.current += 1;
+    };
+  }, [isPreview, reloadGovernanceExceptions]);
 
   useEffect(() => {
     if (isPreview) return;
@@ -658,6 +811,196 @@ export function AtlasProvider({
     [isPreview],
   );
 
+  const saveGovernanceTargets = useCallback(
+    async (targets: GovernanceTargets) => {
+      if (!canSync) {
+        const error = new Error(
+          "Only the configured Atlas sync administrator can change governance targets.",
+        );
+        setGovernancePolicyError(error.message);
+        throw error;
+      }
+      if (governancePolicyLoadingRef.current) {
+        const error = new Error("Governance targets are still loading.");
+        setGovernancePolicyError(error.message);
+        throw error;
+      }
+      setGovernancePolicyError(undefined);
+      setGovernancePolicyLoading(true);
+      governancePolicyLoadingRef.current = true;
+      try {
+        const saved = await saveGovernancePolicy(
+          isPreview,
+          data.workspace.fabricId,
+          currentUser,
+          targets,
+          governancePolicy,
+        );
+        setGovernancePolicy(saved);
+      } catch (error) {
+        setGovernancePolicyError(
+          error instanceof Error ? error.message : String(error),
+        );
+        throw error;
+      } finally {
+        governancePolicyLoadingRef.current = false;
+        setGovernancePolicyLoading(false);
+      }
+    },
+    [
+      canSync,
+      currentUser,
+      data.workspace.fabricId,
+      governancePolicy,
+      isPreview,
+    ],
+  );
+
+  const resetGovernanceTargets = useCallback(async () => {
+    if (!canSync) {
+      const error = new Error(
+        "Only the configured Atlas sync administrator can reset governance targets.",
+      );
+      setGovernancePolicyError(error.message);
+      throw error;
+    }
+    if (governancePolicyLoadingRef.current) {
+      const error = new Error("Governance targets are still loading.");
+      setGovernancePolicyError(error.message);
+      throw error;
+    }
+    setGovernancePolicyError(undefined);
+    setGovernancePolicyLoading(true);
+    governancePolicyLoadingRef.current = true;
+    try {
+      await deleteGovernancePolicy(isPreview, governancePolicy.id);
+      setGovernancePolicy({
+        targets: { ...POSTURE_TARGETS },
+        source: "default",
+      });
+    } catch (error) {
+      setGovernancePolicyError(
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    } finally {
+      governancePolicyLoadingRef.current = false;
+      setGovernancePolicyLoading(false);
+    }
+  }, [canSync, governancePolicy.id, isPreview]);
+
+  const saveSharedGovernanceException = useCallback(
+    async (input: {
+      findingId: string;
+      reason: string;
+      expiresAt: string;
+    }) => {
+      if (!canSync) {
+        const error = new Error(
+          "Only the configured Atlas sync administrator can change governance exceptions.",
+        );
+        setGovernanceExceptionsError(error.message);
+        throw error;
+      }
+      if (governanceExceptionsLoadingRef.current) {
+        const error = new Error("Governance exceptions are still loading.");
+        setGovernanceExceptionsError(error.message);
+        throw error;
+      }
+      const generation = governanceExceptionGeneration.current;
+      setGovernanceExceptionsError(undefined);
+      setGovernanceExceptionPendingIds((pending) => {
+        const next = new Set(pending);
+        next.add(input.findingId);
+        return next;
+      });
+      try {
+        const current = governanceExceptions.find(
+          (exception) => exception.findingId === input.findingId,
+        );
+        const saved = await saveGovernanceException(
+          isPreview,
+          data.workspace.fabricId,
+          currentUser,
+          { ...input, current },
+        );
+        if (governanceExceptionGeneration.current !== generation) return;
+        setGovernanceExceptions((existing) => [
+          saved,
+          ...existing.filter(
+            (exception) => exception.findingId !== saved.findingId,
+          ),
+        ]);
+      } catch (error) {
+        if (governanceExceptionGeneration.current === generation) {
+          setGovernanceExceptionsError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        throw error;
+      } finally {
+        if (governanceExceptionGeneration.current === generation) {
+          setGovernanceExceptionPendingIds((pending) => {
+            const next = new Set(pending);
+            next.delete(input.findingId);
+            return next;
+          });
+        }
+      }
+    },
+    [
+      canSync,
+      currentUser,
+      data.workspace.fabricId,
+      governanceExceptions,
+      isPreview,
+    ],
+  );
+
+  const removeSharedGovernanceException = useCallback(
+    async (id: string) => {
+      if (!canSync) {
+        const error = new Error(
+          "Only the configured Atlas sync administrator can remove governance exceptions.",
+        );
+        setGovernanceExceptionsError(error.message);
+        throw error;
+      }
+      const current = governanceExceptions.find(
+        (exception) => exception.id === id,
+      );
+      if (!current) {
+        const error = new Error("The selected governance exception is unavailable.");
+        setGovernanceExceptionsError(error.message);
+        throw error;
+      }
+      setGovernanceExceptionsError(undefined);
+      setGovernanceExceptionPendingIds((pending) => {
+        const next = new Set(pending);
+        next.add(current.findingId);
+        return next;
+      });
+      try {
+        await deleteGovernanceException(isPreview, id);
+        setGovernanceExceptions((existing) =>
+          existing.filter((exception) => exception.id !== id),
+        );
+      } catch (error) {
+        setGovernanceExceptionsError(
+          error instanceof Error ? error.message : String(error),
+        );
+        throw error;
+      } finally {
+        setGovernanceExceptionPendingIds((pending) => {
+          const next = new Set(pending);
+          next.delete(current.findingId);
+          return next;
+        });
+      }
+    },
+    [canSync, governanceExceptions, isPreview],
+  );
+
   const loadHistorySnapshot = useCallback(
     async (snapshotId: string) => {
       if (
@@ -733,6 +1076,13 @@ export function AtlasProvider({
       findingAcksLoading,
       findingAcksError,
       findingAckPendingIds,
+      governanceTargets: governancePolicy.targets,
+      governancePolicyLoading,
+      governancePolicyError,
+      governanceExceptions,
+      governanceExceptionsLoading,
+      governanceExceptionsError,
+      governanceExceptionPendingIds,
       syncing,
       syncProgress,
       syncStage,
@@ -750,9 +1100,15 @@ export function AtlasProvider({
       removeSavedView,
       saveFindingAcknowledgement,
       removeFindingAcknowledgement,
+      reloadGovernancePolicy,
+      saveGovernanceTargets,
+      resetGovernanceTargets,
+      reloadGovernanceExceptions,
+      saveGovernanceException: saveSharedGovernanceException,
+      removeGovernanceException: removeSharedGovernanceException,
       loadHistorySnapshot,
     }),
-    [data, history, hydrating, historyLoading, historyError, historyFailedSnapshotIds, savedViews, savedViewsLoading, savedViewsError, findingAcks, findingAcksLoading, findingAcksError, findingAckPendingIds, syncing, syncProgress, syncStage, lastSyncedAt, isPreview, configured, canSync, hasData, requiresDeploymentSync, syncError, currentUser, sync, addComment, addSavedView, removeSavedView, saveFindingAcknowledgement, removeFindingAcknowledgement, loadHistorySnapshot],
+    [data, history, hydrating, historyLoading, historyError, historyFailedSnapshotIds, savedViews, savedViewsLoading, savedViewsError, findingAcks, findingAcksLoading, findingAcksError, findingAckPendingIds, governancePolicy.targets, governancePolicyLoading, governancePolicyError, governanceExceptions, governanceExceptionsLoading, governanceExceptionsError, governanceExceptionPendingIds, syncing, syncProgress, syncStage, lastSyncedAt, isPreview, configured, canSync, hasData, requiresDeploymentSync, syncError, currentUser, sync, addComment, addSavedView, removeSavedView, saveFindingAcknowledgement, removeFindingAcknowledgement, reloadGovernancePolicy, saveGovernanceTargets, resetGovernanceTargets, reloadGovernanceExceptions, saveSharedGovernanceException, removeSharedGovernanceException, loadHistorySnapshot],
   );
 
   return <AtlasContext.Provider value={value}>{children}</AtlasContext.Provider>;

--- a/src/atlas/ui.tsx
+++ b/src/atlas/ui.tsx
@@ -118,7 +118,7 @@ export function Chip({
   return (
     <span
       className={cn(
-        "inline-flex min-h-[24px] items-center gap-[6px] rounded-md border border-transparent px-[8px] py-[2px] text-[11px] font-semibold",
+        "inline-flex min-h-xxl items-center gap-xs rounded-md border border-transparent px-s py-xxs text-[length:var(--text-200)] font-semibold",
         className,
       )}
       style={style}
@@ -187,21 +187,19 @@ export function EndorsementChip({ endorsement }: { endorsement: string }) {
 }
 
 export function HealthChip({ health }: { health: Health }) {
-  const label =
-    health === "healthy"
-      ? "Healthy"
-      : health === "stale"
-        ? "Stale"
-        : health === "failing"
-          ? "Failing"
-          : "Unknown";
+  const states: Record<Health, { label: string; tone: string }> = {
+    healthy: { label: "Healthy", tone: "border-status-healthy/30 bg-status-healthy/10 text-status-healthy" },
+    stale: { label: "Stale", tone: "border-status-warning/30 bg-status-warning/10 text-status-warning" },
+    failing: { label: "Failing", tone: "border-status-failing/30 bg-status-failing/10 text-status-failing" },
+    unknown: { label: "Health unknown", tone: "border-border bg-muted text-muted-foreground" },
+  };
+  const state = states[health];
   return (
     <span
-      className="inline-flex items-center gap-[6px] rounded-md px-[8px] py-[2px] text-[11px] font-semibold"
-      style={{ background: `${HEALTH_COLOR[health]}22`, color: HEALTH_COLOR[health] }}
+      className={cn("inline-flex items-center gap-xs rounded-md border px-s py-xxs text-[length:var(--text-200)] font-semibold", state.tone)}
     >
-      <HealthDot health={health} size={8} />
-      {label}
+      <span className="size-s shrink-0 rounded-full bg-current" aria-hidden="true" />
+      {state.label}
     </span>
   );
 }

--- a/src/atlas/views/Access.spec.tsx
+++ b/src/atlas/views/Access.spec.tsx
@@ -2,14 +2,16 @@ import {
   fireEvent,
   render,
   screen,
+  within,
   waitFor,
 } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { buildAccessReviewRows } from "../governance";
 import { accessRowsToCsv } from "../access-export";
+import type { AccessReviewHistory } from "../access-reviews";
 import { SAMPLE_DATA } from "../model";
 import { AtlasProvider } from "../store";
-import { AccessView } from "./Access";
+import { AccessReviewDetailPanel, AccessView } from "./Access";
 
 function renderAccess() {
   return render(
@@ -67,6 +69,69 @@ describe("AccessView", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("2 contributing grants · 2 determine effective access")).toBeInTheDocument();
     expect(screen.getAllByText("Determines effective")).toHaveLength(2);
+  });
+
+  it("shows changed evidence as needing review while retaining the prior decision", () => {
+    const row = buildAccessReviewRows(SAMPLE_DATA).find(
+      (candidate) =>
+        candidate.principalRef === "System Administrator" &&
+        candidate.item.displayName === "AlpineRent Executive Dashboard",
+    )!;
+    const review: AccessReviewHistory = {
+      rowKey: row.id,
+      itemFabricId: row.itemId,
+      principalRef: row.principalRef,
+      decision: {
+        id: "event-1",
+        rowKey: row.id,
+        itemFabricId: row.itemId,
+        principalRef: row.principalRef,
+        status: "accepted",
+        evidenceKey: "old-evidence",
+        reviewedAt: "2026-09-04T10:00:00.000Z",
+        updatedAt: "2026-09-04T10:00:00.000Z",
+        needsReview: true,
+        source: "event",
+      },
+      history: [
+        {
+          id: "event-1",
+          rowKey: row.id,
+          itemFabricId: row.itemId,
+          principalRef: row.principalRef,
+          status: "accepted",
+          evidenceKey: "old-evidence",
+          eventOrder: "0000000000001:event-1",
+          occurredAt: "2026-09-04T10:00:00.000Z",
+          source: "event",
+        },
+      ],
+    };
+
+    render(
+      <AccessReviewDetailPanel
+        row={row}
+        review={review}
+        reviewsLoading={false}
+        saving={false}
+        onSaveDecision={vi.fn()}
+        onClearDecision={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Needs review")).toBeVisible();
+    expect(
+      screen.getByText(/effective permission evidence changed/i),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Accepted" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    const history = screen
+      .getByRole("heading", { name: "Personal review history" })
+      .closest("section")!;
+    expect(within(history).getByText("Accepted")).toBeVisible();
   });
 
   it("starts principal groups collapsed and expands them on click", () => {
@@ -190,7 +255,7 @@ describe("AccessView", () => {
     );
   });
 
-  it("keeps preview review decisions locally after save", async () => {
+  it("keeps preview decisions and clears in personal history", async () => {
     renderAccess();
 
     fireEvent.click(
@@ -215,6 +280,24 @@ describe("AccessView", () => {
       screen.getByText("Decision is saved for your account."),
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue("Owner access confirmed.")).toBeVisible();
+
+    const history = screen
+      .getByRole("heading", { name: "Personal review history" })
+      .closest("section")!;
+    expect(within(history).getByText("Accepted")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear decision" }));
+    await waitFor(() =>
+      expect(screen.getByText("Not reviewed yet")).toBeInTheDocument(),
+    );
+    const retainedHistory = screen
+      .getByRole("heading", { name: "Personal review history" })
+      .closest("section")!;
+    expect(within(retainedHistory).getByText("Cleared")).toBeVisible();
+    expect(within(retainedHistory).getByText("Accepted")).toBeVisible();
+    expect(
+      within(retainedHistory).getByText("Owner access confirmed."),
+    ).toBeVisible();
   });
 
   it("downloads the filtered rows as CSV", async () => {

--- a/src/atlas/views/Access.tsx
+++ b/src/atlas/views/Access.tsx
@@ -17,12 +17,20 @@ import {
 import { SavedViewsMenu } from "../components/SavedViewsMenu";
 import { OffboardingDialog } from "../components/OffboardingDialog";
 import {
-  deleteAccessReview,
-  loadAccessReviews,
+  appendAccessReviewEvent,
+  clearAccessReview,
+  loadAccessReviewHistories,
   saveAccessReview,
   type AccessReviewDecision,
+  type AccessReviewHistory,
+  type AccessReviewHistoryEntry,
   type AccessReviewStatus,
 } from "../access-reviews";
+import {
+  accessReviewEvidenceKey,
+  accessReviewEvidenceKeys,
+  serializeAccessReviewEvidence,
+} from "../access-review-evidence";
 import { accessRowsToCsv } from "../access-export";
 import {
   buildAccessReviewRows,
@@ -53,7 +61,7 @@ const ACCESS_STYLE: Record<
   { label: string; className: string }
 > = {
   owner: {
-    label: "Owner",
+    label: "Owner permission",
     className:
       "border-status-warning/30 bg-status-warning/10 text-status-warning",
   },
@@ -101,7 +109,7 @@ const SOURCE_LABEL: Record<AccessSource, string> = {
   directShare: "Direct share",
   group: "Group grant (recorded)",
   orgLink: "Organization link",
-  itemOwner: "Item owner",
+  itemOwner: "Item owner grant",
 };
 
 const FLAG_LABEL: Record<NonNullable<Grant["flag"]>, string> = {
@@ -319,7 +327,7 @@ function MatrixTable({
     <div role="listbox" aria-label="Access review matrix">
       <div
         aria-hidden="true"
-        className="hidden grid-cols-[minmax(190px,1.2fr)_minmax(190px,1.2fr)_auto_auto_minmax(150px,1fr)_70px] gap-m border-b border-border bg-secondary/70 px-l py-m text-200 font-semibold text-muted-foreground md:grid"
+        className="atlas-row hidden grid-cols-[minmax(190px,1.2fr)_minmax(190px,1.2fr)_auto_auto_minmax(150px,1fr)_70px] gap-m border-b border-border bg-secondary/70 px-l text-200 font-semibold text-muted-foreground md:grid"
       >
         <span>Principal</span>
         <span>Item</span>
@@ -369,7 +377,7 @@ function MatrixTable({
                 }
               }}
               className={cn(
-                "atlas-windowed-block grid w-full cursor-pointer gap-m p-l text-left transition-colors hover:bg-accent/60 md:grid-cols-[minmax(190px,1.2fr)_minmax(190px,1.2fr)_auto_auto_minmax(150px,1fr)_70px] md:items-center",
+                "atlas-row atlas-windowed-block grid w-full cursor-pointer gap-m px-l text-left transition-colors hover:bg-accent/60 md:grid-cols-[minmax(190px,1.2fr)_minmax(190px,1.2fr)_auto_auto_minmax(150px,1fr)_70px] md:items-center",
                 selected && "bg-primary/10",
               )}
             >
@@ -485,7 +493,7 @@ function PrincipalGroups({
                 aria-controls={regionId}
                 disabled={searching}
                 onClick={() => onToggle(principalKey)}
-                className="flex min-w-0 flex-1 items-center gap-m px-l py-m text-left transition-colors hover:bg-accent/60 disabled:cursor-default disabled:opacity-100"
+                className="atlas-row flex min-w-0 flex-1 items-center gap-m px-l text-left transition-colors hover:bg-accent/60 disabled:cursor-default disabled:opacity-100"
               >
               {isExpanded ? (
                 <ChevronDown
@@ -512,7 +520,7 @@ function PrincipalGroups({
               <button
                 type="button"
                 onClick={() => onOpenPack(first)}
-                className="mr-l rounded-lg border border-primary/30 bg-primary/10 px-m py-s text-200 font-semibold text-brand-foreground hover:bg-primary/15"
+                className="atlas-control mr-l rounded-lg border border-primary/30 bg-primary/10 px-m text-200 font-semibold text-brand-foreground hover:bg-primary/15"
               >
                 {first.principal?.kind === "user" ||
                 first.principal?.kind === "guest"
@@ -537,7 +545,7 @@ function PrincipalGroups({
                         aria-label={`Review ${row.principalRef} access to ${row.item.displayName}`}
                         onClick={() => onSelect(row)}
                         className={cn(
-                          "grid w-full gap-m rounded-lg px-m py-s text-left transition-colors hover:bg-accent sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:items-center",
+                          "atlas-row grid w-full gap-m rounded-lg px-m text-left transition-colors hover:bg-accent sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:items-center",
                           selected && "bg-primary/10",
                         )}
                       >
@@ -577,7 +585,7 @@ function reviewSummary(
   const grants = row.applicableGrants
     .map((grant) => {
       const effective = row.effectiveGrants.includes(grant)
-        ? " — determines effective access"
+        ? ", determines effective access"
         : "";
       return `- ${SOURCE_LABEL[grant.source]} (${grantScope(grant, row)}): ${
         ACCESS_STYLE[grant.accessLevel].label
@@ -591,7 +599,13 @@ function reviewSummary(
     `Principal resolution: ${row.principalResolution}`,
     `Flags: ${flags.length ? flags.map((flag) => FLAG_LABEL[flag]).join(", ") : "None"}`,
     `Contributing grants: ${row.applicableGrants.length}`,
-    `Review decision: ${decision ? REVIEW_STATUS[decision.status].label : "Not reviewed"}`,
+    `Review decision: ${
+      decision
+        ? decision.needsReview
+          ? `Needs review (previously ${REVIEW_STATUS[decision.status].label})`
+          : REVIEW_STATUS[decision.status].label
+        : "Not reviewed"
+    }`,
     ...(decision?.reviewedAt
       ? [`Reviewed at: ${new Date(decision.reviewedAt).toLocaleString()}`]
       : []),
@@ -602,9 +616,15 @@ function reviewSummary(
   ].join("\n");
 }
 
-function DetailPanel({
+function historyStatusLabel(entry: AccessReviewHistoryEntry): string {
+  return entry.status === "cleared"
+    ? "Cleared"
+    : REVIEW_STATUS[entry.status].label;
+}
+
+export function AccessReviewDetailPanel({
   row,
-  decision,
+  review,
   reviewsLoading,
   saving,
   reviewError,
@@ -613,7 +633,7 @@ function DetailPanel({
   onClose,
 }: {
   row: AccessReviewRow;
-  decision?: AccessReviewDecision;
+  review?: AccessReviewHistory;
   reviewsLoading: boolean;
   saving: boolean;
   reviewError?: string;
@@ -624,6 +644,7 @@ function DetailPanel({
   onClearDecision: () => Promise<void>;
   onClose: () => void;
 }) {
+  const decision = review?.decision;
   const [copied, setCopied] = useState(false);
   const [note, setNote] = useState(decision?.note ?? "");
 
@@ -641,7 +662,7 @@ function DetailPanel({
 
   return (
     <Card className="overflow-hidden xl:sticky xl:top-l">
-      <div className="flex items-start justify-between gap-m border-b border-border bg-secondary/60 p-l">
+      <div className="atlas-page-header flex items-start justify-between gap-m border-b border-border bg-secondary/60 p-l">
         <div className="min-w-0">
           <SectionLabel>Selected pair</SectionLabel>
           <h2 className="mt-xs text-400 font-semibold">Review detail</h2>
@@ -713,7 +734,9 @@ function DetailPanel({
                 {reviewsLoading
                   ? "Loading current decision…"
                   : decision
-                    ? `Reviewed ${new Date(decision.reviewedAt).toLocaleString()}`
+                    ? decision.needsReview
+                      ? `Previous decision from ${new Date(decision.reviewedAt).toLocaleString()}`
+                      : `Reviewed ${new Date(decision.reviewedAt).toLocaleString()}`
                     : "Not reviewed yet"}
               </p>
             </div>
@@ -721,13 +744,36 @@ function DetailPanel({
               <span
                 className={cn(
                   "inline-flex rounded-md border px-s py-xxs text-200 font-semibold",
-                  REVIEW_STATUS[decision.status].className,
+                  decision.needsReview
+                    ? "border-status-warning/30 bg-status-warning/10 text-status-warning"
+                    : REVIEW_STATUS[decision.status].className,
                 )}
               >
-                {REVIEW_STATUS[decision.status].label}
+                {decision.needsReview
+                  ? "Needs review"
+                  : REVIEW_STATUS[decision.status].label}
               </span>
             )}
           </div>
+
+          {decision?.needsReview && (
+            <div
+              className="mt-m rounded-lg border border-status-warning/30 bg-status-warning/10 p-m"
+              role="status"
+            >
+              <div className="flex gap-s">
+                <AlertTriangle
+                  className="mt-xxs icon-size-200 shrink-0 text-status-warning"
+                  aria-hidden="true"
+                />
+                <p className="text-200 leading-300 text-muted-foreground">
+                  {decision.source === "legacy"
+                    ? "This legacy decision has no recorded permission evidence. Review the current grants before relying on it."
+                    : "The effective permission evidence changed after this decision. Review the current grants before relying on it."}
+                </p>
+              </div>
+            </div>
+          )}
 
           <label
             htmlFor="access-review-note"
@@ -761,12 +807,14 @@ function DetailPanel({
                   <button
                     key={status}
                     type="button"
-                    aria-pressed={decision?.status === status}
+                    aria-pressed={
+                      !decision?.needsReview && decision?.status === status
+                    }
                     disabled={saving || reviewsLoading}
                     onClick={() => void onSaveDecision(status, note)}
                     className={cn(
-                      "inline-flex min-h-xxxl items-center justify-center rounded-lg border px-m py-s text-300 font-semibold transition-colors hover:bg-accent disabled:opacity-60",
-                      decision?.status === status
+                      "atlas-control inline-flex items-center justify-center rounded-lg border px-m text-300 font-semibold transition-colors hover:bg-accent disabled:opacity-60",
+                      !decision?.needsReview && decision?.status === status
                         ? statusMeta.className
                         : "border-border bg-card text-foreground",
                     )}
@@ -791,7 +839,9 @@ function DetailPanel({
               {reviewError ??
                 (saving
                   ? "Saving review decision…"
-                  : decision
+                  : decision?.needsReview
+                    ? "Choose a status to review the current evidence."
+                    : decision
                     ? "Decision is saved for your account."
                     : "Choose a status to save this review.")}
             </span>
@@ -807,6 +857,50 @@ function DetailPanel({
             )}
           </div>
         </section>
+
+        {review && review.history.length > 0 && (
+          <section aria-labelledby="review-history-heading">
+            <h3
+              id="review-history-heading"
+              className="text-300 font-semibold"
+            >
+              Personal review history
+            </h3>
+            <p className="mt-xs text-200 text-muted-foreground">
+              Decisions and clears are retained for your account, newest first.
+            </p>
+            <ol className="mt-m grid gap-s">
+              {review.history.map((entry) => (
+                <li
+                  key={`${entry.source}:${entry.id}`}
+                  className="rounded-lg border border-border bg-secondary/30 p-m"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-s">
+                    <div>
+                      <div className="text-300 font-semibold">
+                        {historyStatusLabel(entry)}
+                      </div>
+                      <div className="mt-xxs text-200 text-muted-foreground">
+                        {new Date(entry.occurredAt).toLocaleString()}
+                        {entry.source === "legacy" ? " · Legacy record" : ""}
+                      </div>
+                    </div>
+                    {!entry.evidenceKey && (
+                      <span className="rounded-md border border-status-warning/30 bg-status-warning/10 px-s py-xxs text-200 font-semibold text-status-warning">
+                        Evidence not recorded
+                      </span>
+                    )}
+                  </div>
+                  {entry.note && (
+                    <p className="mt-s whitespace-pre-wrap text-200 leading-300 text-muted-foreground">
+                      {entry.note}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </section>
+        )}
 
         {row.principalResolution !== "resolved" && (
           <div
@@ -847,7 +941,7 @@ function DetailPanel({
               <dd className="text-right font-medium">{row.item.itemType}</dd>
             </div>
             <div className="flex justify-between gap-m">
-              <dt className="text-muted-foreground">Owner</dt>
+              <dt className="text-muted-foreground">Documented owner</dt>
               <dd className="text-right font-medium">
                 {row.item.ownerName ??
                   (row.item.ownerMetadataAvailable === false
@@ -937,7 +1031,7 @@ function DetailPanel({
         <button
           type="button"
           onClick={() => void copy()}
-          className="inline-flex min-h-xxxl items-center justify-center gap-s rounded-lg bg-primary px-l py-s text-300 font-semibold text-primary-foreground transition-colors hover:bg-primary-hover"
+          className="atlas-control inline-flex items-center justify-center gap-s rounded-lg bg-primary px-l text-300 font-semibold text-primary-foreground transition-colors hover:bg-primary-hover"
         >
           {copied ? (
             <Check className="icon-size-200" aria-hidden="true" />
@@ -974,6 +1068,25 @@ export function AccessView({
     addSavedView,
     removeSavedView,
   } = useAtlas();
+  const rows = useMemo(
+    () =>
+      buildAccessReviewRows(data).filter(
+        (row) => row.effectiveAccess !== "none",
+      ),
+    [data],
+  );
+  const summary = useMemo(() => summarizeAccessReview(rows), [rows]);
+  const reviewScopeKey = `${isPreview ? "preview" : "live"}\u0000${data.workspace.fabricId}\u0000${currentUser.id}`;
+  const reviewLoadKey = useMemo(
+    () =>
+      [
+        reviewScopeKey,
+        ...rows.map(
+          (row) => `${row.id}\u0000${serializeAccessReviewEvidence(row)}`,
+        ),
+      ].join("\u0001"),
+    [reviewScopeKey, rows],
+  );
   const [mode, setMode] = useState<AccessMode>(
     initialFilters?.mode === "principals" ||
       (initialPrincipalId && !initialItemId)
@@ -1004,11 +1117,17 @@ export function AccessView({
   const [expandedPrincipals, setExpandedPrincipals] = useState<Set<string>>(
     () => new Set(),
   );
-  const [reviewDecisions, setReviewDecisions] = useState<
-    AccessReviewDecision[]
-  >([]);
-  const [reviewsLoading, setReviewsLoading] = useState(!isPreview);
-  const [reviewError, setReviewError] = useState<string>();
+  const [reviewState, setReviewState] = useState<{
+    key: string;
+    histories: AccessReviewHistory[];
+  }>(() => ({
+    key: isPreview ? reviewLoadKey : "",
+    histories: [],
+  }));
+  const [reviewErrorState, setReviewErrorState] = useState<{
+    key: string;
+    message?: string;
+  }>(() => ({ key: reviewLoadKey }));
   const [reviewOperationId, setReviewOperationId] = useState<string | null>(
     null,
   );
@@ -1019,40 +1138,45 @@ export function AccessView({
   useEffect(() => {
     if (isPreview) return;
     let active = true;
-    void loadAccessReviews(
-      false,
-      data.workspace.fabricId,
-      currentUser.id,
-    )
-      .then((loaded) => {
+    void (async () => {
+      try {
+        const evidence = await accessReviewEvidenceKeys(rows);
+        if (!active) return;
+        const loaded = await loadAccessReviewHistories(
+          false,
+          data.workspace.fabricId,
+          currentUser.id,
+          evidence,
+        );
         if (active) {
-          setReviewDecisions(loaded);
-          setReviewError(undefined);
+          setReviewState({ key: reviewLoadKey, histories: loaded });
+          setReviewErrorState({ key: reviewLoadKey });
         }
-      })
-      .catch((error) => {
+      } catch (error) {
         if (active) {
-          setReviewError(
-            error instanceof Error ? error.message : String(error),
-          );
+          setReviewState({ key: reviewLoadKey, histories: [] });
+          setReviewErrorState({
+            key: reviewLoadKey,
+            message: error instanceof Error ? error.message : String(error),
+          });
         }
-      })
-      .finally(() => {
-        if (active) setReviewsLoading(false);
-      });
+      }
+    })();
     return () => {
       active = false;
     };
-  }, [currentUser.id, data.workspace.fabricId, isPreview]);
-
-  const rows = useMemo(
-    () =>
-      buildAccessReviewRows(data).filter(
-        (row) => row.effectiveAccess !== "none",
-      ),
-    [data],
-  );
-  const summary = useMemo(() => summarizeAccessReview(rows), [rows]);
+  }, [
+    currentUser.id,
+    data.workspace.fabricId,
+    isPreview,
+    reviewLoadKey,
+    rows,
+  ]);
+  const reviewsLoading = !isPreview && reviewState.key !== reviewLoadKey;
+  const reviewError =
+    reviewErrorState.key === reviewLoadKey
+      ? reviewErrorState.message
+      : undefined;
 
   const focusRows = useMemo(() => {
     let candidates = rows;
@@ -1139,23 +1263,16 @@ export function AccessView({
   const flaggedCount = rows.filter(hasRisk).length;
   const reviewsByRowKey = useMemo(
     () => {
-      const byKey = new Map<string, AccessReviewDecision>();
-      for (const decision of reviewDecisions) {
-        if (!byKey.has(decision.rowKey)) {
-          byKey.set(decision.rowKey, decision);
-        }
+      const byKey = new Map<string, AccessReviewHistory>();
+      const histories =
+        reviewState.key === reviewLoadKey ? reviewState.histories : [];
+      for (const review of histories) {
+        byKey.set(review.rowKey, review);
       }
       return byKey;
     },
-    [reviewDecisions],
+    [reviewLoadKey, reviewState],
   );
-
-  const replaceDecision = (decision: AccessReviewDecision) => {
-    setReviewDecisions((previous) => [
-      decision,
-      ...previous.filter((entry) => entry.rowKey !== decision.rowKey),
-    ]);
-  };
 
   const saveDecision = async (
     row: AccessReviewRow,
@@ -1163,59 +1280,73 @@ export function AccessView({
     note: string,
   ) => {
     setReviewOperationId(row.id);
-    setReviewError(undefined);
+    setReviewErrorState({ key: reviewLoadKey });
     try {
+      const evidenceKey = await accessReviewEvidenceKey(row);
+      const evidence = new Map([[row.id, evidenceKey]]);
       const saved = await saveAccessReview(
         isPreview,
         data.workspace.fabricId,
         currentUser.id,
         {
-          current: reviewsByRowKey.get(row.id),
           rowKey: row.id,
           itemFabricId: row.itemId,
           principalRef: row.principalRef,
           status,
+          evidenceKey,
           note,
         },
       );
-      replaceDecision(saved);
-      if (!isPreview) {
-        setReviewDecisions(
-          await loadAccessReviews(
-            false,
-            data.workspace.fabricId,
-            currentUser.id,
-          ),
-        );
-      }
+      setReviewState((previous) => ({
+        key: reviewLoadKey,
+        histories: appendAccessReviewEvent(
+          previous.key === reviewLoadKey ? previous.histories : [],
+          saved,
+          evidence,
+        ),
+      }));
     } catch (error) {
-      setReviewError(error instanceof Error ? error.message : String(error));
+      setReviewErrorState({
+        key: reviewLoadKey,
+        message: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setReviewOperationId(null);
     }
   };
 
   const clearDecision = async (row: AccessReviewRow) => {
-    const current = reviewsByRowKey.get(row.id);
+    const current = reviewsByRowKey.get(row.id)?.decision;
     if (!current) return;
     setReviewOperationId(row.id);
-    setReviewError(undefined);
+    setReviewErrorState({ key: reviewLoadKey });
     try {
-      await deleteAccessReview(isPreview, current.id);
-      setReviewDecisions((previous) =>
-        previous.filter((decision) => decision.rowKey !== row.id),
+      const evidenceKey = await accessReviewEvidenceKey(row);
+      const evidence = new Map([[row.id, evidenceKey]]);
+      const cleared = await clearAccessReview(
+        isPreview,
+        data.workspace.fabricId,
+        currentUser.id,
+        {
+          rowKey: row.id,
+          itemFabricId: row.itemId,
+          principalRef: row.principalRef,
+          evidenceKey,
+        },
       );
-      if (!isPreview) {
-        setReviewDecisions(
-          await loadAccessReviews(
-            false,
-            data.workspace.fabricId,
-            currentUser.id,
-          ),
-        );
-      }
+      setReviewState((previous) => ({
+        key: reviewLoadKey,
+        histories: appendAccessReviewEvent(
+          previous.key === reviewLoadKey ? previous.histories : [],
+          cleared,
+          evidence,
+        ),
+      }));
     } catch (error) {
-      setReviewError(error instanceof Error ? error.message : String(error));
+      setReviewErrorState({
+        key: reviewLoadKey,
+        message: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setReviewOperationId(null);
     }
@@ -1274,7 +1405,7 @@ export function AccessView({
   return (
     <div className="atlas-content-frame flex flex-col gap-l p-l sm:p-xxl">
       <Card className="overflow-hidden border-primary/25">
-        <div className="atlas-fabric-hero flex flex-col gap-l border-b border-border p-l lg:flex-row lg:items-end lg:justify-between">
+        <div className="atlas-page-header atlas-fabric-hero flex flex-col gap-l border-b border-border p-l lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
             <SectionLabel>Governance / additive permissions</SectionLabel>
             <h1 className="mt-xs text-600 font-bold leading-600">
@@ -1296,7 +1427,7 @@ export function AccessView({
               aria-pressed={mode === "matrix"}
               onClick={() => setMode("matrix")}
               className={cn(
-                "rounded-md px-l py-s text-300 font-semibold transition-colors",
+                "atlas-control rounded-md px-l text-300 font-semibold transition-colors",
                 mode === "matrix"
                   ? "bg-primary text-primary-foreground"
                   : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
@@ -1309,7 +1440,7 @@ export function AccessView({
               aria-pressed={mode === "principals"}
               onClick={() => setMode("principals")}
               className={cn(
-                "rounded-md px-l py-s text-300 font-semibold transition-colors",
+                "atlas-control rounded-md px-l text-300 font-semibold transition-colors",
                 mode === "principals"
                   ? "bg-primary text-primary-foreground"
                   : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
@@ -1349,13 +1480,13 @@ export function AccessView({
       </Card>
 
       <Card className="overflow-hidden">
-        <div className="border-b border-border bg-secondary/40 px-l py-m">
+        <div className="atlas-toolbar border-b border-border bg-secondary/40 px-l py-m">
           <div className="flex flex-col gap-m xl:flex-row xl:items-end">
             <label className="min-w-0 flex-1">
               <span className="mb-xs block text-200 font-semibold text-muted-foreground">
                 Search
               </span>
-              <span className="flex min-h-xxxl items-center gap-s rounded-lg border border-input bg-card px-m">
+              <span className="atlas-control flex items-center gap-s rounded-lg border border-input bg-card px-m">
                 <Search
                   className="icon-size-200 shrink-0 text-muted-foreground"
                   aria-hidden="true"
@@ -1380,10 +1511,10 @@ export function AccessView({
                 onChange={(event) =>
                   setAccessLevel(event.target.value as "all" | AccessLevel)
                 }
-                className="min-h-xxxl w-full rounded-lg border border-input bg-card px-m py-s text-300 text-foreground xl:w-auto"
+                className="atlas-control w-full rounded-lg border border-input bg-card px-m text-300 text-foreground xl:w-auto"
               >
                 <option value="all">All levels</option>
-                <option value="owner">Owner</option>
+                <option value="owner">Owner permission</option>
                 <option value="edit">Edit</option>
                 <option value="view">View</option>
               </select>
@@ -1398,7 +1529,7 @@ export function AccessView({
                 onChange={(event) =>
                   setOrigin(event.target.value as OriginFilter)
                 }
-                className="min-h-xxxl w-full rounded-lg border border-input bg-card px-m py-s text-300 text-foreground xl:w-auto"
+                className="atlas-control w-full rounded-lg border border-input bg-card px-m text-300 text-foreground xl:w-auto"
               >
                 <option value="all">All origins</option>
                 <option value="workspace">Workspace / inherited</option>
@@ -1416,7 +1547,7 @@ export function AccessView({
                 onChange={(event) =>
                   setRisk(event.target.value as RiskFilter)
                 }
-                className="min-h-xxxl w-full rounded-lg border border-input bg-card px-m py-s text-300 text-foreground xl:w-auto"
+                className="atlas-control w-full rounded-lg border border-input bg-card px-m text-300 text-foreground xl:w-auto"
               >
                 <option value="all">All flags</option>
                 <option value="flagged">Any flag or warning</option>
@@ -1475,7 +1606,7 @@ export function AccessView({
                 type="button"
                 onClick={clearFilters}
                 disabled={!activeFilters}
-                className="inline-flex min-h-xxxl items-center justify-center gap-s rounded-lg border border-border bg-card px-m py-s text-300 font-semibold text-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                className="atlas-control inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m text-300 font-semibold text-foreground transition-colors hover:bg-accent disabled:opacity-50"
               >
                 <FilterX className="icon-size-200" aria-hidden="true" />
                 Clear filters
@@ -1484,7 +1615,7 @@ export function AccessView({
                 type="button"
                 onClick={() => downloadCsv(filteredRows)}
                 disabled={filteredRows.length === 0}
-                className="inline-flex min-h-xxxl items-center justify-center gap-s rounded-lg bg-primary px-m py-s text-300 font-semibold text-primary-foreground transition-colors hover:bg-primary-hover disabled:opacity-50"
+                className="atlas-control inline-flex items-center justify-center gap-s rounded-lg bg-primary px-m text-300 font-semibold text-primary-foreground transition-colors hover:bg-primary-hover disabled:opacity-50"
               >
                 <Download className="icon-size-200" aria-hidden="true" />
                 Export CSV
@@ -1493,7 +1624,7 @@ export function AccessView({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-s px-l py-m">
+        <div className="atlas-row flex flex-wrap items-center justify-between gap-s px-l">
           <div>
             <h2 className="text-300 font-semibold">
               {mode === "matrix" ? "Review matrix" : "Principals"}
@@ -1507,6 +1638,15 @@ export function AccessView({
           </span>
         </div>
       </Card>
+
+      {reviewError && !selectedRow && (
+        <div
+          className="rounded-lg border border-status-failing/30 bg-status-failing/10 px-m py-s text-200 text-status-failing"
+          role="alert"
+        >
+          Access review history could not be loaded: {reviewError}
+        </div>
+      )}
 
       <div
         className={cn(
@@ -1544,10 +1684,10 @@ export function AccessView({
         </Card>
 
         {selectedRow && (
-          <DetailPanel
-            key={`${selectedRow.id}:${reviewsByRowKey.get(selectedRow.id)?.updatedAt ?? "none"}`}
+          <AccessReviewDetailPanel
+            key={`${selectedRow.id}:${reviewsByRowKey.get(selectedRow.id)?.history[0]?.id ?? "none"}`}
             row={selectedRow}
-            decision={reviewsByRowKey.get(selectedRow.id)}
+            review={reviewsByRowKey.get(selectedRow.id)}
             reviewsLoading={reviewsLoading}
             saving={reviewOperationId === selectedRow.id}
             reviewError={reviewError}

--- a/src/atlas/views/AssetCatalog.spec.tsx
+++ b/src/atlas/views/AssetCatalog.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AtlasProvider } from "../store";
 import { AssetCatalogView } from "./AssetCatalog";
@@ -95,6 +95,21 @@ describe("AssetCatalogView", () => {
     expect(
       screen.getByText(/No tables, views, columns or measures were exposed/),
     ).toBeInTheDocument();
+  });
+
+  it("does not present missing visibility or provenance as confirmed metadata", async () => {
+    render(
+      <AtlasProvider isPreview>
+        <AssetCatalogView />
+      </AtlasProvider>,
+    );
+    fireEvent.change(screen.getByLabelText("Search assets"), {
+      target: { value: "Total Revenue" },
+    });
+    fireEvent.click(screen.getByText("Total Revenue").closest("button")!);
+    const inspector = within(await screen.findByLabelText("Total Revenue inspector"));
+    expect(inspector.getByText("Visibility").parentElement).toHaveTextContent("Not collected");
+    expect(inspector.getByText("Source").parentElement).toHaveTextContent("Source not recorded");
   });
 
   it("keeps real assets visible when searching by item type", () => {

--- a/src/atlas/views/AssetCatalog.spec.tsx
+++ b/src/atlas/views/AssetCatalog.spec.tsx
@@ -93,7 +93,7 @@ describe("AssetCatalogView", () => {
     fireEvent.click(group!);
     expect(screen.getByText("Item synchronized")).toBeInTheDocument();
     expect(
-      screen.getByText(/No tables, views, columns or measures were exposed/),
+      screen.getByText(/No discoverable objects were exposed/),
     ).toBeInTheDocument();
   });
 

--- a/src/atlas/views/AssetCatalog.tsx
+++ b/src/atlas/views/AssetCatalog.tsx
@@ -2,19 +2,36 @@ import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Boxes,
+  Bot,
+  Braces,
   ChevronDown,
   ChevronRight,
   Columns3,
   FileDown,
   FilterX,
+  Link2,
+  Network,
   Search,
   ShieldCheck,
   Sigma,
   Table2,
   Users,
+  Waypoints,
   X,
 } from "lucide-react";
 import { ImpactReportDialog } from "../components/ImpactReportDialog";
+import { MetadataObjectImpactDialog } from "../components/MetadataObjectImpactDialog";
+import {
+  ASSET_OBJECT_KINDS,
+  assetObjectKindLabel,
+  buildCatalogObjects,
+  isAssetObjectKind,
+  isMetadataAssetKind,
+  metadataObjectImpact,
+  metadataObjectKindLabel,
+  type AssetObjectKind,
+  type CatalogObject,
+} from "../catalog-objects";
 import {
   buildAccessReviewRows,
   selectAccessByItem,
@@ -29,28 +46,13 @@ import {
 import { useAtlas } from "../store";
 import { PrincipalAvatar, SectionLabel, TypeGlyph, cn } from "../ui";
 import {
-  schemaFor,
   typeMeta,
   type AccessLevel,
   type ItemType,
 } from "../model";
 
-type AssetKind = "table" | "column" | "measure" | "view";
-
-interface Asset {
-  id: string;
-  itemFabricId: string;
-  itemName: string;
-  itemType: ItemType;
-  kind: AssetKind;
-  name: string;
-  table?: string;
-  dataType?: string;
-  source?: string;
-  description?: string;
-  isHidden?: boolean;
-  expression?: string;
-}
+type AssetKind = AssetObjectKind;
+type Asset = CatalogObject;
 
 const KIND_META: Record<
   AssetKind,
@@ -86,6 +88,120 @@ const KIND_META: Record<
     tone: "border-object-measure/30 bg-object-measure/10 text-object-measure",
     selectedTone: "border-object-measure/50 bg-object-measure/10",
   },
+  kqlTable: {
+    label: "KQL table",
+    icon: Table2,
+    tone: "border-lineage-downstream/30 bg-lineage-downstream/10 text-lineage-downstream",
+    selectedTone: "border-lineage-downstream/50 bg-lineage-downstream/10",
+  },
+  kqlColumn: {
+    label: "KQL column",
+    icon: Columns3,
+    tone: "border-object-column/30 bg-object-column/10 text-object-column",
+    selectedTone: "border-object-column/50 bg-object-column/10",
+  },
+  kqlFunction: {
+    label: "KQL function",
+    icon: Braces,
+    tone: "border-primary/30 bg-primary/10 text-primary",
+    selectedTone: "border-primary/50 bg-primary/10",
+  },
+  kqlFunctionParameter: {
+    label: "KQL function parameter",
+    icon: Braces,
+    tone: "border-object-column/30 bg-object-column/10 text-object-column",
+    selectedTone: "border-object-column/50 bg-object-column/10",
+  },
+  kqlMaterializedView: {
+    label: "KQL materialized view",
+    icon: Table2,
+    tone: "border-lineage-upstream/30 bg-lineage-upstream/10 text-lineage-upstream",
+    selectedTone: "border-lineage-upstream/50 bg-lineage-upstream/10",
+  },
+  sqlTable: {
+    label: "SQL table",
+    icon: Table2,
+    tone: "border-object-source/30 bg-object-source/10 text-object-source",
+    selectedTone: "border-object-source/50 bg-object-source/10",
+  },
+  sqlView: {
+    label: "SQL view",
+    icon: Table2,
+    tone: "border-lineage-downstream/30 bg-lineage-downstream/10 text-lineage-downstream",
+    selectedTone: "border-lineage-downstream/50 bg-lineage-downstream/10",
+  },
+  sqlColumn: {
+    label: "SQL column",
+    icon: Columns3,
+    tone: "border-object-column/30 bg-object-column/10 text-object-column",
+    selectedTone: "border-object-column/50 bg-object-column/10",
+  },
+  ontologyEntity: {
+    label: "Ontology entity",
+    icon: Network,
+    tone: "border-primary/30 bg-primary/10 text-primary",
+    selectedTone: "border-primary/50 bg-primary/10",
+  },
+  ontologyProperty: {
+    label: "Ontology property",
+    icon: Columns3,
+    tone: "border-object-column/30 bg-object-column/10 text-object-column",
+    selectedTone: "border-object-column/50 bg-object-column/10",
+  },
+  ontologyTimeSeriesProperty: {
+    label: "Ontology time-series property",
+    icon: Columns3,
+    tone: "border-lineage-upstream/30 bg-lineage-upstream/10 text-lineage-upstream",
+    selectedTone: "border-lineage-upstream/50 bg-lineage-upstream/10",
+  },
+  ontologyRelationship: {
+    label: "Ontology relationship",
+    icon: Link2,
+    tone: "border-lineage-downstream/30 bg-lineage-downstream/10 text-lineage-downstream",
+    selectedTone: "border-lineage-downstream/50 bg-lineage-downstream/10",
+  },
+  ontologyContextualization: {
+    label: "Ontology contextualization",
+    icon: Link2,
+    tone: "border-status-warning/30 bg-status-warning/10 text-status-warning",
+    selectedTone: "border-status-warning/50 bg-status-warning/10",
+  },
+  graphNode: {
+    label: "Graph node type",
+    icon: Waypoints,
+    tone: "border-primary/30 bg-primary/10 text-primary",
+    selectedTone: "border-primary/50 bg-primary/10",
+  },
+  graphEdge: {
+    label: "Graph edge type",
+    icon: Link2,
+    tone: "border-lineage-downstream/30 bg-lineage-downstream/10 text-lineage-downstream",
+    selectedTone: "border-lineage-downstream/50 bg-lineage-downstream/10",
+  },
+  graphProperty: {
+    label: "Graph property",
+    icon: Columns3,
+    tone: "border-object-column/30 bg-object-column/10 text-object-column",
+    selectedTone: "border-object-column/50 bg-object-column/10",
+  },
+  graphSourceMapping: {
+    label: "Graph source mapping",
+    icon: Link2,
+    tone: "border-object-source/30 bg-object-source/10 text-object-source",
+    selectedTone: "border-object-source/50 bg-object-source/10",
+  },
+  dataAgentSource: {
+    label: "Data Agent source",
+    icon: Bot,
+    tone: "border-primary/30 bg-primary/10 text-primary",
+    selectedTone: "border-primary/50 bg-primary/10",
+  },
+  dataAgentElement: {
+    label: "Data Agent selected source element",
+    icon: Boxes,
+    tone: "border-object-source/30 bg-object-source/10 text-object-source",
+    selectedTone: "border-object-source/50 bg-object-source/10",
+  },
 };
 
 const SCHEMA_CATALOG_ITEM_TYPES = new Set<ItemType>([
@@ -98,6 +214,9 @@ const SCHEMA_CATALOG_ITEM_TYPES = new Set<ItemType>([
   "SemanticModel",
   "Datamart",
   "MirroredDatabase",
+  "Ontology",
+  "GraphModel",
+  "DataAgent",
 ]);
 
 const ACCESS_META: Record<
@@ -177,6 +296,33 @@ function safeGroupId(value: string) {
   return `asset-group-${value.replace(/[^a-zA-Z0-9_-]+/g, "-")}`;
 }
 
+function matchesAsset(
+  asset: Asset,
+  itemById: ReadonlyMap<string, { displayName: string; itemType: ItemType }>,
+  query: string,
+  kind: AssetKind | "all",
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  const item = itemById.get(asset.itemFabricId);
+  const itemMatches =
+    item?.displayName.toLowerCase().includes(normalizedQuery) ||
+    typeMeta(item?.itemType ?? asset.itemType)
+      .label.toLowerCase()
+      .includes(normalizedQuery);
+  return (
+    (kind === "all" || asset.kind === kind) &&
+    (!normalizedQuery ||
+      itemMatches ||
+      asset.name.toLowerCase().includes(normalizedQuery) ||
+      asset.itemName.toLowerCase().includes(normalizedQuery) ||
+      (asset.tableName ?? "").toLowerCase().includes(normalizedQuery) ||
+      (asset.parentName ?? "").toLowerCase().includes(normalizedQuery) ||
+      (asset.source ?? "").toLowerCase().includes(normalizedQuery) ||
+      (asset.sourceItemName ?? "").toLowerCase().includes(normalizedQuery) ||
+      (asset.description ?? "").toLowerCase().includes(normalizedQuery))
+  );
+}
+
 export function AssetCatalogView({
   focus,
   onStateChange,
@@ -185,7 +331,7 @@ export function AssetCatalogView({
   onStateChange?: (navigation: AtlasNavigation) => void;
 } = {}) {
   const { data } = useAtlas();
-  const { items, config, principals } = data;
+  const { items, principals } = data;
 
   const itemById = useMemo(
     () => new Map(items.map((item) => [item.fabricId, item])),
@@ -199,95 +345,29 @@ export function AssetCatalogView({
     [principals],
   );
 
-  const assets = useMemo<Asset[]>(() => {
-    const output: Asset[] = [];
-    const seen = new Set<string>();
-    const push = (asset: Asset) => {
-      if (!seen.has(asset.id)) {
-        seen.add(asset.id);
-        output.push(asset);
-      }
-    };
-    for (const item of items) {
-      const schema = schemaFor(data, item.fabricId);
-      if (schema) {
-        for (const table of schema) {
-          const tableKind: AssetKind = table.objectType
-            ?.toLowerCase()
-            .includes("view")
-            ? "view"
-            : "table";
-          push({
-            id: `${item.fabricId}::t::${table.name}`,
-            itemFabricId: item.fabricId,
-            itemName: item.displayName,
-            itemType: item.itemType,
-            kind: tableKind,
-            name: table.name,
-            dataType: table.objectType,
-            source: table.source,
-            description: table.description,
-            isHidden: table.isHidden,
-          });
-          for (const column of table.columns) {
-            push({
-              id: `${item.fabricId}::c::${table.name}::${column.name}`,
-              itemFabricId: item.fabricId,
-              itemName: item.displayName,
-              itemType: item.itemType,
-              kind: "column",
-              name: column.name,
-              table: table.name,
-              dataType: column.dataType,
-              description: column.description,
-              isHidden: column.isHidden,
-            });
-          }
-          for (const measure of table.measures) {
-            push({
-              id: `${item.fabricId}::m::${table.name}::${measure.name}`,
-              itemFabricId: item.fabricId,
-              itemName: item.displayName,
-              itemType: item.itemType,
-              kind: "measure",
-              name: measure.name,
-              table: table.name,
-              description: measure.description,
-              isHidden: measure.isHidden,
-              expression: measure.expr,
-            });
-          }
-        }
-      }
-      for (const entry of config.filter(
-        (candidate) =>
-          candidate.itemFabricId === item.fabricId &&
-          candidate.section === "Tables",
-      )) {
-        push({
-          id: `${item.fabricId}::t::${entry.label}`,
-          itemFabricId: item.fabricId,
-          itemName: item.displayName,
-          itemType: item.itemType,
-          kind: "table",
-          name: entry.label,
-        });
-      }
-    }
-    return output;
-  }, [data, items, config]);
-
-  const initialFocusedAsset = assets.find(
-    (asset) =>
-      (!focus?.itemId || asset.itemFabricId === focus.itemId) &&
-      (!focus?.objectName || asset.name === focus.objectName) &&
-      (!focus?.tableName || asset.table === focus.tableName) &&
-      (!focus?.objectKind || asset.kind === focus.objectKind),
+  const assets = useMemo<Asset[]>(
+    () => buildCatalogObjects(data, { includeConfigTables: true }),
+    [data],
   );
+
+  const initialFocusedAsset =
+    focus?.objectId || focus?.objectName
+      ? assets.find(
+          (asset) =>
+            (!focus.itemId || asset.itemFabricId === focus.itemId) &&
+            (!focus.objectId || asset.objectId === focus.objectId) &&
+            (!focus.objectName || asset.name === focus.objectName) &&
+            (!focus.tableName ||
+              asset.tableName === focus.tableName ||
+              asset.parentName === focus.tableName) &&
+            (!focus.objectKind || asset.kind === focus.objectKind),
+        )
+      : undefined;
   const [query, setQuery] = useState(focus?.query ?? "");
   const [kind, setKind] = useState<AssetKind | "all">(
-    typeof focus?.filters?.kind === "string"
-      ? (focus.filters.kind as AssetKind)
+    typeof focus?.filters?.kind === "string" &&
+      isAssetObjectKind(focus.filters.kind)
+      ? focus.filters.kind
       : "all",
   );
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
@@ -298,27 +378,7 @@ export function AssetCatalogView({
   );
 
   const filtered = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    return assets.filter(
-      (asset) => {
-        const item = itemById.get(asset.itemFabricId);
-        const itemMatches =
-          item?.displayName.toLowerCase().includes(normalizedQuery) ||
-          typeMeta(item?.itemType ?? asset.itemType)
-            .label.toLowerCase()
-            .includes(normalizedQuery);
-        return (
-          (kind === "all" || asset.kind === kind) &&
-          (!normalizedQuery ||
-            itemMatches ||
-            asset.name.toLowerCase().includes(normalizedQuery) ||
-            asset.itemName.toLowerCase().includes(normalizedQuery) ||
-            (asset.table ?? "").toLowerCase().includes(normalizedQuery) ||
-            (asset.source ?? "").toLowerCase().includes(normalizedQuery) ||
-            (asset.description ?? "").toLowerCase().includes(normalizedQuery))
-        );
-      },
-    );
+    return assets.filter((asset) => matchesAsset(asset, itemById, query, kind));
   }, [assets, itemById, query, kind]);
 
   const inventoryItems = useMemo(() => {
@@ -372,8 +432,9 @@ export function AssetCatalogView({
       focus: {
         requestId: "assets-view-state",
         itemId: selectedAsset?.itemFabricId,
-        tableName: selectedAsset?.table,
+        tableName: selectedAsset?.tableName ?? selectedAsset?.parentName,
         objectName: selectedAsset?.name,
+        objectId: selectedAsset?.objectId,
         objectKind: selectedAsset?.kind,
         query: query.trim() || undefined,
         filters: kind === "all" ? undefined : { kind },
@@ -406,13 +467,13 @@ export function AssetCatalogView({
     );
   }, [accessRows, selectedAsset]);
 
-  const counts = {
-    all: assets.length,
-    table: assets.filter((asset) => asset.kind === "table").length,
-    view: assets.filter((asset) => asset.kind === "view").length,
-    column: assets.filter((asset) => asset.kind === "column").length,
-    measure: assets.filter((asset) => asset.kind === "measure").length,
-  };
+  const counts = Object.fromEntries([
+    ["all", assets.length],
+    ...ASSET_OBJECT_KINDS.map((assetKind) => [
+      assetKind,
+      assets.filter((asset) => asset.kind === assetKind).length,
+    ]),
+  ]) as Record<AssetKind | "all", number>;
   const kinds: { key: AssetKind | "all"; label: string; count: number }[] = [
     { key: "all", label: "All", count: counts.all },
     { key: "table", label: "Tables", count: counts.table },
@@ -420,17 +481,24 @@ export function AssetCatalogView({
     { key: "column", label: "Columns", count: counts.column },
     { key: "measure", label: "Measures / KPIs", count: counts.measure },
   ];
+  const additionalKinds = ASSET_OBJECT_KINDS.filter(
+    (assetKind) =>
+      !["table", "view", "column", "measure"].includes(assetKind) &&
+      counts[assetKind] > 0,
+  );
 
   const selectedItem = selectedAsset
     ? itemById.get(selectedAsset.itemFabricId)
     : undefined;
   const selectedObject = selectedAsset
-    ? ({
+    ? (["table", "view", "column", "measure"].includes(selectedAsset.kind)
+      ? ({
         itemId: selectedAsset.itemFabricId,
-        kind: selectedAsset.kind,
+        kind: selectedAsset.kind as SchemaObjectRef["kind"],
         name: selectedAsset.name,
-        tableName: selectedAsset.table,
+        tableName: selectedAsset.tableName,
       } satisfies SchemaObjectRef)
+      : undefined)
     : undefined;
   const selectedDependencies = selectedObject
     ? {
@@ -443,11 +511,32 @@ export function AssetCatalogView({
           [],
       }
     : { upstream: [], downstream: [] };
+  const selectedMetadataImpact = selectedAsset?.metadataRef
+    ? metadataObjectImpact(data.objectEdges, selectedAsset.metadataRef)
+    : undefined;
   const hasActiveFilters = Boolean(query.trim() || kind !== "all");
 
   const resetFilters = () => {
     setQuery("");
     setKind("all");
+  };
+  const changeQuery = (nextQuery: string) => {
+    setQuery(nextQuery);
+    if (
+      requestedAsset &&
+      !matchesAsset(requestedAsset, itemById, nextQuery, kind)
+    ) {
+      setSelId("");
+    }
+  };
+  const changeKind = (nextKind: AssetKind | "all") => {
+    setKind(nextKind);
+    if (
+      requestedAsset &&
+      !matchesAsset(requestedAsset, itemById, query, nextKind)
+    ) {
+      setSelId("");
+    }
   };
 
   return (
@@ -459,7 +548,7 @@ export function AssetCatalogView({
             <div className="mt-xs flex flex-wrap items-baseline gap-s">
               <h1 className="text-600 font-bold leading-600">Asset Catalog</h1>
               <span className="text-300 text-muted-foreground">
-                Tables, columns, measures and effective access
+                Physical, semantic, ontology, graph, KQL and agent objects
               </span>
             </div>
           </div>
@@ -498,14 +587,14 @@ export function AssetCatalogView({
             <input
               id="asset-search"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search asset, table or parent item"
+              onChange={(event) => changeQuery(event.target.value)}
+              placeholder="Search object, source or parent item"
               className="h-9 w-full rounded-lg border border-input bg-card pl-xxxl pr-xxxl text-300 text-foreground placeholder:text-muted-foreground"
             />
             {query && (
               <button
                 type="button"
-                onClick={() => setQuery("")}
+                onClick={() => changeQuery("")}
                 aria-label="Clear asset search"
                 className="absolute right-s top-1/2 -translate-y-1/2 rounded-md p-xs text-muted-foreground hover:bg-accent hover:text-foreground"
               >
@@ -524,7 +613,7 @@ export function AssetCatalogView({
                 type="button"
                 key={key}
                 aria-pressed={kind === key}
-                onClick={() => setKind(key)}
+                onClick={() => changeKind(key)}
                 className={cn(
                   "inline-flex h-9 items-center gap-s rounded-lg border px-m text-[length:var(--text-200)] font-semibold transition-colors",
                   kind === key
@@ -543,6 +632,29 @@ export function AssetCatalogView({
                 </span>
               </button>
             ))}
+            {additionalKinds.length > 0 && (
+              <select
+                aria-label="Filter by discovered object kind"
+                value={
+                  kind !== "all" &&
+                  !["table", "view", "column", "measure"].includes(kind)
+                    ? kind
+                    : ""
+                }
+                onChange={(event) => {
+                  const next = event.target.value;
+                  changeKind(isAssetObjectKind(next) ? next : "all");
+                }}
+                className="h-9 max-w-64 rounded-lg border border-input bg-card px-m text-200 font-semibold text-muted-foreground"
+              >
+                <option value="">More object kinds</option>
+                {additionalKinds.map((assetKind) => (
+                  <option key={assetKind} value={assetKind}>
+                    {assetObjectKindLabel(assetKind)} ({counts[assetKind]})
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
 
           {hasActiveFilters && (
@@ -680,8 +792,8 @@ export function AssetCatalogView({
                                   Item synchronized
                                 </div>
                                 <p className="mt-xs text-200 text-muted-foreground">
-                                  No tables, views, columns or measures were
-                                  exposed for this item in the latest sync.
+                                  No discoverable objects were exposed for this
+                                  item in the latest sync.
                                 </p>
                               </div>
                             </div>
@@ -708,7 +820,9 @@ export function AssetCatalogView({
                                   </span>
                                   <span className="block truncate text-200 text-muted-foreground">
                                     {meta.label}
-                                    {asset.table ? ` · ${asset.table}` : ""}
+                                    {asset.parentName
+                                      ? ` · ${asset.parentName}`
+                                      : ""}
                                   </span>
                                 </span>
                                 {asset.dataType && (
@@ -752,14 +866,16 @@ export function AssetCatalogView({
                         {selectedAsset.name}
                       </h2>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => setImpactOpen(true)}
-                      className="inline-flex items-center gap-s rounded-lg border border-border bg-card px-m py-s text-200 font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
-                    >
-                      <FileDown className="icon-size-100" aria-hidden="true" />
-                      Impact
-                    </button>
+                    {(selectedObject || selectedAsset.metadataRef) && (
+                      <button
+                        type="button"
+                        onClick={() => setImpactOpen(true)}
+                        className="inline-flex items-center gap-s rounded-lg border border-border bg-card px-m py-s text-200 font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
+                      >
+                        <FileDown className="icon-size-100" aria-hidden="true" />
+                        Impact
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={() => setSelId("")}
@@ -786,8 +902,8 @@ export function AssetCatalogView({
                       value={selectedAsset.dataType ?? "Not applicable"}
                     />
                     <MetadataCell
-                      label="Parent table"
-                      value={selectedAsset.table ?? "Root object"}
+                      label="Parent object"
+                      value={selectedAsset.parentName ?? "Root object"}
                     />
                     <MetadataCell
                       label="Parent item"
@@ -798,8 +914,24 @@ export function AssetCatalogView({
                       value={selectedAsset.source ?? "Source not recorded"}
                     />
                     <MetadataCell
+                      label="Source item"
+                      value={
+                        selectedAsset.sourceItemName ??
+                        selectedAsset.sourceItemId ??
+                        "Not recorded"
+                      }
+                    />
+                    <MetadataCell
                       label="Visibility"
-                      value={selectedAsset.isHidden == null ? "Not collected" : selectedAsset.isHidden ? "Hidden" : "Visible"}
+                      value={
+                        isMetadataAssetKind(selectedAsset.kind)
+                          ? "Not applicable"
+                          : selectedAsset.isHidden == null
+                            ? "Not collected"
+                            : selectedAsset.isHidden
+                              ? "Hidden"
+                              : "Visible"
+                      }
                     />
                   </div>
 
@@ -887,6 +1019,47 @@ export function AssetCatalogView({
                       ))}
                     </div>
                   )}
+
+                  {selectedMetadataImpact &&
+                    (selectedMetadataImpact.upstream.length > 0 ||
+                      selectedMetadataImpact.downstream.length > 0) && (
+                      <div className="mt-s grid gap-s sm:grid-cols-2">
+                        {[
+                          {
+                            title: "Verified sources",
+                            values: selectedMetadataImpact.upstream,
+                          },
+                          {
+                            title: "Verified consumers",
+                            values: selectedMetadataImpact.downstream,
+                          },
+                        ].map(({ title, values }) => (
+                          <section
+                            key={title}
+                            className="rounded-lg border border-border bg-secondary/55 p-m"
+                          >
+                            <h3 className="text-200 font-semibold">{title}</h3>
+                            <div className="mt-s space-y-xs">
+                              {values.map((object) => (
+                                <div
+                                  key={`${object.itemId}:${object.kind}:${object.id}`}
+                                  className="rounded-md bg-card px-s py-xs"
+                                >
+                                  <div className="truncate text-200 font-medium">
+                                    {object.name}
+                                  </div>
+                                  <div className="truncate text-100 text-muted-foreground">
+                                    {metadataObjectKindLabel(object.kind)} ·{" "}
+                                    {itemById.get(object.itemId)?.displayName ??
+                                      object.itemId}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </section>
+                        ))}
+                      </div>
+                    )}
 
                   <div className="mt-s flex items-center gap-m rounded-lg border border-border bg-secondary px-m py-m">
                     {selectedItem && (
@@ -1006,15 +1179,22 @@ export function AssetCatalogView({
                   Inspect an asset
                 </h2>
                 <p className="mt-xs text-300 text-muted-foreground">
-                  Expand an item group, then select a table, column or measure
-                  to review its context and effective access.
+                  Expand an item group, then select an object to review its
+                  context, provenance and effective access.
                 </p>
               </div>
             </motion.aside>
           )}
         </AnimatePresence>
       </div>
-      {selectedAsset && selectedObject && (
+      {selectedAsset?.metadataRef ? (
+        <MetadataObjectImpactDialog
+          data={data}
+          subject={selectedAsset.metadataRef}
+          open={impactOpen}
+          onClose={() => setImpactOpen(false)}
+        />
+      ) : selectedAsset && selectedObject ? (
         <ImpactReportDialog
           data={data}
           itemId={selectedAsset.itemFabricId}
@@ -1022,7 +1202,7 @@ export function AssetCatalogView({
           open={impactOpen}
           onClose={() => setImpactOpen(false)}
         />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/atlas/views/AssetCatalog.tsx
+++ b/src/atlas/views/AssetCatalog.tsx
@@ -105,7 +105,7 @@ const ACCESS_META: Record<
   { label: string; className: string }
 > = {
   owner: {
-    label: "Owner",
+    label: "Owner permission",
     className:
       "border-object-measure/30 bg-object-measure/10 text-object-measure",
   },
@@ -165,10 +165,10 @@ function MetadataCell({
 }) {
   return (
     <div className="min-w-0 rounded-lg border border-border bg-secondary px-m py-s">
-      <div className="text-100 font-semibold uppercase tracking-wide text-muted-foreground">
+      <div className="text-200 font-semibold text-muted-foreground">
         {label}
       </div>
-      <div className="mt-xxs truncate text-300 font-semibold">{value || "—"}</div>
+      <div className="mt-xxs break-words text-300 font-semibold">{value || "Not collected"}</div>
     </div>
   );
 }
@@ -453,7 +453,7 @@ export function AssetCatalogView({
   return (
     <div className="atlas-content-frame flex h-full flex-col gap-l p-xxl">
       <header className="overflow-hidden rounded-xl border border-border bg-card shadow-fabric-2">
-        <div className="flex flex-col gap-l px-xl py-l lg:flex-row lg:items-center">
+        <div className="atlas-page-header flex flex-col lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <SectionLabel>Schema inventory</SectionLabel>
             <div className="mt-xs flex flex-wrap items-baseline gap-s">
@@ -489,7 +489,7 @@ export function AssetCatalogView({
           </dl>
         </div>
 
-        <div className="flex flex-col gap-s border-t border-border bg-secondary px-xl py-m xl:flex-row xl:items-center">
+        <div className="atlas-toolbar flex flex-col border-t border-border bg-secondary px-l py-s xl:flex-row xl:items-center">
           <div className="relative min-w-0 flex-1">
             <label htmlFor="asset-search" className="sr-only">
               Search assets
@@ -560,7 +560,7 @@ export function AssetCatalogView({
 
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-l xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <section className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-fabric-2">
-          <div className="flex flex-wrap items-center gap-s border-b border-border bg-card px-l py-m">
+          <div className="atlas-toolbar atlas-row flex flex-wrap items-center border-b border-border bg-card px-l">
             <div>
               <h2 className="text-300 font-semibold">Items and assets</h2>
               <p className="text-200 text-muted-foreground">
@@ -643,7 +643,7 @@ export function AssetCatalogView({
                           return next;
                         })
                       }
-                      className="flex w-full items-center gap-m px-l py-m text-left transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-100"
+                      className="atlas-row flex w-full items-center gap-m px-l text-left transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-100"
                     >
                       <span className="flex size-xxl shrink-0 items-center justify-center rounded-md border border-border bg-secondary text-muted-foreground">
                         {open ? (
@@ -795,11 +795,11 @@ export function AssetCatalogView({
                     />
                     <MetadataCell
                       label="Source"
-                      value={selectedAsset.source ?? "Fabric metadata"}
+                      value={selectedAsset.source ?? "Source not recorded"}
                     />
                     <MetadataCell
                       label="Visibility"
-                      value={selectedAsset.isHidden ? "Hidden" : "Visible"}
+                      value={selectedAsset.isHidden == null ? "Not collected" : selectedAsset.isHidden ? "Hidden" : "Visible"}
                     />
                   </div>
 

--- a/src/atlas/views/Catalog.spec.tsx
+++ b/src/atlas/views/Catalog.spec.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SAMPLE_DATA } from "../model";
+import { displayPreferenceKey } from "../display-preferences";
+import { CatalogView } from "./Catalog";
+
+vi.mock("../store", () => ({
+  useAtlas: () => ({
+    data: SAMPLE_DATA,
+    currentUser: { id: "catalog-reviewer", name: "Reviewer" },
+  }),
+}));
+
+describe("CatalogView layout", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("preserves the card default and saves a personal table preference", () => {
+    render(<CatalogView />);
+    expect(screen.getByRole("button", { name: "Cards" })).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(screen.getByRole("button", { name: "Table" }));
+    expect(screen.getByRole("table")).toBeVisible();
+    expect(localStorage.getItem(
+      displayPreferenceKey("catalog-reviewer", SAMPLE_DATA.workspace.fabricId, "catalog-layout"),
+    )).toBe('"table"');
+  });
+
+  it("opens a table item in the existing detail drawer", () => {
+    const model = SAMPLE_DATA.items.find((item) => item.itemType === "SemanticModel")!;
+    render(<CatalogView />);
+    fireEvent.click(screen.getByRole("button", { name: "Table" }));
+    const table = within(screen.getByRole("region", { name: "Catalog table" }));
+    expect(table.queryByRole("button", { name: `Open details for ${model.displayName}` })).not.toBeInTheDocument();
+    fireEvent.click(table.getByRole("button", { name: /Semantic model/i }));
+    fireEvent.click(table.getByRole("button", { name: `Open details for ${model.displayName}` }));
+    expect(screen.getByRole("dialog", { name: `${model.displayName} details` })).toBeVisible();
+  });
+
+  it("expands search results without changing the default collapsed groups", () => {
+    const model = SAMPLE_DATA.items.find((item) => item.itemType === "SemanticModel")!;
+    render(<CatalogView />);
+    fireEvent.click(screen.getByRole("button", { name: "Table" }));
+    fireEvent.change(screen.getByLabelText("Search catalog"), { target: { value: model.displayName } });
+    const table = within(screen.getByRole("region", { name: "Catalog table" }));
+    expect(table.getByRole("button", { name: `Open details for ${model.displayName}` })).toBeVisible();
+    fireEvent.change(screen.getByLabelText("Search catalog"), { target: { value: "" } });
+    expect(table.queryByRole("button", { name: `Open details for ${model.displayName}` })).not.toBeInTheDocument();
+  });
+});

--- a/src/atlas/views/Catalog.tsx
+++ b/src/atlas/views/Catalog.tsx
@@ -5,10 +5,12 @@ import {
   ChevronRight,
   FilterX,
   Layers,
+  LayoutGrid,
   Search,
   Settings2,
   ShieldCheck,
   Tag,
+  Table2,
   Waypoints,
   X,
 } from "lucide-react";
@@ -20,6 +22,8 @@ import {
   type PosturePillar,
 } from "../posture";
 import { useAtlas } from "../store";
+import { isCatalogLayout, useDisplayPreference } from "../display-preferences";
+import { CatalogTable } from "../components/CatalogTable";
 import {
   Avatar,
   EndorsementChip,
@@ -59,7 +63,7 @@ const HEALTH_META: Record<
     dotClassName: "bg-status-failing",
   },
   unknown: {
-    label: "Unknown",
+    label: "Health unknown",
     className:
       "border-lineage-neutral/30 bg-lineage-neutral/10 text-muted-foreground",
     dotClassName: "bg-lineage-neutral",
@@ -90,7 +94,7 @@ function DrawerRow({
 }) {
   if (value == null || value === "") return null;
   return (
-    <div className="grid grid-cols-1 gap-xs border-t border-border/60 px-l py-m first:border-t-0 sm:grid-cols-3 sm:gap-l">
+    <div className="atlas-row grid grid-cols-1 gap-xs border-t border-border/60 px-l first:border-t-0 sm:grid-cols-3 sm:gap-l">
       <div className="text-200 font-semibold text-muted-foreground">
         {label}
       </div>
@@ -135,8 +139,15 @@ export function CatalogView({
   focus?: AtlasFocusRequest;
   onStateChange?: (navigation: AtlasNavigation) => void;
 } = {}) {
-  const { data } = useAtlas();
+  const { data, currentUser } = useAtlas();
   const { items, config, grants, edges, jobs, principals } = data;
+  const layout = useDisplayPreference(
+    currentUser.id,
+    data.workspace.fabricId,
+    "catalog-layout",
+    "cards",
+    isCatalogLayout,
+  );
 
   const groups = useMemo(() => {
     const grouped = new Map<ItemType, Item[]>();
@@ -193,6 +204,8 @@ export function CatalogView({
           )),
     );
   }, [items, postureItemIds, selType, query]);
+  const searching = Boolean(query.trim());
+  const visibleIds = useMemo(() => new Set(visible.map((item) => item.fabricId)), [visible]);
 
   const [detailId, setDetailId] = useState<string | null>(
     focus?.itemId ?? null,
@@ -309,7 +322,7 @@ export function CatalogView({
   return (
     <div className="atlas-content-frame p-xxl">
       <header className="mb-l overflow-hidden rounded-xl border border-border bg-card shadow-fabric-2">
-        <div className="flex flex-col gap-l px-xl py-l lg:flex-row lg:items-center">
+        <div className="atlas-page-header flex flex-col lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <SectionLabel>Workspace inventory</SectionLabel>
             <div className="mt-xs flex flex-wrap items-baseline gap-s">
@@ -342,7 +355,7 @@ export function CatalogView({
             </div>
           </dl>
         </div>
-        <div className="flex flex-wrap items-center gap-s border-t border-border bg-secondary px-xl py-s">
+        {hasActiveFilters && <div className="atlas-toolbar flex flex-wrap items-center border-t border-border bg-secondary px-l py-s">
           <Search className="icon-size-200 text-muted-foreground" />
           <span className="text-200 text-muted-foreground">
             Search by item name or tag, then narrow the inventory by type.
@@ -372,12 +385,13 @@ export function CatalogView({
               Clear filters
             </button>
           )}
-        </div>
+        </div>}
       </header>
+      {layout.error && <p role="status" className="mb-m rounded-lg border border-status-warning/30 bg-status-warning/10 p-m text-200">{layout.error}</p>}
 
       <div className="grid items-start gap-l lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] xl:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
         <aside className="flex flex-col overflow-hidden rounded-xl border border-border bg-card shadow-fabric-2 lg:sticky lg:top-l lg:max-h-screen">
-          <div className="sticky top-0 z-10 border-b border-border bg-card p-m">
+          <div className="atlas-toolbar sticky top-0 z-10 border-b border-border bg-card p-m">
             <label
               htmlFor="catalog-search"
               className="mb-s block text-200 font-semibold text-foreground"
@@ -438,8 +452,10 @@ export function CatalogView({
 
             <div className="my-s border-t border-border" />
 
-            {groups.map(([type, list]) => {
-              const open = expanded.has(type);
+            {groups.map(([type, allItems]) => {
+              const list = searching ? allItems.filter((item) => visibleIds.has(item.fabricId)) : allItems;
+              if (searching && list.length === 0) return null;
+              const open = searching || expanded.has(type);
               const selected = selType === type;
               return (
                 <div key={type} className="px-s">
@@ -455,6 +471,7 @@ export function CatalogView({
                       type="button"
                       aria-expanded={open}
                       aria-label={`${open ? "Collapse" : "Expand"} ${typeMeta(type).label}`}
+                      disabled={searching}
                       onClick={() => toggle(type)}
                       className="m-xs rounded-md p-s text-muted-foreground hover:bg-card hover:text-foreground"
                     >
@@ -512,12 +529,20 @@ export function CatalogView({
         </aside>
 
         <section aria-label="Catalog items">
-          <div className="mb-m flex items-center justify-between gap-m">
+          <div className="atlas-toolbar mb-m flex flex-wrap items-center justify-between">
             <div>
               <h2 className="text-400 font-semibold">Governed items</h2>
               <p className="text-200 text-muted-foreground">
                 {visible.length} {visible.length === 1 ? "result" : "results"}
               </p>
+            </div>
+            <div className="inline-flex gap-xs rounded-lg border border-border bg-card p-xs" role="group" aria-label="Catalog layout">
+              <button type="button" aria-pressed={layout.value === "cards"} onClick={() => layout.setValue("cards")} className={cn("inline-flex items-center gap-s rounded-md px-m py-s text-200 font-semibold", layout.value === "cards" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-accent")}>
+                <LayoutGrid className="icon-size-200" aria-hidden="true" /> Cards
+              </button>
+              <button type="button" aria-pressed={layout.value === "table"} onClick={() => layout.setValue("table")} className={cn("inline-flex items-center gap-s rounded-md px-m py-s text-200 font-semibold", layout.value === "table" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-accent")}>
+                <Table2 className="icon-size-200" aria-hidden="true" /> Table
+              </button>
             </div>
             {selType && (
               <button
@@ -545,6 +570,15 @@ export function CatalogView({
                 Clear filters
               </button>
             </div>
+          ) : layout.value === "table" ? (
+            <CatalogTable
+              items={visible}
+              expanded={expanded}
+              searching={searching}
+              selectedId={detailId}
+              onToggle={toggle}
+              onSelect={setDetailId}
+            />
           ) : (
             <div className="grid grid-cols-1 gap-m sm:grid-cols-2 2xl:grid-cols-3">
               {visible.map((item) => {
@@ -557,48 +591,45 @@ export function CatalogView({
                     aria-label={`Open details for ${item.displayName}`}
                     onClick={() => setDetailId(item.fabricId)}
                     className={cn(
-                      "group flex min-h-52 flex-col overflow-hidden rounded-xl border bg-card text-left text-card-foreground shadow-fabric-2 transition-[border-color,box-shadow,transform,background-color] hover:-translate-y-xxs hover:border-primary/50 hover:shadow-fabric-8",
+                      "atlas-catalog-card group flex flex-col overflow-hidden rounded-xl border bg-card text-left text-card-foreground shadow-fabric-2 transition-[border-color,box-shadow,background-color] hover:border-primary/50 hover:shadow-fabric-4",
                       selected
                         ? "border-primary bg-primary/5 ring-2 ring-primary/20"
                         : "border-border",
                     )}
                   >
-                    <div className="flex w-full items-start gap-m border-b border-border bg-secondary/70 px-l py-m">
+                    <div className="atlas-row flex w-full items-start gap-m border-b border-border bg-secondary/70 px-l">
                       <TypeGlyph type={item.itemType} size={36} />
                       <div className="min-w-0 flex-1">
-                        <div className="text-100 font-semibold uppercase tracking-wide text-muted-foreground">
+                        <div className="text-200 font-semibold text-muted-foreground">
                           {typeMeta(item.itemType).label}
                         </div>
-                        <div className="mt-xxs truncate text-400 font-bold leading-400">
+                        <div className="mt-xxs break-words text-400 font-bold leading-400">
                           {item.displayName}
                         </div>
                       </div>
                       <HealthBadge health={item.health} />
                     </div>
 
-                    <div className="flex flex-1 flex-col gap-m px-l py-m">
+                    <div className="atlas-row flex flex-1 flex-col gap-s px-l">
                       <div className="flex items-center gap-s">
-                        {item.ownerName ? (
+                        {item.ownerName || item.ownerEmail ? (
                           <>
-                            <Avatar name={item.ownerName} size={24} />
+                            <Avatar name={item.ownerName || item.ownerEmail || ""} size={24} />
                             <div className="min-w-0">
-                              <div className="text-100 font-semibold uppercase tracking-wide text-muted-foreground">
-                                Owner
+                              <div className="text-200 font-semibold text-muted-foreground">
+                                Documented owner
                               </div>
                               <div className="truncate text-200 font-semibold">
-                                {item.ownerName}
+                                {item.ownerName || item.ownerEmail}
                               </div>
                             </div>
                           </>
                         ) : (
                           <div>
-                            <div className="text-100 font-semibold uppercase tracking-wide text-muted-foreground">
-                              Owner
-                            </div>
                             <div className="text-200 text-muted-foreground">
                               {item.ownerMetadataAvailable === false
-                                ? "Not collected"
-                                : "Unassigned"}
+                                ? "Ownership not collected"
+                                : "No documented owner"}
                             </div>
                           </div>
                         )}
@@ -718,13 +749,13 @@ export function CatalogView({
                 >
                   <DrawerRow label="Description" value={detail.description} />
                   <DrawerRow
-                    label="Owner"
+                    label="Documented owner"
                     value={
                       detail.ownerName
                         ? `${detail.ownerName}${detail.ownerEmail ? ` · ${detail.ownerEmail}` : ""}`
-                        : detail.ownerMetadataAvailable === false
+                        : detail.ownerEmail || (detail.ownerMetadataAvailable === false
                           ? "Not collected"
-                          : "Unassigned"
+                          : "Unassigned")
                     }
                   />
                   <DrawerRow
@@ -862,7 +893,7 @@ export function CatalogView({
                         return (
                           <div
                             key={index}
-                            className="flex items-center gap-s px-l py-m text-300"
+                            className="atlas-row flex items-center gap-s px-l text-300"
                           >
                             <PrincipalAvatar
                               name={principalName}
@@ -873,7 +904,9 @@ export function CatalogView({
                               {principalName}
                             </span>
                             <span className="text-200 text-muted-foreground">
-                              {grant.roleName ?? grant.accessLevel}
+                              {grant.accessLevel === "owner"
+                                ? "Owner permission"
+                                : grant.roleName ?? grant.accessLevel}
                             </span>
                           </div>
                         );

--- a/src/atlas/views/Config.tsx
+++ b/src/atlas/views/Config.tsx
@@ -130,7 +130,7 @@ export function ConfigView({
       <div className="grid items-start gap-l lg:grid-cols-3">
         <aside aria-label="Configuration items" className="lg:sticky lg:top-l">
           <Card className="overflow-hidden">
-            <div className="border-b border-border p-l">
+            <div className="atlas-toolbar border-b border-border p-l">
               <div className="flex items-center justify-between gap-s">
                 <div>
                   <h2 className="text-400 leading-400 font-semibold">Items</h2>
@@ -198,7 +198,7 @@ export function ConfigView({
                     }}
                     aria-current={isSelected ? "true" : undefined}
                     className={cn(
-                      "flex w-full items-center gap-m border-l px-l py-m text-left transition-colors",
+                      "atlas-row flex w-full items-center gap-m border-l px-l text-left transition-colors",
                       isSelected
                         ? "border-l-primary bg-accent text-accent-foreground"
                         : "border-l-transparent hover:bg-accent/60",
@@ -263,7 +263,7 @@ export function ConfigView({
                       </h2>
                       <p className="mt-xs text-300 leading-300 text-muted-foreground">
                         {typeMeta(selected.itemType).label}
-                        {selected.ownerName ? ` · Owned by ${selected.ownerName}` : ""}
+                        {selected.ownerName ? ` · Documented owner: ${selected.ownerName}` : ""}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-s">
@@ -334,7 +334,7 @@ export function ConfigView({
                               onClick={() => toggleSection(section)}
                               aria-expanded={isOpen}
                               aria-controls={regionId}
-                              className="flex w-full items-center gap-s bg-secondary px-l py-m text-left transition-colors hover:bg-accent"
+                              className="atlas-row flex w-full items-center gap-s bg-secondary px-l text-left transition-colors hover:bg-accent"
                             >
                               {isOpen ? (
                                 <ChevronDown
@@ -360,7 +360,7 @@ export function ConfigView({
                                 {values.map((entry, entryIndex) => (
                                   <div
                                     key={`${entry.label}-${entryIndex}`}
-                                    className="grid gap-s px-l py-m md:grid-cols-3"
+                                    className="atlas-row grid gap-s px-l md:grid-cols-3"
                                   >
                                     <dt className="text-300 leading-300 font-semibold text-muted-foreground">
                                       {entry.label}

--- a/src/atlas/views/GovernanceCenter.spec.tsx
+++ b/src/atlas/views/GovernanceCenter.spec.tsx
@@ -36,6 +36,10 @@ describe("GovernanceCenterView", () => {
         name: "Your governance baseline is ready",
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText("No new priority alert")).toBeInTheDocument();
+    expect(
+      screen.getByText("Workspace governance summary"),
+    ).toBeInTheDocument();
   });
 
   it("supports arrow-key tab navigation", async () => {
@@ -101,6 +105,31 @@ describe("GovernanceCenterView", () => {
       screen.getByRole("heading", { name: /pillars at target/ }),
     ).toBeInTheDocument();
     expect(screen.getByText(/Fixed 0–100 scale/)).toBeInTheDocument();
+    expect(screen.getAllByText("Target 70%").length).toBeGreaterThan(0);
+  });
+
+  it("adds a shared exception without hiding the raw finding", async () => {
+    renderView();
+    const evidenceCount = screen.getAllByRole("button", {
+      name: "Open evidence",
+    }).length;
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Add exception" })[0],
+    );
+    fireEvent.change(screen.getByLabelText("Justification"), {
+      target: { value: "Accepted while the owner record is corrected." },
+    });
+    fireEvent.change(screen.getByLabelText("Expires"), {
+      target: { value: "2099-09-05T12:00" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save exception" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Active exception")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getAllByRole("button", { name: "Open evidence" }),
+    ).toHaveLength(evidenceCount);
   });
 });
 
@@ -130,7 +159,7 @@ describe("RadarPanel", () => {
     onDownload: vi.fn(),
   };
 
-  it("shows the monitored goal as a watermark when no risk is new", () => {
+  it("keeps monitored signals in expandable details when no risk is new", () => {
     render(<RadarPanel {...baseProps} radar={readyRadar} />);
 
     expect(

--- a/src/atlas/views/GovernanceCenter.tsx
+++ b/src/atlas/views/GovernanceCenter.tsx
@@ -1550,8 +1550,8 @@ function PostureSection({
               {atTarget} of {current.pillars.length} pillars at target
             </h2>
             <p className="mt-xs text-200 text-muted-foreground">
-              Pillars are evaluated independently; non-applicable evidence is
-              never counted as zero.
+              Standard baseline: 70% for each pillar. Non-applicable evidence
+              is never counted as zero.
             </p>
           </div>
           <label>

--- a/src/atlas/views/GovernanceCenter.tsx
+++ b/src/atlas/views/GovernanceCenter.tsx
@@ -24,6 +24,9 @@ import { motion } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
 import { SavedViewsMenu } from "../components/SavedViewsMenu";
 import { TrendChart } from "../components/TrendChart";
+import { GovernanceExceptionControl } from "../components/GovernanceExceptionControl";
+import { GovernancePolicyEditor } from "../components/GovernancePolicyEditor";
+import { HistoricalChangeDetails } from "../components/HistoricalChangeDetails";
 import { ATLAS_CONFIG } from "../config";
 import {
   buildGovernanceFindings,
@@ -37,6 +40,7 @@ import {
   snapshotCatalogFromData,
   type AtlasChange,
   type AtlasChangeDomain,
+  type HistoricalSnapshot,
   type SnapshotSummary,
 } from "../history";
 import type {
@@ -52,6 +56,7 @@ import {
   type RiskyChange,
 } from "../radar";
 import type { FindingAcknowledgement } from "../finding-acks";
+import type { GovernanceException } from "../governance-exceptions";
 import { radarToMarkdown } from "../radar-markdown";
 import {
   scorePosture,
@@ -198,17 +203,6 @@ function changeTone(change: AtlasChange): string {
   return "border-status-warning/30 bg-status-warning/10 text-status-warning";
 }
 
-function compactValue(value: unknown): string {
-  if (value == null || value === "") return "None";
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value);
-  }
-  const serialized = JSON.stringify(value);
-  return serialized.length > 140
-    ? `${serialized.slice(0, 137)}...`
-    : serialized;
-}
-
 function focusRequest(
   values: Omit<AtlasFocusRequest, "requestId">,
 ): AtlasFocusRequest {
@@ -275,6 +269,20 @@ export function GovernanceCenterView({
     findingAckPendingIds,
     saveFindingAcknowledgement,
     removeFindingAcknowledgement,
+    governanceTargets,
+    governancePolicyLoading,
+    governancePolicyError,
+    governanceExceptions,
+    governanceExceptionsLoading,
+    governanceExceptionsError,
+    governanceExceptionPendingIds,
+    canSync,
+    reloadGovernancePolicy,
+    saveGovernanceTargets,
+    resetGovernanceTargets,
+    reloadGovernanceExceptions,
+    saveGovernanceException,
+    removeGovernanceException,
   } = useAtlas();
   const initialSection =
     focus?.governanceSection ??
@@ -497,12 +505,15 @@ export function GovernanceCenterView({
       new Map(
         history.snapshots.map((snapshot) => [
           snapshot.snapshotId,
-          scorePosture(snapshot.catalog),
+          scorePosture(snapshot.catalog, governanceTargets),
         ]),
       ),
-    [history.snapshots],
+    [governanceTargets, history.snapshots],
   );
-  const currentPosture = scorePosture(snapshotCatalogFromData(data));
+  const currentPosture = scorePosture(
+    snapshotCatalogFromData(data),
+    governanceTargets,
+  );
   const previousPosture = historyIsCurrent
     ? postureScores.get(history.summaries[1]?.snapshotId ?? "")
     : undefined;
@@ -518,6 +529,19 @@ export function GovernanceCenterView({
     !historyError &&
     Boolean(effectiveCurrentSnapshotId && effectivePreviousSnapshotId) &&
     (!selectedCurrent || !selectedPrevious);
+  const comparisonNewer =
+    selectedCurrent && selectedPrevious
+      ? Date.parse(selectedCurrent.syncedAt) >=
+        Date.parse(selectedPrevious.syncedAt)
+        ? selectedCurrent
+        : selectedPrevious
+      : undefined;
+  const comparisonOlder =
+    selectedCurrent && selectedPrevious
+      ? comparisonNewer === selectedCurrent
+        ? selectedPrevious
+        : selectedCurrent
+      : undefined;
 
   useEffect(() => {
     if (section !== "changes") return;
@@ -542,14 +566,9 @@ export function GovernanceCenterView({
     section,
   ]);
   const snapshotChanges = useMemo(() => {
-    if (!selectedCurrent || !selectedPrevious) return [];
-    const newer =
-      Date.parse(selectedCurrent.syncedAt) >= Date.parse(selectedPrevious.syncedAt)
-        ? selectedCurrent
-        : selectedPrevious;
-    const older = newer === selectedCurrent ? selectedPrevious : selectedCurrent;
-    return compareSnapshots(older, newer);
-  }, [selectedCurrent, selectedPrevious]);
+    if (!comparisonNewer || !comparisonOlder) return [];
+    return compareSnapshots(comparisonOlder, comparisonNewer);
+  }, [comparisonNewer, comparisonOlder]);
   const filteredChanges = useMemo(() => {
     const query = changeSearch.trim().toLowerCase();
     return snapshotChanges.filter(
@@ -583,6 +602,18 @@ export function GovernanceCenterView({
       : history.changes.filter(
           (change) => change.snapshotId === history.current?.snapshotId,
         ).length;
+  const exceptionByFinding = useMemo(
+    () =>
+      new Map(
+        governanceExceptions.map((exception) => [
+          exception.findingId,
+          exception,
+        ]),
+      ),
+    [governanceExceptions],
+  );
+  const hasNewPriorityAlert =
+    radar.state === "ready" && allRadarEntries.length > 0;
   const tabs: Array<{
     id: GovernanceSection;
     label: string;
@@ -739,6 +770,11 @@ export function GovernanceCenterView({
         historyLoading={historyLoading}
         failedSnapshotIds={radarFailedSnapshotIds}
         pendingIds={findingAckPendingIds}
+        exceptions={exceptionByFinding}
+        exceptionsLoading={governanceExceptionsLoading}
+        exceptionsError={governanceExceptionsError}
+        exceptionPendingIds={governanceExceptionPendingIds}
+        canManageExceptions={canSync}
         onAcknowledge={(entry) =>
           saveFindingAcknowledgement({
             findingId: entry.id,
@@ -754,6 +790,9 @@ export function GovernanceCenterView({
           })
         }
         onRestore={(id) => removeFindingAcknowledgement(id)}
+        onSaveException={saveGovernanceException}
+        onRemoveException={removeGovernanceException}
+        onRetryExceptions={reloadGovernanceExceptions}
         onReviewChanges={() => {
           if (radar.state === "ready") {
             setCurrentSnapshotId(radar.currentSnapshotId);
@@ -817,24 +856,25 @@ export function GovernanceCenterView({
         }}
       />
       <Card className="overflow-hidden border-border shadow-fabric-4">
-        <div className="atlas-fabric-hero relative overflow-hidden p-l sm:p-xl">
-          <div className="relative flex flex-col gap-l lg:flex-row lg:items-end lg:justify-between">
+        <div className="atlas-page-header atlas-fabric-hero relative overflow-hidden">
+          <div className="atlas-row relative flex flex-col gap-m lg:flex-row lg:items-center lg:justify-between">
             <div className="flex items-start gap-m">
-              <span className="atlas-brand-mark flex icon-size-700 shrink-0 items-center justify-center rounded-xl text-primary-foreground">
-                <ShieldCheck className="icon-size-400" aria-hidden="true" />
+              <span className="atlas-brand-mark flex icon-size-600 shrink-0 items-center justify-center rounded-xl text-primary-foreground">
+                <ShieldCheck className="icon-size-300" aria-hidden="true" />
               </span>
               <div>
                 <SectionLabel>Govern / workspace assurance</SectionLabel>
-                <h1 className="mt-xs font-heading text-600 font-bold leading-600">
+                <h1 className="mt-xxs font-heading text-500 font-bold leading-500">
                   Governance Center
                 </h1>
-                <p className="mt-xs max-w-3xl text-300 leading-300 text-muted-foreground">
-                  See what changed, what needs attention, and where Fabric
-                  metadata coverage is incomplete without leaving the workspace.
+                <p className="mt-xxs max-w-3xl text-200 text-muted-foreground">
+                  {hasNewPriorityAlert
+                    ? `${allRadarEntries.length} new priority alert${allRadarEntries.length === 1 ? "" : "s"} require review.`
+                    : "No new priority alert. Governance details remain available below."}
                 </p>
               </div>
             </div>
-            <div className="flex flex-wrap items-center gap-s">
+            <div className="atlas-toolbar flex flex-wrap items-center gap-s">
               <SavedViewsMenu
                 views={savedViews.filter(
                   (view) => view.section === "governance",
@@ -850,55 +890,57 @@ export function GovernanceCenterView({
               <span
                 className={cn(
                   "rounded-full border px-m py-s text-200 font-semibold",
-                  priorityFindings
+                  hasNewPriorityAlert
                     ? "border-status-warning/30 bg-status-warning/10 text-status-warning"
                     : "border-status-healthy/30 bg-status-healthy/10 text-status-healthy",
                 )}
               >
-                {priorityFindings
-                  ? `${priorityFindings} priority findings`
-                  : "No priority finding"}
+                {hasNewPriorityAlert
+                  ? `${allRadarEntries.length} new priority alert${allRadarEntries.length === 1 ? "" : "s"}`
+                  : "No new priority alert"}
               </span>
             </div>
           </div>
 
-          <div className="relative mt-l grid grid-cols-2 gap-s lg:grid-cols-4">
-            {[
-              {
-                label: "Open findings",
-                value: findings.length,
-                detail: `${priorityFindings} high priority`,
-              },
-              {
-                label: "Latest changes",
-                value: currentChanges,
-                detail: history.summaries.length > 1 ? "Since previous sync" : "Needs two snapshots",
-              },
-              {
-                label: "Coverage",
-                value: `${coverageScore}%`,
-                detail: "Across available metadata",
-              },
-              {
-                label: "History",
-                value: history.summaries.length,
-                detail: "Validated snapshots",
-              },
-            ].map((metric) => (
-              <div
-                key={metric.label}
-                className="rounded-xl border border-border bg-background/65 p-m backdrop-blur"
-              >
-                <div className="font-numeric text-500 font-bold">
-                  {metric.value}
+          <details className="relative mt-m rounded-lg border border-border bg-background/65">
+            <summary className="cursor-pointer px-m py-s text-200 font-semibold text-primary">
+              Workspace governance summary
+            </summary>
+            <div className="grid grid-cols-2 gap-s border-t border-border p-m lg:grid-cols-4">
+              {[
+                {
+                  label: "Open findings",
+                  value: findings.length,
+                  detail: `${priorityFindings} high priority`,
+                },
+                {
+                  label: "Latest changes",
+                  value: currentChanges,
+                  detail: history.summaries.length > 1 ? "Since previous sync" : "Needs two snapshots",
+                },
+                {
+                  label: "Coverage",
+                  value: `${coverageScore}%`,
+                  detail: "Across available metadata",
+                },
+                {
+                  label: "History",
+                  value: history.summaries.length,
+                  detail: "Validated snapshots",
+                },
+              ].map((metric) => (
+                <div key={metric.label} className="rounded-lg bg-secondary/60 p-m">
+                  <div className="font-numeric text-400 font-bold">
+                    {metric.value}
+                  </div>
+                  <div className="text-200 font-semibold">{metric.label}</div>
+                  <div className="mt-xxs text-100 text-muted-foreground">
+                    {metric.detail}
+                  </div>
                 </div>
-                <div className="text-200 font-semibold">{metric.label}</div>
-                <div className="mt-xxs text-100 text-muted-foreground">
-                  {metric.detail}
-                </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </details>
         </div>
 
         <Tabs.List
@@ -971,6 +1013,12 @@ export function GovernanceCenterView({
             onNavigate={(finding) =>
               onNavigate(navigationForFinding(finding))
             }
+            exceptions={exceptionByFinding}
+            exceptionsLoading={governanceExceptionsLoading}
+            exceptionPendingIds={governanceExceptionPendingIds}
+            canManageExceptions={canSync}
+            onSaveException={saveGovernanceException}
+            onRemoveException={removeGovernanceException}
             onPreset={(preset) => {
               setFindingPillar("");
               if (preset === "external") {
@@ -1009,24 +1057,20 @@ export function GovernanceCenterView({
             search={changeSearch}
             domain={changeDomain}
             loading={historyLoading || comparisonLoading}
+            historyError={historyError}
+            failedSnapshotIds={historyFailedSnapshotIds}
+            loadedSnapshots={history.snapshots}
+            loadHistorySnapshot={loadHistorySnapshot}
+            comparisonCurrentSnapshotId={
+              comparisonNewer?.snapshotId ?? effectiveCurrentSnapshotId
+            }
+            comparisonPreviousSnapshotId={
+              comparisonOlder?.snapshotId ?? effectivePreviousSnapshotId
+            }
             onCurrentSnapshot={setCurrentSnapshotId}
             onPreviousSnapshot={setPreviousSnapshotId}
             onSearch={setChangeSearch}
             onDomain={setChangeDomain}
-            onNavigate={(change) => {
-              if (change.itemFabricId) {
-                onNavigate({
-                  tab:
-                    change.domain === "schema" ? "assets" : "catalog",
-                  focus: focusRequest({
-                    itemId: change.itemFabricId,
-                    objectName: change.objectName,
-                    tableName: change.tableName,
-                    objectKind: change.objectType,
-                  }),
-                });
-              }
-            }}
           />
         </motion.div>
       </Tabs.Content>
@@ -1070,6 +1114,12 @@ export function GovernanceCenterView({
             summaries={history.trend}
             selectedPillar={postureMetric}
             loading={historyLoading}
+            policyLoading={governancePolicyLoading}
+            policyError={governancePolicyError}
+            canEditPolicy={canSync}
+            onRetryPolicy={reloadGovernancePolicy}
+            onSaveTargets={saveGovernanceTargets}
+            onResetTargets={resetGovernanceTargets}
             onPillar={setPostureMetric}
             onNavigate={onNavigate}
           />
@@ -1089,9 +1139,17 @@ export function RadarPanel({
   historyLoading,
   failedSnapshotIds,
   pendingIds,
+  exceptions = new Map<string, GovernanceException>(),
+  exceptionsLoading = false,
+  exceptionsError,
+  exceptionPendingIds = new Set<string>(),
+  canManageExceptions = false,
   onAcknowledge,
   onMute,
   onRestore,
+  onSaveException = async () => undefined,
+  onRemoveException = async () => undefined,
+  onRetryExceptions = async () => undefined,
   onReviewChanges,
   onRetryHistory,
   onOpen,
@@ -1105,9 +1163,21 @@ export function RadarPanel({
   historyLoading: boolean;
   failedSnapshotIds: string[];
   pendingIds: Set<string>;
+  exceptions?: ReadonlyMap<string, GovernanceException>;
+  exceptionsLoading?: boolean;
+  exceptionsError?: string;
+  exceptionPendingIds?: Set<string>;
+  canManageExceptions?: boolean;
   onAcknowledge: (entry: RadarEntry) => Promise<void>;
   onMute: (entry: RadarEntry) => Promise<void>;
   onRestore: (id: string) => Promise<void>;
+  onSaveException?: (input: {
+    findingId: string;
+    reason: string;
+    expiresAt: string;
+  }) => Promise<void>;
+  onRemoveException?: (id: string) => Promise<void>;
+  onRetryExceptions?: () => Promise<void>;
   onReviewChanges: () => void;
   onRetryHistory: () => void;
   onOpen: (entry: RadarEntry) => void;
@@ -1118,28 +1188,28 @@ export function RadarPanel({
     radar.state === "baseline" && radar.reason === "first-snapshot";
   return (
     <Card className="overflow-hidden border-primary/25 shadow-fabric-4">
-      <div className="atlas-fabric-hero flex flex-col gap-l p-l lg:flex-row lg:items-center">
-        <span className="flex icon-size-700 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-          <RadarIcon className="icon-size-400" aria-hidden="true" />
+      <div className="atlas-page-header atlas-fabric-hero flex flex-col gap-m lg:flex-row lg:items-center">
+        <span className="flex icon-size-600 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+          <RadarIcon className="icon-size-300" aria-hidden="true" />
         </span>
         <div className="min-w-0 flex-1">
           <SectionLabel>Governance radar</SectionLabel>
-          <h2 className="mt-xs text-500 font-semibold">
+          <h2 className="mt-xxs text-400 font-semibold">
             {firstSnapshotBaseline
               ? "Your governance baseline is ready"
               : "What became risky since the last sync"}
           </h2>
-          <p className="mt-xs text-200 text-muted-foreground">
+          <p className="mt-xxs text-200 text-muted-foreground">
             {firstSnapshotBaseline
               ? "The first validated snapshot arms the Radar; the next sync will produce risk deltas."
               : "New high-priority findings and dangerous access, sensitivity, lineage or removal changes only."}
           </p>
         </div>
-        {ready && (
+        {ready && entries.length > 0 && (
           <button
             type="button"
             onClick={onDownload}
-            className="inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m py-s text-200 font-semibold hover:bg-accent"
+            className="atlas-control inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent"
           >
             <Download className="icon-size-100" />
             Export digest
@@ -1155,6 +1225,33 @@ export function RadarPanel({
           >
             Personal acknowledgements are unavailable; Radar remains fully
             visible. {error}
+          </div>
+        )}
+        {exceptionsError && (
+          <div
+            role="alert"
+            className="flex flex-col gap-s border-b border-status-warning/25 bg-status-warning/10 px-l py-s text-200 text-status-warning sm:flex-row sm:items-center"
+          >
+            <span className="min-w-0 flex-1">
+              Shared governance exceptions are unavailable; findings remain
+              visible. {exceptionsError}
+            </span>
+            <button
+              type="button"
+              disabled={exceptionsLoading}
+              onClick={() => void onRetryExceptions().catch(() => undefined)}
+              className="atlas-control rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent disabled:opacity-50"
+            >
+              Retry exceptions
+            </button>
+          </div>
+        )}
+        {exceptionsLoading && ready && !exceptionsError && (
+          <div
+            role="status"
+            className="border-b border-border bg-secondary/50 px-l py-s text-100 text-muted-foreground"
+          >
+            Loading shared governance exceptions...
           </div>
         )}
         {loading && ready && (
@@ -1185,7 +1282,7 @@ export function RadarPanel({
               type="button"
               disabled={historyLoading}
               onClick={onRetryHistory}
-              className="inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m py-s text-200 font-semibold hover:bg-accent disabled:opacity-50"
+              className="atlas-control inline-flex items-center justify-center gap-s rounded-lg border border-border bg-card px-m font-semibold hover:bg-accent disabled:opacity-50"
             >
               <RotateCcw className="icon-size-100" />
               {historyLoading ? "Retrying…" : "Retry comparison"}
@@ -1223,7 +1320,7 @@ export function RadarPanel({
             {entries.map((entry) => (
               <div
                 key={entry.id}
-                className="grid gap-m p-l lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center"
+                className="atlas-row grid gap-m px-l lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center"
               >
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-s">
@@ -1246,10 +1343,20 @@ export function RadarPanel({
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-s">
+                  <GovernanceExceptionControl
+                    findingId={entry.id}
+                    findingTitle={entry.title}
+                    exception={exceptions.get(entry.id)}
+                    canEdit={canManageExceptions}
+                    loading={exceptionsLoading}
+                    pending={exceptionPendingIds.has(entry.id)}
+                    onSave={onSaveException}
+                    onRemove={onRemoveException}
+                  />
                   <button
                     type="button"
                     onClick={() => onOpen(entry)}
-                    className="rounded-lg border border-border px-m py-s text-200 font-semibold hover:bg-accent"
+                    className="atlas-control rounded-lg border border-border px-m font-semibold hover:bg-accent"
                   >
                     Open evidence
                   </button>
@@ -1259,7 +1366,7 @@ export function RadarPanel({
                     onClick={() =>
                       void onAcknowledge(entry).catch(() => undefined)
                     }
-                    className="inline-flex items-center gap-s rounded-lg border border-status-healthy/30 bg-status-healthy/10 px-m py-s text-200 font-semibold text-status-healthy disabled:opacity-50"
+                    className="atlas-control inline-flex items-center gap-s rounded-lg border border-status-healthy/30 bg-status-healthy/10 px-m font-semibold text-status-healthy disabled:opacity-50"
                   >
                     <CheckCheck className="icon-size-100" />
                     Acknowledge
@@ -1270,7 +1377,7 @@ export function RadarPanel({
                     onClick={() =>
                       void onMute(entry).catch(() => undefined)
                     }
-                    className="inline-flex items-center gap-s rounded-lg border border-border px-m py-s text-200 font-semibold text-muted-foreground hover:bg-accent disabled:opacity-50"
+                    className="atlas-control inline-flex items-center gap-s rounded-lg border border-border px-m font-semibold text-muted-foreground hover:bg-accent disabled:opacity-50"
                   >
                     <VolumeX className="icon-size-100" />
                     Mute
@@ -1281,7 +1388,7 @@ export function RadarPanel({
           </div>
         )}
         {suppressed.length > 0 && (
-          <div className="flex flex-wrap items-center gap-s border-t border-border bg-secondary/50 px-l py-s">
+          <div className="atlas-row flex flex-wrap items-center gap-s border-t border-border bg-secondary/50 px-l">
             <span className="text-200 text-muted-foreground">
               {suppressed.length} hidden radar item
               {suppressed.length === 1 ? "" : "s"}
@@ -1298,7 +1405,7 @@ export function RadarPanel({
                     () => undefined,
                   )
                 }
-                className="rounded-full border border-border bg-card px-s py-xs text-100 font-semibold text-primary hover:bg-primary/10 disabled:opacity-50"
+                className="atlas-control rounded-full border border-border bg-card px-s text-100 font-semibold text-primary hover:bg-primary/10 disabled:opacity-50"
               >
                 Restore {acknowledgement.findingId.slice(0, 18)}
               </button>
@@ -1325,39 +1432,35 @@ function RadarTargetState({
 }) {
   const baseline = mode === "baseline";
   const StatusIcon = baseline ? Clock3 : CheckCircle2;
-  const CenterIcon = baseline ? Clock3 : ShieldCheck;
-  const watermarkClass = baseline ? "text-primary" : "text-status-healthy";
   const titleClass = baseline ? "text-primary" : "text-status-healthy";
   const signalClass = baseline
     ? "inline-flex items-center gap-xs rounded-full border border-primary/20 bg-primary/5 px-s py-xs text-100 font-semibold text-primary"
     : "inline-flex items-center gap-xs rounded-full border border-status-healthy/20 bg-status-healthy/5 px-s py-xs text-100 font-semibold text-status-healthy";
 
   return (
-    <div className="relative overflow-hidden p-l">
-      <div
-        aria-hidden="true"
-        className={`pointer-events-none absolute right-l top-1/2 -translate-y-1/2 opacity-10 ${watermarkClass}`}
-      >
-        <RadarIcon className="icon-size-800" />
-        <CenterIcon className="absolute left-1/2 top-1/2 icon-size-400 -translate-x-1/2 -translate-y-1/2" />
-      </div>
-      <div className="relative max-w-3xl">
+    <div className="p-m">
+      <div className="max-w-3xl">
         <div className="flex items-center gap-s text-300 font-semibold">
           <StatusIcon className={`icon-size-200 ${titleClass}`} />
           <span className={titleClass}>{title}</span>
         </div>
         <p className="mt-xs text-200 text-muted-foreground">{description}</p>
-        <div
-          aria-label="Radar monitored signals"
-          className="mt-m flex flex-wrap gap-s"
-        >
-          {RADAR_SIGNALS.map((signal) => (
-            <span key={signal} className={signalClass}>
-              <StatusIcon className="icon-size-100" />
-              {signal}
-            </span>
-          ))}
-        </div>
+        <details className="mt-s">
+          <summary className="cursor-pointer text-200 font-semibold text-primary">
+            Radar details
+          </summary>
+          <div
+            aria-label="Radar monitored signals"
+            className="mt-m flex flex-wrap gap-s"
+          >
+            {RADAR_SIGNALS.map((signal) => (
+              <span key={signal} className={signalClass}>
+                <StatusIcon className="icon-size-100" />
+                {signal}
+              </span>
+            ))}
+          </div>
+        </details>
         {!baseline && observedChangeCount > 0 && onReviewChanges && (
           <div className="mt-m flex flex-col gap-s rounded-lg border border-border bg-secondary/70 p-m sm:flex-row sm:items-center">
             <FileClock className="icon-size-200 shrink-0 text-primary" />
@@ -1369,7 +1472,7 @@ function RadarTargetState({
             <button
               type="button"
               onClick={onReviewChanges}
-              className="shrink-0 rounded-lg border border-border bg-card px-m py-s text-200 font-semibold text-primary hover:bg-primary/10"
+              className="atlas-control shrink-0 rounded-lg border border-border bg-card px-m font-semibold text-primary hover:bg-primary/10"
             >
               Review changes
             </button>
@@ -1396,6 +1499,12 @@ function PostureSection({
   summaries,
   selectedPillar,
   loading,
+  policyLoading,
+  policyError,
+  canEditPolicy,
+  onRetryPolicy,
+  onSaveTargets,
+  onResetTargets,
   onPillar,
   onNavigate,
 }: {
@@ -1405,6 +1514,14 @@ function PostureSection({
   summaries: SnapshotSummary[];
   selectedPillar: PosturePillar;
   loading: boolean;
+  policyLoading: boolean;
+  policyError?: string;
+  canEditPolicy: boolean;
+  onRetryPolicy: () => Promise<void>;
+  onSaveTargets: (
+    targets: Record<PosturePillar, number>,
+  ) => Promise<void>;
+  onResetTargets: () => Promise<void>;
   onPillar: (pillar: PosturePillar) => void;
   onNavigate: (navigation: AtlasNavigation) => void;
 }) {
@@ -1444,7 +1561,7 @@ function PostureSection({
               onChange={(event) =>
                 onPillar(event.target.value as PosturePillar)
               }
-              className="h-9 rounded-lg border border-input bg-card px-m text-300"
+              className="atlas-control rounded-lg border border-input bg-card px-m"
             >
               {current.pillars.map((pillar) => (
                 <option key={pillar.pillar} value={pillar.pillar}>
@@ -1529,6 +1646,21 @@ function PostureSection({
         </div>
       </Card>
 
+      <GovernancePolicyEditor
+        key={current.pillars
+          .map((pillar) => `${pillar.pillar}:${pillar.target}`)
+          .join("|")}
+        targets={Object.fromEntries(
+          current.pillars.map((pillar) => [pillar.pillar, pillar.target]),
+        ) as Record<PosturePillar, number>}
+        loading={policyLoading}
+        error={policyError}
+        canEdit={canEditPolicy}
+        onRetry={onRetryPolicy}
+        onSave={onSaveTargets}
+        onReset={onResetTargets}
+      />
+
       <Card className="overflow-hidden">
         <div className="border-b border-border bg-secondary/55 px-l py-m">
           <h3 className="text-300 font-semibold">
@@ -1571,6 +1703,12 @@ function FindingsSection({
   onClearPillar,
   onNavigate,
   onPreset,
+  exceptions,
+  exceptionsLoading,
+  exceptionPendingIds,
+  canManageExceptions,
+  onSaveException,
+  onRemoveException,
 }: {
   findings: GovernanceFinding[];
   total: number;
@@ -1584,6 +1722,16 @@ function FindingsSection({
   onClearPillar: () => void;
   onNavigate: (finding: GovernanceFinding) => void;
   onPreset: (value: "all" | "external" | "metadata" | "failures") => void;
+  exceptions: ReadonlyMap<string, GovernanceException>;
+  exceptionsLoading: boolean;
+  exceptionPendingIds: Set<string>;
+  canManageExceptions: boolean;
+  onSaveException: (input: {
+    findingId: string;
+    reason: string;
+    expiresAt: string;
+  }) => Promise<void>;
+  onRemoveException: (id: string) => Promise<void>;
 }) {
   const activeFilters =
     search || severity !== "all" || category !== "all" || pillar;
@@ -1622,13 +1770,13 @@ function FindingsSection({
             <button
               type="button"
               onClick={onClearPillar}
-              className="rounded-lg px-s py-xs text-200 font-semibold text-primary hover:bg-primary/10"
+              className="atlas-control rounded-lg px-s text-200 font-semibold text-primary hover:bg-primary/10"
             >
               Clear pillar
             </button>
           </div>
         )}
-        <div className="flex flex-col gap-s border-b border-border bg-secondary/55 p-m lg:flex-row lg:items-center">
+        <div className="atlas-toolbar flex flex-col gap-s border-b border-border bg-secondary/55 p-m lg:flex-row lg:items-center">
           <label className="relative min-w-0 flex-1">
             <span className="sr-only">Search governance findings</span>
             <Search className="icon-size-200 pointer-events-none absolute left-m top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -1636,7 +1784,7 @@ function FindingsSection({
               value={search}
               onChange={(event) => onSearch(event.target.value)}
               placeholder="Search finding, evidence or recommendation"
-              className="h-9 w-full rounded-lg border border-input bg-card pl-xxxl pr-m text-300"
+              className="atlas-control w-full rounded-lg border border-input bg-card pl-xxxl pr-m"
             />
           </label>
           <select
@@ -1645,7 +1793,7 @@ function FindingsSection({
             onChange={(event) =>
               onSeverity(event.target.value as GovernanceSeverity | "all")
             }
-            className="h-9 rounded-lg border border-input bg-card px-m text-300"
+            className="atlas-control rounded-lg border border-input bg-card px-m"
           >
             <option value="all">All severities</option>
             <option value="critical">Critical</option>
@@ -1659,7 +1807,7 @@ function FindingsSection({
             onChange={(event) =>
               onCategory(event.target.value as GovernanceCategory | "all")
             }
-            className="h-9 rounded-lg border border-input bg-card px-m text-300"
+            className="atlas-control rounded-lg border border-input bg-card px-m"
           >
             <option value="all">All categories</option>
             <option value="access">Access</option>
@@ -1671,7 +1819,7 @@ function FindingsSection({
             <button
               type="button"
               onClick={() => onPreset("all")}
-              className="inline-flex h-9 items-center gap-s rounded-lg px-m text-200 font-semibold text-primary hover:bg-primary/10"
+              className="atlas-control inline-flex items-center gap-s rounded-lg px-m font-semibold text-primary hover:bg-primary/10"
             >
               <FilterX className="icon-size-100" />
               Reset
@@ -1735,14 +1883,26 @@ function FindingsSection({
                   <div className="mt-m rounded-lg bg-secondary px-m py-s text-200 text-muted-foreground">
                     {finding.recommendation}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => onNavigate(finding)}
-                    className="mt-m inline-flex items-center gap-s self-start text-200 font-semibold text-primary hover:underline"
-                  >
-                    Open evidence
-                    <ArrowRight className="icon-size-100" />
-                  </button>
+                  <div className="atlas-row mt-m flex flex-wrap items-center gap-s">
+                    <button
+                      type="button"
+                      onClick={() => onNavigate(finding)}
+                      className="atlas-control inline-flex items-center gap-s px-s font-semibold text-primary hover:underline"
+                    >
+                      Open evidence
+                      <ArrowRight className="icon-size-100" />
+                    </button>
+                    <GovernanceExceptionControl
+                      findingId={finding.id}
+                      findingTitle={finding.title}
+                      exception={exceptions.get(finding.id)}
+                      canEdit={canManageExceptions}
+                      loading={exceptionsLoading}
+                      pending={exceptionPendingIds.has(finding.id)}
+                      onSave={onSaveException}
+                      onRemove={onRemoveException}
+                    />
+                  </div>
                 </article>
               );
             })}
@@ -1762,11 +1922,16 @@ function ChangesSection({
   search,
   domain,
   loading,
+  historyError,
+  failedSnapshotIds,
+  loadedSnapshots,
+  loadHistorySnapshot,
+  comparisonCurrentSnapshotId,
+  comparisonPreviousSnapshotId,
   onCurrentSnapshot,
   onPreviousSnapshot,
   onSearch,
   onDomain,
-  onNavigate,
 }: {
   changes: AtlasChange[];
   total: number;
@@ -1776,11 +1941,16 @@ function ChangesSection({
   search: string;
   domain: AtlasChangeDomain | "all";
   loading: boolean;
+  historyError?: string;
+  failedSnapshotIds: Set<string>;
+  loadedSnapshots: HistoricalSnapshot[];
+  loadHistorySnapshot: (snapshotId: string) => Promise<void>;
+  comparisonCurrentSnapshotId: string;
+  comparisonPreviousSnapshotId: string;
   onCurrentSnapshot: (value: string) => void;
   onPreviousSnapshot: (value: string) => void;
   onSearch: (value: string) => void;
   onDomain: (value: AtlasChangeDomain | "all") => void;
-  onNavigate: (change: AtlasChange) => void;
 }) {
   return (
     <Card className="overflow-hidden">
@@ -1792,7 +1962,7 @@ function ChangesSection({
           <select
             value={currentSnapshotId}
             onChange={(event) => onCurrentSnapshot(event.target.value)}
-            className="h-9 w-full rounded-lg border border-input bg-card px-m text-300"
+            className="atlas-control w-full rounded-lg border border-input bg-card px-m"
           >
             {snapshots.map((snapshot) => (
               <option key={snapshot.snapshotId} value={snapshot.snapshotId}>
@@ -1808,7 +1978,7 @@ function ChangesSection({
           <select
             value={previousSnapshotId}
             onChange={(event) => onPreviousSnapshot(event.target.value)}
-            className="h-9 w-full rounded-lg border border-input bg-card px-m text-300"
+            className="atlas-control w-full rounded-lg border border-input bg-card px-m"
           >
             {snapshots.map((snapshot) => (
               <option key={snapshot.snapshotId} value={snapshot.snapshotId}>
@@ -1827,7 +1997,7 @@ function ChangesSection({
         </div>
       </div>
 
-      <div className="flex flex-col gap-s border-b border-border p-m sm:flex-row">
+      <div className="atlas-toolbar flex flex-col gap-s border-b border-border p-m sm:flex-row">
         <label className="relative min-w-0 flex-1">
           <span className="sr-only">Search snapshot changes</span>
           <Search className="icon-size-200 pointer-events-none absolute left-m top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -1835,7 +2005,7 @@ function ChangesSection({
             value={search}
             onChange={(event) => onSearch(event.target.value)}
             placeholder="Search item, schema object or changed field"
-            className="h-9 w-full rounded-lg border border-input bg-card pl-xxxl pr-m text-300"
+            className="atlas-control w-full rounded-lg border border-input bg-card pl-xxxl pr-m"
           />
         </label>
         <select
@@ -1844,7 +2014,7 @@ function ChangesSection({
           onChange={(event) =>
             onDomain(event.target.value as AtlasChangeDomain | "all")
           }
-          className="h-9 rounded-lg border border-input bg-card px-m text-300"
+          className="atlas-control rounded-lg border border-input bg-card px-m"
         >
           <option value="all">All domains</option>
           {Object.entries(CHANGE_DOMAIN_LABEL).map(([id, label]) => (
@@ -1885,7 +2055,7 @@ function ChangesSection({
           {changes.map((change) => (
             <article
               key={change.id}
-              className="grid gap-m px-l py-m hover:bg-accent/40 lg:grid-cols-[150px_minmax(0,1fr)_auto]"
+              className="atlas-row grid gap-m px-l hover:bg-accent/40 lg:grid-cols-[150px_minmax(0,1fr)_auto]"
             >
               <div className="flex flex-wrap items-start gap-s">
                 <span
@@ -1909,39 +2079,17 @@ function ChangesSection({
                     ? `Changed: ${change.changedFields.join(", ")}`
                     : change.type.replaceAll("-", " ")}
                 </p>
-                {(change.before !== undefined || change.after !== undefined) && (
-                  <div className="mt-s grid gap-s text-100 sm:grid-cols-2">
-                    <div className="rounded-lg bg-secondary px-s py-xs">
-                      <span className="font-semibold text-muted-foreground">
-                        Before
-                      </span>
-                      <div className="mt-xxs break-all font-mono">
-                        {compactValue(change.before)}
-                      </div>
-                    </div>
-                    <div className="rounded-lg bg-primary/5 px-s py-xs">
-                      <span className="font-semibold text-muted-foreground">
-                        After
-                      </span>
-                      <div className="mt-xxs break-all font-mono">
-                        {compactValue(change.after)}
-                      </div>
-                    </div>
-                  </div>
-                )}
               </div>
-              {change.itemFabricId &&
-                change.type !== "item-removed" &&
-                change.type !== "schema-object-removed" && (
-                <button
-                  type="button"
-                  onClick={() => onNavigate(change)}
-                  className="inline-flex items-center gap-s self-start text-200 font-semibold text-primary hover:underline"
-                >
-                  Inspect
-                  <ArrowRight className="icon-size-100" />
-                </button>
-              )}
+              <HistoricalChangeDetails
+                change={change}
+                previousSnapshotId={comparisonPreviousSnapshotId}
+                currentSnapshotId={comparisonCurrentSnapshotId}
+                snapshots={loadedSnapshots}
+                historyLoading={loading}
+                historyError={historyError}
+                failedSnapshotIds={failedSnapshotIds}
+                loadHistorySnapshot={loadHistorySnapshot}
+              />
             </article>
           ))}
         </div>
@@ -1989,7 +2137,7 @@ function HistorySection({
               onChange={(event) =>
                 onMetric(event.target.value as HistoryMetric)
               }
-              className="h-9 rounded-lg border border-input bg-card px-m text-300"
+              className="atlas-control rounded-lg border border-input bg-card px-m"
             >
               {HISTORY_METRICS.map((candidate) => (
                 <option key={candidate.id} value={candidate.id}>

--- a/src/atlas/views/Jobs.tsx
+++ b/src/atlas/views/Jobs.tsx
@@ -226,7 +226,7 @@ export function JobsView({
 
   return (
     <div className="atlas-content-frame flex flex-col gap-xl p-xl lg:p-xxl">
-      <header className="border-l border-primary pl-l">
+      <header className="atlas-page-header">
         <SectionLabel>Operations / run history</SectionLabel>
         <div className="mt-s flex flex-col gap-s lg:flex-row lg:items-end lg:justify-between">
           <div>
@@ -286,7 +286,7 @@ export function JobsView({
             )}
           </div>
 
-          <div className="flex flex-col gap-s border-b border-border bg-secondary/60 px-l py-s sm:flex-row sm:items-center">
+          <div className="atlas-toolbar flex flex-col border-b border-border bg-secondary/60 px-l py-s sm:flex-row sm:items-center">
             <label className="relative min-w-0 flex-1">
               <span className="sr-only">Search job history</span>
               <Search className="icon-size-200 pointer-events-none absolute left-m top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -466,7 +466,7 @@ function JobTimeline({
               <li
                 key={`${job.itemFabricId}-${job.jobType}-${job.startedAt}`}
                 className={cn(
-                  "atlas-windowed-block relative grid gap-m border-b border-border/60 px-l py-m transition-colors last:border-b-0 hover:bg-accent/50 md:grid-cols-[auto_minmax(180px,1.3fr)_minmax(120px,0.8fr)_minmax(150px,0.9fr)_100px_minmax(180px,1fr)] md:items-center",
+                  "atlas-row atlas-windowed-block relative grid gap-m border-b border-border/60 px-l transition-colors last:border-b-0 hover:bg-accent/50 md:grid-cols-[auto_minmax(180px,1.3fr)_minmax(120px,0.8fr)_minmax(150px,0.9fr)_100px_minmax(180px,1fr)] md:items-center",
                   job.status === "failed" && "bg-status-failing/5",
                 )}
               >

--- a/src/atlas/views/Map.spec.tsx
+++ b/src/atlas/views/Map.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { displayPreferenceKey } from "../display-preferences";
 import { MAP_INSPECTOR_DEFAULT_WIDTH } from "../map-inspector";
-import { SAMPLE_DATA } from "../model";
+import { SAMPLE_DATA, typeMeta } from "../model";
 import { AtlasProvider } from "../store";
 import { MapView } from "./Map";
 
@@ -110,6 +110,7 @@ describe("MapView selection", () => {
       clientY: 100,
       pointerId: 1,
     });
+
     fireEvent.pointerUp(lakehouse, {
       button: 0,
       clientX: 100,
@@ -123,6 +124,76 @@ describe("MapView selection", () => {
     expect(selectedLakehouse).toHaveAttribute("aria-pressed", "true");
     expect(selectedLakehouse.style.left).toBe(position.left);
     expect(selectedLakehouse.style.top).toBe(position.top);
+  });
+
+  it("keeps item nodes compact with visible space between rows and stages", () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+    const nodes = SAMPLE_DATA.items
+      .map((item) =>
+        screen.queryByLabelText(
+          `${item.displayName}, ${typeMeta(item.itemType).label}, ${item.health}`,
+        ),
+      )
+      .filter((node): node is HTMLButtonElement => node instanceof HTMLButtonElement);
+    expect(nodes.length).toBeGreaterThan(1);
+    expect(
+      Math.max(...nodes.map((node) => parseFloat(node.style.width))),
+    ).toBeLessThanOrEqual(224);
+
+    const byColumn = new Map<number, HTMLButtonElement[]>();
+    for (const node of nodes) {
+      const left = parseFloat(node.style.left);
+      byColumn.set(left, [...(byColumn.get(left) ?? []), node]);
+    }
+    const columns = [...byColumn.keys()].sort((left, right) => left - right);
+    for (let index = 1; index < columns.length; index += 1) {
+      const previous = byColumn.get(columns[index - 1])![0];
+      expect(
+        columns[index] -
+          columns[index - 1] -
+          parseFloat(previous.style.width),
+      ).toBeGreaterThanOrEqual(48);
+    }
+    for (const column of byColumn.values()) {
+      const ordered = column.sort(
+        (left, right) => parseFloat(left.style.top) - parseFloat(right.style.top),
+      );
+      for (let index = 1; index < ordered.length; index += 1) {
+        const previous = ordered[index - 1];
+        expect(
+          parseFloat(ordered[index].style.top) -
+            parseFloat(previous.style.top) -
+            parseFloat(previous.style.height),
+        ).toBeGreaterThanOrEqual(16);
+      }
+    }
+  });
+
+  it("moves selection to a matching item when its type is filtered", () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+    const report = SAMPLE_DATA.items.find((item) => item.itemType === "Report")!;
+    fireEvent.change(screen.getByLabelText("Filter by item type"), {
+      target: { value: "Report" },
+    });
+    expect(
+      screen.queryByLabelText("AlpineRent Sales Model, Semantic model, healthy"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText(`${report.displayName}, Report, ${report.health}`),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Item details inspector")).toHaveTextContent(
+      report.displayName,
+    );
   });
 
   it("supports object selection, highlighting and drag", () => {
@@ -146,6 +217,7 @@ describe("MapView selection", () => {
       clientY: 100,
       pointerId: 2,
     });
+
     fireEvent.pointerMove(table, {
       clientX: 150,
       clientY: 130,
@@ -181,6 +253,30 @@ describe("MapView selection", () => {
         name: "Selected object lineage relationships",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("selects the matching table when the object table filter changes", () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "objects" }));
+    const tableFilter = screen.getByLabelText("Select object lineage table");
+    const options = [...tableFilter.querySelectorAll("option")];
+    expect(options.length).toBeGreaterThan(1);
+    const nextTable = options[1].value;
+    fireEvent.click(screen.getByLabelText(/Total Revenue, Measure/i));
+    fireEvent.change(tableFilter, { target: { value: nextTable } });
+    const selectedTable = screen
+      .getAllByLabelText(
+        new RegExp(`^${nextTable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")},`),
+      )
+      .find((node) => node.getAttribute("aria-label")?.includes("columns"));
+    expect(
+      selectedTable,
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("moves a multi-selection together and fully resets positions", () => {

--- a/src/atlas/views/Map.spec.tsx
+++ b/src/atlas/views/Map.spec.tsx
@@ -5,12 +5,34 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { displayPreferenceKey } from "../display-preferences";
+import { MAP_INSPECTOR_DEFAULT_WIDTH } from "../map-inspector";
 import { SAMPLE_DATA } from "../model";
 import { AtlasProvider } from "../store";
 import { MapView } from "./Map";
 
 describe("MapView selection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  const selectInspectorTab = async (
+    currentName: string,
+    nextName: string,
+  ) => {
+    const current = screen.getByRole("tab", { name: currentName });
+    act(() => current.focus());
+    fireEvent.keyDown(current, { key: "ArrowRight" });
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: nextName })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+  };
+
   it("shows the full workspace by default without edge text overlays", () => {
     window.history.replaceState(null, "", "/#map");
     const { container } = render(
@@ -189,6 +211,7 @@ describe("MapView selection", () => {
       clientY: 100,
       pointerId: 4,
     });
+
     fireEvent.pointerMove(lakehouse, {
       clientX: 150,
       clientY: 140,
@@ -212,5 +235,117 @@ describe("MapView selection", () => {
     expect(model.style.top).toBe(initial.modelTop);
     expect(lakehouse.style.left).toBe(initial.lakehouseLeft);
     expect(lakehouse.style.top).toBe(initial.lakehouseTop);
+  });
+
+  it("keeps widened object nodes inside the canvas bounds", () => {
+    window.history.replaceState(null, "", "/#map");
+    const { container } = render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "objects" }));
+    const nodes = [...container.querySelectorAll<HTMLButtonElement>(".atlas-map-grid button[aria-pressed]")]
+      .filter((node) => node.style.width && node.style.left);
+    expect(nodes.length).toBeGreaterThan(0);
+    for (const node of nodes) {
+      const canvas = node.parentElement!;
+      expect(parseFloat(node.style.left) + parseFloat(node.style.width))
+        .toBeLessThanOrEqual(parseFloat(canvas.style.width));
+      expect(parseFloat(node.style.top) + parseFloat(node.style.height))
+        .toBeLessThanOrEqual(parseFloat(canvas.style.height));
+    }
+  });
+
+  it("persists and resets the inspector width for the preview identity and workspace", () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+
+    const separator = screen.getByRole("separator", {
+      name: "Resize details inspector",
+    });
+    fireEvent.keyDown(separator, { key: "ArrowLeft" });
+
+    const key = displayPreferenceKey(
+      "preview-user",
+      SAMPLE_DATA.workspace.fabricId,
+      "map-inspector-width",
+    );
+    expect(localStorage.getItem(key)).toBe(
+      JSON.stringify(MAP_INSPECTOR_DEFAULT_WIDTH + 16),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reset inspector width" }),
+    );
+    expect(localStorage.getItem(key)).toBe(
+      JSON.stringify(MAP_INSPECTOR_DEFAULT_WIDTH),
+    );
+  });
+
+  it("surfaces an invalid saved inspector preference", () => {
+    window.history.replaceState(null, "", "/#map");
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    localStorage.setItem(
+      displayPreferenceKey(
+        "preview-user",
+        SAMPLE_DATA.workspace.fabricId,
+        "map-inspector-width",
+      ),
+      JSON.stringify(100),
+    );
+
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "saved display setting could not be loaded",
+    );
+  });
+
+  it("distinguishes documented ownership from owner permission", async () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+
+    expect(screen.getByText("Documented owner")).toBeInTheDocument();
+    await selectInspectorTab("Summary", "Schema");
+    await selectInspectorTab("Schema", "Access");
+    expect(
+      await screen.findByText(
+        /owner permission is an access role and is separate from documented ownership/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Owner permission").length).toBeGreaterThan(0);
+  });
+
+  it("keeps schema groups collapsed until a search is active", async () => {
+    window.history.replaceState(null, "", "/#map");
+    render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+
+    await selectInspectorTab("Summary", "Schema");
+    const table = await screen.findByRole("button", {
+      name: /rentals_daily_summary/i,
+    });
+    expect(table).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.change(screen.getByLabelText("Search lineage"), {
+      target: { value: "rentals" },
+    });
+    expect(table).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/src/atlas/views/Map.spec.tsx
+++ b/src/atlas/views/Map.spec.tsx
@@ -7,7 +7,12 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { displayPreferenceKey } from "../display-preferences";
+import type { MetadataObjectLineageEdge } from "../item-metadata";
 import { MAP_INSPECTOR_DEFAULT_WIDTH } from "../map-inspector";
+import {
+  buildMetadataObjectGraph,
+  MAX_VISIBLE_OBJECT_EDGES,
+} from "../metadata-object-graph";
 import { SAMPLE_DATA, typeMeta } from "../model";
 import { AtlasProvider } from "../store";
 import { MapView } from "./Map";
@@ -16,6 +21,154 @@ describe("MapView selection", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+  });
+
+  describe("metadata object graph", () => {
+    const items = new Map(
+      [
+        {
+          fabricId: "warehouse",
+          displayName: "Operations warehouse",
+          itemType: "Warehouse" as const,
+          health: "healthy" as const,
+          endorsement: "none" as const,
+          tags: [],
+        },
+        {
+          fabricId: "ontology",
+          displayName: "Operations ontology",
+          itemType: "Ontology" as const,
+          health: "healthy" as const,
+          endorsement: "none" as const,
+          tags: [],
+        },
+      ].map((item) => [item.fabricId, item]),
+    );
+    const edges: MetadataObjectLineageEdge[] = [
+      {
+        source: {
+          itemId: "warehouse",
+          kind: "sourceObject",
+          id: "dbo.Devices",
+          name: "Devices",
+          tableName: "Devices",
+        },
+        target: {
+          itemId: "ontology",
+          kind: "ontologyEntity",
+          id: "device",
+          name: "Device",
+        },
+        relation: "binds entity",
+        confidence: "verified",
+      },
+      {
+        source: {
+          itemId: "ontology",
+          kind: "ontologyEntity",
+          id: "device",
+          name: "Device",
+        },
+        target: {
+          itemId: "ontology",
+          kind: "ontologyRelationship",
+          id: "installed-at",
+          name: "Installed at",
+        },
+        relation: "relationship source",
+        confidence: "verified",
+      },
+      {
+        source: {
+          itemId: "ontology",
+          kind: "ontologyRelationship",
+          id: "installed-at",
+          name: "Installed at",
+        },
+        target: {
+          itemId: "ontology",
+          kind: "ontologyEntity",
+          id: "site",
+          name: "Site",
+        },
+        relation: "relationship target",
+        confidence: "verified",
+      },
+      {
+        source: {
+          itemId: "unrelated",
+          kind: "sourceObject",
+          id: "Other",
+          name: "Other",
+        },
+        target: {
+          itemId: "another-item",
+          kind: "graphNode",
+          id: "OtherNode",
+          name: "Other node",
+        },
+        relation: "maps node",
+        confidence: "verified",
+      },
+    ];
+
+    it("lays out verified selected-item edges from source to consumer", () => {
+      const graph = buildMetadataObjectGraph(edges, "ontology", items);
+      const byName = new Map(graph.nodes.map((node) => [node.label, node]));
+
+      expect(graph.verifiedMetadata).toBe(true);
+      expect(graph.edges).toHaveLength(3);
+      expect(byName.has("Other")).toBe(false);
+      expect(byName.get("Devices")!.x).toBeLessThan(byName.get("Device")!.x);
+      expect(byName.get("Device")!.x).toBeLessThan(
+        byName.get("Installed at")!.x,
+      );
+      expect(byName.get("Installed at")!.x).toBeLessThan(
+        byName.get("Site")!.x,
+      );
+    });
+
+    it("filters around matching objects and caps dense graphs", () => {
+      const relationshipGraph = buildMetadataObjectGraph(
+        edges,
+        "ontology",
+        items,
+        { objectKind: "ontologyRelationship" },
+      );
+      expect(relationshipGraph.edges).toHaveLength(2);
+      expect(relationshipGraph.nodes.map((node) => node.label)).toEqual(
+        expect.arrayContaining(["Device", "Installed at", "Site"]),
+      );
+
+      const denseEdges: MetadataObjectLineageEdge[] = Array.from(
+        { length: MAX_VISIBLE_OBJECT_EDGES + 25 },
+        (_, index) => ({
+          source: {
+            itemId: "warehouse",
+            kind: "sourceField" as const,
+            id: `Devices.Field${index}`,
+            name: `Field${index}`,
+            tableName: "Devices",
+          },
+          target: {
+            itemId: "ontology",
+            kind: "ontologyProperty" as const,
+            id: `property-${index}`,
+            name: `Property ${index}`,
+            tableName: "Device",
+          },
+          relation: "binds property",
+          confidence: "verified" as const,
+        }),
+      );
+      const denseGraph = buildMetadataObjectGraph(
+        denseEdges,
+        "ontology",
+        items,
+      );
+      expect(denseGraph.edges).toHaveLength(MAX_VISIBLE_OBJECT_EDGES);
+      expect(denseGraph.truncated).toBe(true);
+    });
   });
 
   const selectInspectorTab = async (

--- a/src/atlas/views/Map.tsx
+++ b/src/atlas/views/Map.tsx
@@ -66,10 +66,13 @@ import {
   type SchemaObjectRef,
 } from "../lineage";
 
-const NODE_W = 260;
-const NODE_H = 84;
-const OBJECT_W = 268;
-const OBJECT_H = 92;
+const NODE_W = 220;
+const NODE_H = 76;
+const OBJECT_W = 224;
+const OBJECT_H = 76;
+const NODE_COLUMN_GAP = 292;
+const NODE_ROW_GAP = 100;
+const OBJECT_ROW_GAP = 100;
 const UP = "var(--color-lineage-upstream)";
 const DOWN = "var(--color-lineage-downstream)";
 
@@ -201,6 +204,32 @@ function curve(source: Point, target: Point, width = NODE_W, height = NODE_H): s
   return `M${x1},${y1} C${x1 + bend},${y1} ${x2 - bend},${y2} ${x2},${y2}`;
 }
 
+function matchesItemFilters(
+  item: Item,
+  type: string,
+  health: Health | "all",
+  query: string,
+): boolean {
+  const normalized = query.trim().toLowerCase();
+  return (
+    (type === "all" || item.itemType === type) &&
+    (health === "all" || item.health === health) &&
+    (!normalized ||
+      item.displayName.toLowerCase().includes(normalized) ||
+      typeMeta(item.itemType).label.toLowerCase().includes(normalized) ||
+      item.tags.some((tag) => tag.toLowerCase().includes(normalized)))
+  );
+}
+
+function matchesObjectQuery(node: ObjectNode, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  return (
+    !normalized ||
+    node.label.toLowerCase().includes(normalized) ||
+    node.subtitle.toLowerCase().includes(normalized)
+  );
+}
+
 function objectGraph(
   data: AtlasData,
   selected: Item | undefined,
@@ -228,7 +257,7 @@ function objectGraph(
       table: entry.name,
       kind: "table",
       x: 330,
-      y: 62 + index * 100,
+      y: 62 + index * OBJECT_ROW_GAP,
     };
     nodes.push(modelNode);
 
@@ -310,7 +339,7 @@ function objectGraph(
       itemId: selected.fabricId,
       kind: "field",
       x: 660,
-      y: 134 + index * 100,
+      y: 126 + index * OBJECT_ROW_GAP,
     };
     nodes.push(node);
     graphEdges.push({
@@ -335,7 +364,7 @@ function objectGraph(
         itemId: consumer.fabricId,
         kind: "consumer",
         x: 1000,
-        y: 72 + index * 100,
+        y: 72 + index * OBJECT_ROW_GAP,
       };
       nodes.push(node);
       graphEdges.push({ source: owner.id, target: node.id, relation: edge.relation });
@@ -347,8 +376,8 @@ function objectGraph(
     width: 1240,
     height: Math.max(
       520,
-      selectedSchema.length * 100 + 96,
-      fields.length * 100 + 220,
+      selectedSchema.length * OBJECT_ROW_GAP + 96,
+      fields.length * OBJECT_ROW_GAP + 204,
     ),
     table: table.name,
   };
@@ -449,7 +478,7 @@ export function MapView() {
   const mapRef = useRef<HTMLDivElement>(null);
 
   const selected =
-    itemById.get(selId) ?? itemById.get(startingId);
+    itemById.get(selId) ?? (selId ? itemById.get(startingId) : undefined);
   const activeId = selected?.fabricId ?? "";
   const resolvedFocusId = itemById.has(focusId) ? focusId : activeId;
   const schema = useMemo(
@@ -531,22 +560,13 @@ export function MapView() {
     ) {
       return items;
     }
-    const normalized = query.trim().toLowerCase();
     return items.filter((item) => {
-      if (item.fabricId === activeId) return true;
-      const matchesFilters =
-        (typeFilter === "all" || item.itemType === typeFilter) &&
-        (healthFilter === "all" || item.health === healthFilter) &&
-        (!normalized ||
-          item.displayName.toLowerCase().includes(normalized) ||
-          typeMeta(item.itemType).label.toLowerCase().includes(normalized) ||
-          item.tags.some((tag) => tag.toLowerCase().includes(normalized)));
       return (
-        matchesFilters &&
+        matchesItemFilters(item, typeFilter, healthFilter, query) &&
         (!impactMode || !resolvedFocusId || focusedItems.has(item.fabricId))
       );
     });
-  }, [activeId, focusedItems, healthFilter, impactMode, items, query, resolvedFocusId, typeFilter]);
+  }, [focusedItems, healthFilter, impactMode, items, query, resolvedFocusId, typeFilter]);
   const visibleIds = useMemo(
     () => new Set(visibleItems.map((item) => item.fabricId)),
     [visibleItems],
@@ -563,7 +583,9 @@ export function MapView() {
       buildStagedLayout(visibleItems, visibleEdges, {
         nodeWidth: NODE_W,
         nodeHeight: NODE_H,
-        columnGap: 285,
+        columnGap: NODE_COLUMN_GAP,
+        rowGap: NODE_ROW_GAP,
+        componentGap: 52,
         focusId: resolvedFocusId,
       }),
     [resolvedFocusId, visibleEdges, visibleItems],
@@ -600,12 +622,12 @@ export function MapView() {
     [objects.nodes],
   );
   const activeObjectId = objects.nodes.some(
-    (node) => node.id === selectedObjectId,
+    (node) =>
+      node.id === selectedObjectId &&
+      matchesObjectQuery(node, query),
   )
     ? selectedObjectId
-    : (objects.nodes.find((node) => node.kind === "owner")?.id ??
-      objects.nodes[0]?.id ??
-      "");
+    : (objects.nodes.find((node) => matchesObjectQuery(node, query))?.id ?? "");
   const activeObject = objectNodeById.get(activeObjectId);
   const reportItemId =
     mode === "objects" ? activeObject?.itemId ?? activeId : activeId;
@@ -744,6 +766,47 @@ export function MapView() {
     if ((node.kind === "source" || node.kind === "table") && node.table) {
       setTableName(node.table);
     }
+  };
+
+  const reconcileItemSelection = (
+    nextType: string,
+    nextHealth: Health | "all",
+    nextQuery: string,
+  ) => {
+    if (
+      selected &&
+      matchesItemFilters(selected, nextType, nextHealth, nextQuery)
+    ) {
+      return;
+    }
+    const next = items.find((item) =>
+      matchesItemFilters(item, nextType, nextHealth, nextQuery),
+    );
+    const nextId = next?.fabricId ?? "";
+    setSelId(nextId);
+    setFocusId(nextId);
+    setSelectedItemIds(new Set(nextId ? [nextId] : []));
+    setDrag({});
+  };
+
+  const changeObjectTable = (nextTable: string) => {
+    setTableName(nextTable);
+    const nextId = `table:${nextTable}`;
+    setSelectedObjectId(nextId);
+    setSelectedObjectIds(new Set([nextId]));
+    setObjectDrag({});
+  };
+
+  const changeQuery = (nextQuery: string) => {
+    setQuery(nextQuery);
+    if (mode === "items") return;
+    const active = objectNodeById.get(activeObjectId);
+    if (active && matchesObjectQuery(active, nextQuery)) return;
+    const next = objects.nodes.find((node) =>
+      matchesObjectQuery(node, nextQuery),
+    );
+    setSelectedObjectId(next?.id ?? "");
+    setSelectedObjectIds(new Set(next ? [next.id] : []));
   };
 
   const objectNodeDown = (
@@ -958,7 +1021,7 @@ export function MapView() {
           <span className="sr-only">Search lineage</span>
           <input
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => changeQuery(event.target.value)}
             placeholder={mode === "items" ? "Search items…" : "Search objects…"}
             className="w-full rounded-lg border border-input bg-card pl-[31px] pr-m outline-none"
           />
@@ -968,7 +1031,11 @@ export function MapView() {
             <select
               aria-label="Filter by item type"
               value={typeFilter}
-              onChange={(event) => setTypeFilter(event.target.value)}
+              onChange={(event) => {
+                const nextType = event.target.value;
+                setTypeFilter(nextType);
+                reconcileItemSelection(nextType, healthFilter, query);
+              }}
               className="rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               <option value="all">All types</option>
@@ -981,9 +1048,11 @@ export function MapView() {
             <select
               aria-label="Filter by health"
               value={healthFilter}
-              onChange={(event) =>
-                setHealthFilter(event.target.value as Health | "all")
-              }
+              onChange={(event) => {
+                const nextHealth = event.target.value as Health | "all";
+                setHealthFilter(nextHealth);
+                reconcileItemSelection(typeFilter, nextHealth, query);
+              }}
               className="rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               <option value="all">All health</option>
@@ -998,7 +1067,7 @@ export function MapView() {
             <select
               aria-label="Select object lineage table"
               value={objects.table ?? ""}
-              onChange={(event) => setTableName(event.target.value)}
+              onChange={(event) => changeObjectTable(event.target.value)}
               className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               {schema.map((entry) => (
@@ -1287,7 +1356,7 @@ export function MapView() {
                           <span className="line-clamp-2 break-words text-200 font-semibold leading-200">
                             {item.displayName}
                           </span>
-                          <span className="mt-xs line-clamp-2 text-200 leading-200 text-muted-foreground">
+                          <span className="mt-xs line-clamp-1 text-200 leading-200 text-muted-foreground">
                             {typeMeta(item.itemType).label} · {item.health}
                           </span>
                         </span>
@@ -1455,10 +1524,7 @@ export function MapView() {
                     const dim = !!activeObjectId && !objectConnected.has(node.id);
                     const draggingNode = objectDragId === node.id;
                     const activeTable = node.table === objects.table;
-                    const matches =
-                      !query.trim() ||
-                      node.label.toLowerCase().includes(query.trim().toLowerCase()) ||
-                      node.subtitle.toLowerCase().includes(query.trim().toLowerCase());
+                    const matches = matchesObjectQuery(node, query);
                     const accent = primaryNode
                       ? "var(--color-primary)"
                       : isUp
@@ -1513,10 +1579,10 @@ export function MapView() {
                           {node.code}
                         </span>
                         <span className="min-w-0 flex-1">
-                          <span className="line-clamp-3 break-words text-200 font-semibold leading-200">
+                          <span className="line-clamp-2 break-words text-200 font-semibold leading-200">
                             {node.label}
                           </span>
-                          <span className="mt-xs line-clamp-2 break-words text-200 leading-200 text-muted-foreground">
+                          <span className="mt-xs line-clamp-1 break-words text-200 leading-200 text-muted-foreground">
                             {node.subtitle}
                           </span>
                         </span>
@@ -1800,7 +1866,7 @@ export function MapView() {
                           type="button"
                           onClick={() => {
                             setMode("objects");
-                            setTableName(schema[0].name);
+                            changeObjectTable(schema[0].name);
                           }}
                           className="text-[10px] font-semibold text-primary hover:underline"
                         >

--- a/src/atlas/views/Map.tsx
+++ b/src/atlas/views/Map.tsx
@@ -25,7 +25,19 @@ import {
 } from "lucide-react";
 import * as Tabs from "@radix-ui/react-tabs";
 import { ImpactReportDialog } from "../components/ImpactReportDialog";
+import { MetadataObjectImpactDialog } from "../components/MetadataObjectImpactDialog";
 import { ResizableInspector } from "../components/ResizableInspector";
+import {
+  metadataObjectKindLabel,
+  verifiedMetadataEdgesForItem,
+} from "../catalog-objects";
+import {
+  buildMetadataObjectGraph,
+  MAX_VISIBLE_OBJECT_EDGES,
+  type ObjectGraph,
+  type ObjectGraphEdge as ObjectEdge,
+  type ObjectGraphNode as ObjectNode,
+} from "../metadata-object-graph";
 import { useDisplayPreference } from "../display-preferences";
 import {
   buildAccessReviewRows,
@@ -56,6 +68,9 @@ import {
   type Item,
   type ModelTableSchema,
 } from "../model";
+import type {
+  MetadataObjectKind,
+} from "../item-metadata";
 import {
   LINEAGE_STAGE_LABELS,
   buildStagedLayout,
@@ -82,24 +97,6 @@ type InspectorTab = "summary" | "schema" | "access" | "runs";
 interface Point {
   x: number;
   y: number;
-}
-
-interface ObjectNode extends Point {
-  id: string;
-  label: string;
-  subtitle: string;
-  code: string;
-  color: string;
-  table?: string;
-  itemId?: string;
-  kind: "source" | "table" | "field" | "owner" | "consumer";
-}
-
-interface ObjectEdge {
-  source: string;
-  target: string;
-  relation: string;
-  structural?: boolean;
 }
 
 interface ObjectLineageIndex {
@@ -238,9 +235,17 @@ function objectGraph(
   itemById: Map<string, Item>,
   lineageIndex: LineageIndex,
   tableName: string,
-): { nodes: ObjectNode[]; edges: ObjectEdge[]; width: number; height: number; table?: string } {
+): ObjectGraph {
   if (!selected || selectedSchema.length === 0) {
-    return { nodes: [], edges: [], width: 1080, height: 520 };
+    return {
+      nodes: [],
+      edges: [],
+      width: 1080,
+      height: 520,
+      stageLabels: ["Source objects", "Model tables", "Fields", "Consumers"],
+      verifiedMetadata: false,
+      truncated: false,
+    };
   }
 
   const table = selectedSchema.find((entry) => entry.name === tableName) ?? selectedSchema[0];
@@ -380,6 +385,9 @@ function objectGraph(
       fields.length * OBJECT_ROW_GAP + 204,
     ),
     table: table.name,
+    stageLabels: ["Source objects", "Model tables", "Fields", "Consumers"],
+    verifiedMetadata: false,
+    truncated: false,
   };
 }
 
@@ -446,6 +454,12 @@ export function MapView() {
     (searchParam("health") as Health | "all") || "all",
   );
   const [tableName, setTableName] = useState(searchParam("table"));
+  const [sourceItemFilter, setSourceItemFilter] = useState(
+    searchParam("source") || "all",
+  );
+  const [objectKindFilter, setObjectKindFilter] = useState<
+    MetadataObjectKind | "all"
+  >((searchParam("objectKind") as MetadataObjectKind | "all") || "all");
   const [tab, setTab] = useState<InspectorTab>(initialInspectorTab);
   const [openTables, setOpenTables] = useState<Set<string>>(new Set());
   const [drag, setDrag] = useState<Record<string, Point>>({});
@@ -600,18 +614,103 @@ export function MapView() {
     });
     return { width, height };
   }, [drag, layout.height, layout.width]);
+  const selectedMetadataEdges = useMemo(
+    () => verifiedMetadataEdgesForItem(data.objectEdges, activeId),
+    [activeId, data.objectEdges],
+  );
+  const metadataSourceOptions = useMemo(
+    () =>
+      [
+        ...new Set(
+          selectedMetadataEdges
+            .flatMap((edge) => [edge.source.itemId, edge.target.itemId])
+            .filter((itemId) => itemId !== activeId),
+        ),
+      ].sort((left, right) =>
+        (itemById.get(left)?.displayName ?? left).localeCompare(
+          itemById.get(right)?.displayName ?? right,
+        ),
+      ),
+    [activeId, itemById, selectedMetadataEdges],
+  );
+  const metadataTableOptions = useMemo(
+    () =>
+      [
+        ...new Set(
+          selectedMetadataEdges.flatMap((edge) =>
+            [edge.source.tableName, edge.target.tableName].filter(
+              (value): value is string => Boolean(value),
+            ),
+          ),
+        ),
+      ].sort(),
+    [selectedMetadataEdges],
+  );
+  const metadataKindOptions = useMemo(
+    () =>
+      [
+        ...new Set(
+          selectedMetadataEdges.flatMap((edge) => [
+            edge.source.kind,
+            edge.target.kind,
+          ]),
+        ),
+      ].sort((left, right) =>
+        metadataObjectKindLabel(left).localeCompare(
+          metadataObjectKindLabel(right),
+        ),
+      ),
+    [selectedMetadataEdges],
+  );
+  const resolvedSourceFilter = metadataSourceOptions.includes(sourceItemFilter)
+    ? sourceItemFilter
+    : "all";
+  const resolvedTableFilter = metadataTableOptions.includes(tableName)
+    ? tableName
+    : "all";
+  const resolvedObjectKindFilter = metadataKindOptions.includes(
+    objectKindFilter as MetadataObjectKind,
+  )
+    ? objectKindFilter
+    : "all";
   const objects = useMemo(
     () =>
-      objectGraph(
-        data,
-        selected,
-        schema,
-        upstream,
-        itemById,
-        lineageIndex,
-        tableName,
-      ),
-    [data, itemById, lineageIndex, schema, selected, tableName, upstream],
+      selectedMetadataEdges.length > 0
+        ? buildMetadataObjectGraph(
+            selectedMetadataEdges,
+            activeId,
+            itemById,
+            {
+              query,
+              sourceItemId: resolvedSourceFilter,
+              tableName: resolvedTableFilter,
+              objectKind: resolvedObjectKindFilter,
+            },
+          )
+        : objectGraph(
+            data,
+            selected,
+            schema,
+            upstream,
+            itemById,
+            lineageIndex,
+            tableName,
+          ),
+    [
+      activeId,
+      data,
+      itemById,
+      lineageIndex,
+      query,
+      resolvedObjectKindFilter,
+      resolvedSourceFilter,
+      resolvedTableFilter,
+      schema,
+      selected,
+      selectedMetadataEdges,
+      tableName,
+      upstream,
+    ],
   );
   const objectLineageIndex = useMemo(
     () => createObjectLineageIndex(objects.edges),
@@ -631,6 +730,8 @@ export function MapView() {
   const activeObject = objectNodeById.get(activeObjectId);
   const reportItemId =
     mode === "objects" ? activeObject?.itemId ?? activeId : activeId;
+  const metadataReportObject =
+    mode === "objects" ? activeObject?.metadataRef : undefined;
   const reportObject: SchemaObjectRef | undefined =
     mode === "objects" && activeObject?.kind === "table"
       ? {
@@ -692,10 +793,31 @@ export function MapView() {
     else url.searchParams.delete("impact");
     if (mode === "objects" && objects.table) url.searchParams.set("table", objects.table);
     else url.searchParams.delete("table");
+    if (mode === "objects" && resolvedSourceFilter !== "all") {
+      url.searchParams.set("source", resolvedSourceFilter);
+    } else {
+      url.searchParams.delete("source");
+    }
+    if (mode === "objects" && resolvedObjectKindFilter !== "all") {
+      url.searchParams.set("objectKind", resolvedObjectKindFilter);
+    } else {
+      url.searchParams.delete("objectKind");
+    }
     if (tab !== "summary") url.searchParams.set("inspector", tab);
     else url.searchParams.delete("inspector");
     window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
-  }, [activeId, healthFilter, impactMode, mode, objects.table, query, tab, typeFilter]);
+  }, [
+    activeId,
+    healthFilter,
+    impactMode,
+    mode,
+    objects.table,
+    query,
+    resolvedObjectKindFilter,
+    resolvedSourceFilter,
+    tab,
+    typeFilter,
+  ]);
 
   const nodeDown = (event: RPE<HTMLButtonElement>, id: string) => {
     event.currentTarget.setPointerCapture?.(event.pointerId);
@@ -758,6 +880,9 @@ export function MapView() {
       setSelectedItemIds(new Set([id]));
       setSelId(id);
     }
+    setSelectedObjectId("");
+    setSelectedObjectIds(new Set());
+    setObjectDrag({});
     setTab("summary");
   };
 
@@ -787,13 +912,36 @@ export function MapView() {
     setFocusId(nextId);
     setSelectedItemIds(new Set(nextId ? [nextId] : []));
     setDrag({});
+    setSelectedObjectId("");
+    setSelectedObjectIds(new Set());
+    setObjectDrag({});
   };
 
   const changeObjectTable = (nextTable: string) => {
     setTableName(nextTable);
+    if (selectedMetadataEdges.length > 0) {
+      setSelectedObjectId("");
+      setSelectedObjectIds(new Set());
+      setObjectDrag({});
+      return;
+    }
     const nextId = `table:${nextTable}`;
     setSelectedObjectId(nextId);
     setSelectedObjectIds(new Set([nextId]));
+    setObjectDrag({});
+  };
+
+  const changeObjectSource = (nextSource: string) => {
+    setSourceItemFilter(nextSource);
+    setSelectedObjectId("");
+    setSelectedObjectIds(new Set());
+    setObjectDrag({});
+  };
+
+  const changeObjectKind = (nextKind: MetadataObjectKind | "all") => {
+    setObjectKindFilter(nextKind);
+    setSelectedObjectId("");
+    setSelectedObjectIds(new Set());
     setObjectDrag({});
   };
 
@@ -807,6 +955,7 @@ export function MapView() {
     );
     setSelectedObjectId(next?.id ?? "");
     setSelectedObjectIds(new Set(next ? [next.id] : []));
+    setObjectDrag({});
   };
 
   const objectNodeDown = (
@@ -1063,19 +1212,73 @@ export function MapView() {
             </select>
           </>
         ) : (
-          schema.length > 0 && (
-            <select
-              aria-label="Select object lineage table"
-              value={objects.table ?? ""}
-              onChange={(event) => changeObjectTable(event.target.value)}
-              className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
-            >
-              {schema.map((entry) => (
-                <option key={entry.name} value={entry.name}>
-                  {entry.name}
-                </option>
-              ))}
-            </select>
+          selectedMetadataEdges.length > 0 ? (
+            <>
+              {metadataSourceOptions.length > 0 && (
+                <select
+                  aria-label="Filter object lineage by source item"
+                  value={resolvedSourceFilter}
+                  onChange={(event) =>
+                    changeObjectSource(event.target.value)
+                  }
+                  className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
+                >
+                  <option value="all">All source items</option>
+                  {metadataSourceOptions.map((itemId) => (
+                    <option key={itemId} value={itemId}>
+                      {itemById.get(itemId)?.displayName ?? itemId}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {metadataTableOptions.length > 0 && (
+                <select
+                  aria-label="Select object lineage table"
+                  value={resolvedTableFilter}
+                  onChange={(event) => changeObjectTable(event.target.value)}
+                  className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
+                >
+                  <option value="all">All source objects</option>
+                  {metadataTableOptions.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <select
+                aria-label="Filter object lineage by object kind"
+                value={resolvedObjectKindFilter}
+                onChange={(event) =>
+                  changeObjectKind(
+                    event.target.value as MetadataObjectKind | "all",
+                  )
+                }
+                className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
+              >
+                <option value="all">All object kinds</option>
+                {metadataKindOptions.map((objectKind) => (
+                  <option key={objectKind} value={objectKind}>
+                    {metadataObjectKindLabel(objectKind)}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : (
+            schema.length > 0 && (
+              <select
+                aria-label="Select object lineage table"
+                value={objects.table ?? ""}
+                onChange={(event) => changeObjectTable(event.target.value)}
+                className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
+              >
+                {schema.map((entry) => (
+                  <option key={entry.name} value={entry.name}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            )
           )
         )}
         {mode === "items" && <button
@@ -1142,8 +1345,12 @@ export function MapView() {
         >
           {mode === "objects" && (
             <div className="sticky left-[16px] top-[12px] z-20 max-w-[500px] rounded-lg border border-border bg-card px-[10px] py-[7px] text-[11px] text-muted-foreground shadow-fabric-4">
-              Object metadata is exact; field-to-report usage remains item-level because
-              Fabric does not expose visual field bindings through the current APIs.
+              {objects.verifiedMetadata
+                ? "Verified object metadata is shown from the selected item snapshot."
+                : "Object metadata is exact; field-to-report usage remains item-level because Fabric does not expose visual field bindings through the current APIs."}
+              {objects.truncated
+                ? ` The view is limited to ${MAX_VISIBLE_OBJECT_EDGES} edges. Narrow the source, object or kind filter for the remaining relationships.`
+                : ""}
             </div>
           )}
           <div style={{ width: graph.width * zoom, height: graph.height * zoom }}>
@@ -1370,12 +1577,11 @@ export function MapView() {
                   <div
                     className="pointer-events-none absolute inset-x-0 top-[9px] grid"
                     style={{
-                      gridTemplateColumns: "306px 330px 340px 300px",
+                      gridTemplateColumns: `repeat(${objects.stageLabels.length}, 282px)`,
                       paddingLeft: 24,
                     }}
                   >
-                    {["Source objects", "Model tables", "Fields", "Consumers"].map(
-                      (label) => (
+                    {objects.stageLabels.map((label) => (
                         <div
                           key={label}
                           className="flex items-center gap-[7px] pr-[18px] text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground"
@@ -1383,8 +1589,7 @@ export function MapView() {
                           <span>{label}</span>
                           <span className="h-px flex-1 bg-border" />
                         </div>
-                      ),
-                    )}
+                      ))}
                   </div>
                   <svg
                     className="pointer-events-none absolute inset-0 overflow-visible"
@@ -1755,6 +1960,30 @@ export function MapView() {
               <div className="min-h-[300px] flex-1 overflow-auto p-[16px]">
                 {tab === "summary" && (
                   <div className="flex flex-col gap-[14px]">
+                    {mode === "objects" && activeObject && (
+                      <Card className="p-[12px]">
+                        <SectionLabel>Selected object</SectionLabel>
+                        <div className="mt-[7px] break-words text-[13px] font-semibold">
+                          {activeObject.label}
+                        </div>
+                        <div className="mt-[3px] break-words text-[10px] text-muted-foreground">
+                          {activeObject.metadataRef
+                            ? metadataObjectKindLabel(
+                                activeObject.metadataRef.kind,
+                              )
+                            : activeObject.subtitle}
+                          {activeObject.table
+                            ? ` · ${activeObject.table}`
+                            : ""}
+                        </div>
+                        {activeObject.metadataRef && (
+                          <div className="mt-[8px] rounded-lg bg-secondary px-[9px] py-[7px] text-[10px] text-muted-foreground">
+                            Verified source-to-consumer object lineage from the
+                            active snapshot.
+                          </div>
+                        )}
+                      </Card>
+                    )}
                     {selected.description && (
                       <p className="text-[12px] leading-[1.5] text-muted-foreground">{selected.description}</p>
                     )}
@@ -1826,6 +2055,9 @@ export function MapView() {
                               type="button"
                               onClick={() => {
                                 setSelId(item.fabricId);
+                                setSelectedObjectId("");
+                                setSelectedObjectIds(new Set());
+                                setObjectDrag({});
                                 setTab("summary");
                               }}
                               className="atlas-row flex items-center gap-[8px] rounded-lg px-[7px] text-left hover:bg-accent"
@@ -2019,7 +2251,14 @@ export function MapView() {
           </Tabs.Root>
         </ResizableInspector>
       </div>
-      {reportItemId && (
+      {metadataReportObject ? (
+        <MetadataObjectImpactDialog
+          data={data}
+          subject={metadataReportObject}
+          open={impactReportOpen}
+          onClose={() => setImpactReportOpen(false)}
+        />
+      ) : reportItemId ? (
         <ImpactReportDialog
           data={data}
           itemId={reportItemId}
@@ -2027,7 +2266,7 @@ export function MapView() {
           open={impactReportOpen}
           onClose={() => setImpactReportOpen(false)}
         />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/atlas/views/Map.tsx
+++ b/src/atlas/views/Map.tsx
@@ -25,10 +25,16 @@ import {
 } from "lucide-react";
 import * as Tabs from "@radix-ui/react-tabs";
 import { ImpactReportDialog } from "../components/ImpactReportDialog";
+import { ResizableInspector } from "../components/ResizableInspector";
+import { useDisplayPreference } from "../display-preferences";
 import {
   buildAccessReviewRows,
   selectAccessByItem,
 } from "../governance";
+import {
+  MAP_INSPECTOR_DEFAULT_WIDTH,
+  isMapInspectorWidth,
+} from "../map-inspector";
 import { useAtlas } from "../store";
 import {
   Avatar,
@@ -60,10 +66,10 @@ import {
   type SchemaObjectRef,
 } from "../lineage";
 
-const NODE_W = 196;
-const NODE_H = 60;
-const OBJECT_W = 204;
-const OBJECT_H = 52;
+const NODE_W = 260;
+const NODE_H = 84;
+const OBJECT_W = 268;
+const OBJECT_H = 92;
 const UP = "var(--color-lineage-upstream)";
 const DOWN = "var(--color-lineage-downstream)";
 
@@ -222,7 +228,7 @@ function objectGraph(
       table: entry.name,
       kind: "table",
       x: 330,
-      y: 62 + index * 72,
+      y: 62 + index * 100,
     };
     nodes.push(modelNode);
 
@@ -266,7 +272,7 @@ function objectGraph(
     itemId: selected.fabricId,
     kind: "owner",
     x: 660,
-    y: 20,
+    y: 36,
   };
   nodes.push(owner);
 
@@ -304,7 +310,7 @@ function objectGraph(
       itemId: selected.fabricId,
       kind: "field",
       x: 660,
-      y: 98 + index * 58,
+      y: 134 + index * 100,
     };
     nodes.push(node);
     graphEdges.push({
@@ -329,7 +335,7 @@ function objectGraph(
         itemId: consumer.fabricId,
         kind: "consumer",
         x: 1000,
-        y: 72 + index * 80,
+        y: 72 + index * 100,
       };
       nodes.push(node);
       graphEdges.push({ source: owner.id, target: node.id, relation: edge.relation });
@@ -339,7 +345,11 @@ function objectGraph(
     nodes,
     edges: graphEdges,
     width: 1240,
-    height: Math.max(520, selectedSchema.length * 72 + 96, fields.length * 58 + 170),
+    height: Math.max(
+      520,
+      selectedSchema.length * 100 + 96,
+      fields.length * 100 + 220,
+    ),
     table: table.name,
   };
 }
@@ -373,8 +383,15 @@ function InspectorTabButton({
 }
 
 export function MapView() {
-  const { data } = useAtlas();
+  const { data, currentUser } = useAtlas();
   const { items, edges, comments, config, principals, jobs } = data;
+  const inspectorWidth = useDisplayPreference(
+    currentUser.id,
+    data.workspace.fabricId,
+    "map-inspector-width",
+    MAP_INSPECTOR_DEFAULT_WIDTH,
+    isMapInspectorWidth,
+  );
   const itemById = useMemo(
     () => new Map<string, Item>(items.map((item) => [item.fabricId, item])),
     [items],
@@ -631,12 +648,13 @@ export function MapView() {
   const objectBounds = useMemo(() => {
     let width = objects.width;
     let height = objects.height;
-    Object.values(objectDrag).forEach((point) => {
+    objects.nodes.forEach((node) => {
+      const point = objectDrag[node.id] ?? node;
       width = Math.max(width, point.x + OBJECT_W + 48);
       height = Math.max(height, point.y + OBJECT_H + 48);
     });
     return { width, height };
-  }, [objectDrag, objects.height, objects.width]);
+  }, [objectDrag, objects.height, objects.nodes, objects.width]);
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -888,7 +906,7 @@ export function MapView() {
 
   return (
     <div className="flex h-full min-h-[720px] flex-col xl:min-h-0">
-      <div className="flex flex-wrap items-end justify-between gap-[12px] border-b border-border px-[20px] py-[14px]">
+      <div className="atlas-page-header flex flex-wrap items-end justify-between border-b border-border">
         <div>
           <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-lineage-downstream">
             Workspace topology
@@ -916,7 +934,7 @@ export function MapView() {
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-[8px] border-b border-border bg-card px-[20px] py-[8px] shadow-fabric-2">
+      <div className="atlas-toolbar flex flex-wrap items-center border-b border-border bg-card px-l py-s shadow-fabric-2">
         <div className="flex rounded-md border border-border bg-secondary p-[2px]">
           {(["items", "objects"] as const).map((value) => (
             <button
@@ -924,7 +942,7 @@ export function MapView() {
               type="button"
               onClick={() => setMode(value)}
               className={cn(
-                "h-[30px] rounded-md px-[12px] text-[12px] font-semibold capitalize text-muted-foreground",
+                "rounded-md px-m font-semibold capitalize text-muted-foreground",
                 mode === value && "bg-card text-brand-foreground shadow-fabric-2",
               )}
             >
@@ -942,7 +960,7 @@ export function MapView() {
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={mode === "items" ? "Search items…" : "Search objects…"}
-            className="h-[34px] w-full rounded-lg border border-input bg-card pl-[31px] pr-[10px] text-[12px] outline-none"
+            className="w-full rounded-lg border border-input bg-card pl-[31px] pr-m outline-none"
           />
         </label>
         {mode === "items" ? (
@@ -951,7 +969,7 @@ export function MapView() {
               aria-label="Filter by item type"
               value={typeFilter}
               onChange={(event) => setTypeFilter(event.target.value)}
-              className="h-[34px] rounded-lg border border-input bg-card px-[10px] text-[12px] text-muted-foreground outline-none"
+              className="rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               <option value="all">All types</option>
               {types.map((type) => (
@@ -966,7 +984,7 @@ export function MapView() {
               onChange={(event) =>
                 setHealthFilter(event.target.value as Health | "all")
               }
-              className="h-[34px] rounded-lg border border-input bg-card px-[10px] text-[12px] text-muted-foreground outline-none"
+              className="rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               <option value="all">All health</option>
               <option value="healthy">Healthy</option>
@@ -981,7 +999,7 @@ export function MapView() {
               aria-label="Select object lineage table"
               value={objects.table ?? ""}
               onChange={(event) => setTableName(event.target.value)}
-              className="h-[34px] max-w-[220px] rounded-lg border border-input bg-card px-[10px] text-[12px] text-muted-foreground outline-none"
+              className="max-w-[220px] rounded-lg border border-input bg-card px-m text-muted-foreground outline-none"
             >
               {schema.map((entry) => (
                 <option key={entry.name} value={entry.name}>
@@ -1001,7 +1019,7 @@ export function MapView() {
             setImpactMode(next);
           }}
           className={cn(
-            "ml-auto flex h-[34px] items-center gap-[7px] rounded-lg border px-[10px] text-[12px] font-semibold",
+            "ml-auto flex items-center gap-s rounded-lg border px-m font-semibold",
             impactMode
               ? "border-lineage-upstream/50 bg-lineage-upstream/10 text-lineage-upstream"
               : "border-border text-muted-foreground",
@@ -1022,7 +1040,7 @@ export function MapView() {
               setFocusId(activeId);
               setDrag({});
             }}
-            className="flex h-[34px] items-center gap-[6px] rounded-lg border border-border px-[10px] text-[12px] font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
+            className="flex items-center gap-s rounded-lg border border-border px-m font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
           >
             <GitBranch size={13} />
             Focus selection
@@ -1041,17 +1059,17 @@ export function MapView() {
         <button
           type="button"
           onClick={resetGraph}
-          className="flex h-[34px] items-center gap-[6px] rounded-lg border border-border px-[10px] text-[12px] font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
+          className="flex items-center gap-s rounded-lg border border-border px-m font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <RotateCcw size={13} />
           Reset
         </button>
       </div>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
         <div
           ref={mapRef}
-          className="atlas-map-grid relative min-h-[500px] overflow-auto bg-muted/30"
+          className="atlas-map-grid relative min-h-[500px] min-w-0 flex-1 overflow-auto bg-muted/30"
         >
           {mode === "objects" && (
             <div className="sticky left-[16px] top-[12px] z-20 max-w-[500px] rounded-lg border border-border bg-card px-[10px] py-[7px] text-[11px] text-muted-foreground shadow-fabric-4">
@@ -1148,7 +1166,7 @@ export function MapView() {
                             stroke={color}
                             strokeWidth={active ? 2.6 : 1.5}
                             strokeOpacity={
-                              edge.broken ? 0.9 : active ? 0.96 : activeId ? 0.18 : 0.5
+                              edge.broken ? 0.9 : active ? 0.96 : activeId ? 0.3 : 0.55
                             }
                             strokeDasharray={
                               edge.broken
@@ -1233,13 +1251,14 @@ export function MapView() {
                         aria-pressed={selectedNode}
                         onClick={(event) => nodeClick(event, item.fabricId)}
                         aria-label={`${item.displayName}, ${typeMeta(item.itemType).label}, ${item.health}`}
+                        title={item.displayName}
                         onPointerDown={(event) => nodeDown(event, item.fabricId)}
                         onPointerMove={nodeMove}
                         onPointerUp={nodeUp}
                         className={cn(
                           "absolute flex touch-none select-none items-center gap-[10px] rounded-lg border bg-card px-[12px] text-left shadow-fabric-2 transition-[box-shadow,opacity,border-color,transform] hover:-translate-y-[1px] hover:shadow-fabric-8",
                           selectedNode ? "border-primary/70" : "border-border",
-                          dim && "opacity-30",
+                          dim && "border-border/70 bg-card/85 shadow-none",
                           "cursor-grab active:cursor-grabbing",
                         )}
                         style={{
@@ -1265,11 +1284,11 @@ export function MapView() {
                         )}
                         <TypeGlyph type={item.itemType} size={34} />
                         <span className="min-w-0 flex-1">
-                          <span className="block truncate text-[13px] font-semibold leading-[1.15]">
+                          <span className="line-clamp-2 break-words text-200 font-semibold leading-200">
                             {item.displayName}
                           </span>
-                          <span className="mt-[3px] block truncate text-[10px] uppercase tracking-wide text-muted-foreground">
-                            {typeMeta(item.itemType).label}
+                          <span className="mt-xs line-clamp-2 text-200 leading-200 text-muted-foreground">
+                            {typeMeta(item.itemType).label} · {item.health}
                           </span>
                         </span>
                         <HealthDot health={item.health} />
@@ -1361,7 +1380,7 @@ export function MapView() {
                             stroke={color}
                             strokeWidth={active ? 2.6 : edge.structural ? 1.3 : 1.8}
                             strokeOpacity={
-                              active ? 0.96 : activeObjectId ? 0.16 : 0.55
+                              active ? 0.96 : activeObjectId ? 0.3 : 0.55
                             }
                             strokeDasharray={
                               isUp
@@ -1452,6 +1471,7 @@ export function MapView() {
                         key={node.id}
                         type="button"
                         aria-label={`${node.label}, ${node.subtitle}`}
+                        title={`${node.label} (${node.subtitle})`}
                         aria-pressed={selectedNode}
                         onClick={(event) => objectNodeClick(event, node)}
                         onPointerDown={(event) => objectNodeDown(event, node)}
@@ -1460,7 +1480,10 @@ export function MapView() {
                         className={cn(
                           "absolute flex touch-none cursor-grab select-none items-center gap-[10px] rounded-lg border border-border bg-card px-[11px] text-left shadow-fabric-2 transition-[box-shadow,opacity,border-color,transform] hover:-translate-y-[1px] hover:shadow-fabric-8 active:cursor-grabbing",
                           selectedNode && "border-primary/70",
-                          (!matches || dim) && "opacity-25",
+                          !matches && "border-dashed border-border/70 bg-muted/50 shadow-none",
+                          matches &&
+                            dim &&
+                            "border-border/70 bg-card/85 shadow-none",
                         )}
                         style={{
                           left: point.x,
@@ -1490,10 +1513,10 @@ export function MapView() {
                           {node.code}
                         </span>
                         <span className="min-w-0 flex-1">
-                          <span className="block truncate text-[12px] font-semibold">
+                          <span className="line-clamp-3 break-words text-200 font-semibold leading-200">
                             {node.label}
                           </span>
-                          <span className="mt-[2px] block truncate text-[9.5px] text-muted-foreground">
+                          <span className="mt-xs line-clamp-2 break-words text-200 leading-200 text-muted-foreground">
                             {node.subtitle}
                           </span>
                         </span>
@@ -1595,23 +1618,40 @@ export function MapView() {
           </div>
         </div>
 
-        <Tabs.Root
-          value={tab}
-          onValueChange={(value) => setTab(value as InspectorTab)}
-          asChild
+        <ResizableInspector
+          width={inspectorWidth.value}
+          onWidthChange={inspectorWidth.setValue}
+          error={inspectorWidth.error}
+          className="border-t border-border bg-card xl:border-l xl:border-t-0"
         >
-        <aside className="flex min-h-0 flex-col border-t border-border bg-card xl:border-l xl:border-t-0">
+          <Tabs.Root
+            value={tab}
+            onValueChange={(value) => setTab(value as InspectorTab)}
+            asChild
+          >
+        <aside aria-label="Item details inspector" className="flex min-h-0 flex-1 flex-col">
           {selected && (
             <>
               <div className="border-b border-border p-[16px]">
                 <div className="flex items-start gap-[12px]">
                   <TypeGlyph type={selected.itemType} size={44} />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-[17px] font-bold">{selected.displayName}</div>
-                    <div className="mt-[2px] text-[10px] uppercase tracking-wide text-muted-foreground">
+                    <div className="break-words text-[17px] font-bold">{selected.displayName}</div>
+                    <div className="mt-[2px] text-200 uppercase tracking-wide text-muted-foreground">
                       {typeMeta(selected.itemType).label}
                     </div>
                   </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      inspectorWidth.setValue(MAP_INSPECTOR_DEFAULT_WIDTH)
+                    }
+                    aria-label="Reset inspector width"
+                    title="Reset inspector width"
+                    className="hidden h-[32px] w-[32px] items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-accent hover:text-foreground xl:flex"
+                  >
+                    <RotateCcw size={14} />
+                  </button>
                   <button
                     type="button"
                     onClick={() => void copyLink()}
@@ -1654,11 +1694,25 @@ export function MapView() {
                     )}
                     <Card className="p-[12px]">
                       <div className="flex items-center justify-between gap-[10px] text-[12px]">
-                        <span className="text-muted-foreground">Owner</span>
-                        {selected.ownerName ? (
-                          <span className="flex min-w-0 items-center gap-[7px] font-semibold">
-                            <Avatar name={selected.ownerName} size={23} />
-                            <span className="max-w-[190px] truncate">{selected.ownerName}</span>
+                        <span className="text-muted-foreground">Documented owner</span>
+                        {selected.ownerName || selected.ownerEmail ? (
+                          <span className="flex min-w-0 items-center gap-[7px] text-right font-semibold">
+                            <Avatar
+                              name={selected.ownerName ?? selected.ownerEmail ?? "Owner"}
+                              size={23}
+                            />
+                            <span className="min-w-0">
+                              {selected.ownerName && (
+                                <span className="block break-words">
+                                  {selected.ownerName}
+                                </span>
+                              )}
+                              {selected.ownerEmail && (
+                                <span className="block break-all text-200 font-normal text-muted-foreground">
+                                  {selected.ownerEmail}
+                                </span>
+                              )}
+                            </span>
                           </span>
                         ) : (
                           <span className="text-muted-foreground">
@@ -1708,11 +1762,11 @@ export function MapView() {
                                 setSelId(item.fabricId);
                                 setTab("summary");
                               }}
-                              className="flex items-center gap-[8px] rounded-lg px-[7px] py-[5px] text-left hover:bg-accent"
+                              className="atlas-row flex items-center gap-[8px] rounded-lg px-[7px] text-left hover:bg-accent"
                             >
                               <TypeGlyph type={item.itemType} size={23} />
-                              <span className="min-w-0 flex-1 truncate text-[12px] font-semibold">{item.displayName}</span>
-                              <span className="text-[9.5px] text-muted-foreground">
+                              <span className="min-w-0 flex-1 break-words text-200 font-semibold">{item.displayName}</span>
+                              <span className="text-200 text-muted-foreground">
                                 {(distance as Map<string, number>).get(item.fabricId)} hop
                               </span>
                             </button>
@@ -1761,18 +1815,20 @@ export function MapView() {
                         </div>
                       )}
                       {schema.map((table) => {
-                        const open = openTables.has(table.name);
+                        const open =
+                          openTables.has(table.name) || Boolean(query.trim());
                         return (
                           <div key={table.name} className="overflow-hidden rounded-lg border border-border">
                             <button
                               type="button"
                               aria-expanded={open}
+                              disabled={Boolean(query.trim())}
                               onClick={() => toggleTable(table.name)}
-                              className="flex w-full items-center gap-[6px] px-[10px] py-[7px] text-left hover:bg-accent"
+                              className="atlas-row flex w-full items-center gap-[6px] px-[10px] text-left hover:bg-accent"
                             >
                               {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-                              <span className="min-w-0 flex-1 truncate text-[12px] font-semibold">{table.name}</span>
-                              {table.rows != null && <span className="text-[10px] text-muted-foreground">{table.rows} rows</span>}
+                              <span className="min-w-0 flex-1 break-all text-200 font-semibold">{table.name}</span>
+                              {table.rows != null && <span className="text-200 text-muted-foreground">{table.rows} rows</span>}
                             </button>
                             {open && (
                               <div className="border-t border-border px-[10px] py-[8px]">
@@ -1804,17 +1860,18 @@ export function MapView() {
                     <SectionLabel>Effective access · {effectiveAccess.length}</SectionLabel>
                     <div className="mt-[8px] text-[10px] leading-[1.4] text-muted-foreground">
                       Workspace and item grants are additive. Direct shares
-                      never reduce inherited access.
+                      never reduce inherited access. Owner permission is an
+                      access role and is separate from documented ownership.
                     </div>
                     <div className="mt-[10px] flex flex-col gap-[7px]">
                       {effectiveAccess.map((grant) => {
                         const principal = principals.find((entry) => entry.displayName === grant.principalRef);
                         return (
-                          <div key={grant.principalRef} className="flex items-center gap-[9px] rounded-lg border border-border px-[10px] py-[8px]">
+                          <div key={grant.principalRef} className="atlas-row flex items-center gap-[9px] rounded-lg border border-border px-[10px]">
                             <PrincipalAvatar name={grant.principalRef} kind={principal?.kind ?? "user"} size={27} />
                             <div className="min-w-0 flex-1">
                               <div className="truncate text-[12px] font-semibold">{grant.principalRef}</div>
-                              <div className="text-[9.5px] text-muted-foreground">
+                              <div className="text-200 text-muted-foreground">
                                 {grant.inherited
                                   ? "Inherited · workspace"
                                   : grant.mixed
@@ -1823,7 +1880,11 @@ export function MapView() {
                                 {grant.roleName ? ` · ${grant.roleName}` : ""}
                               </div>
                             </div>
-                            <span className="rounded-md bg-primary/10 px-[7px] py-[2px] text-[10px] font-semibold capitalize text-primary">{grant.accessLevel}</span>
+                            <span className="rounded-md bg-primary/10 px-[7px] py-[2px] text-200 font-semibold capitalize text-primary">
+                              {grant.accessLevel === "owner"
+                                ? "Owner permission"
+                                : `${grant.accessLevel} access`}
+                            </span>
                           </div>
                         );
                       })}
@@ -1889,7 +1950,8 @@ export function MapView() {
             </>
           )}
         </aside>
-        </Tabs.Root>
+          </Tabs.Root>
+        </ResizableInspector>
       </div>
       {reportItemId && (
         <ImpactReportDialog

--- a/src/atlas/views/Overview.spec.tsx
+++ b/src/atlas/views/Overview.spec.tsx
@@ -33,6 +33,9 @@ describe("OverviewView navigation", () => {
         <OverviewView onOpen={onOpen} />
       </AtlasProvider>,
     );
+    expect(
+      screen.getByText("Standard baseline: 70% for each governance pillar."),
+    ).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: /External access:/ }));
     expect(onOpen).toHaveBeenLastCalledWith(

--- a/src/atlas/views/Overview.spec.tsx
+++ b/src/atlas/views/Overview.spec.tsx
@@ -1,9 +1,31 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { AtlasProvider } from "../store";
+import { AtlasProvider, useAtlas } from "../store";
 import { OverviewView } from "./Overview";
 
+function GovernanceTargetButton() {
+  const { governanceTargets, saveGovernanceTargets } = useAtlas();
+  return (
+    <button
+      onClick={() => void saveGovernanceTargets({ ...governanceTargets, documentation: 95 })}
+    >
+      Set documentation target
+    </button>
+  );
+}
+
 describe("OverviewView navigation", () => {
+  it("reflects shared target changes without reverting to the default", async () => {
+    render(
+      <AtlasProvider isPreview>
+        <GovernanceTargetButton />
+        <OverviewView onOpen={vi.fn()} />
+      </AtlasProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Set documentation target" }));
+    expect(await screen.findByText(/^Target 95%/)).toBeVisible();
+  });
+
   it("opens governance and access signals with actionable filters", () => {
     const onOpen = vi.fn();
     render(

--- a/src/atlas/views/Overview.tsx
+++ b/src/atlas/views/Overview.tsx
@@ -451,6 +451,9 @@ export function OverviewView({
                   ? "Loading governance targets"
                   : "Governance targets unavailable"}
             </h2>
+            <p className="mt-xs text-200 text-muted-foreground">
+              Standard baseline: 70% for each governance pillar.
+            </p>
           </div>
           <button
             type="button"

--- a/src/atlas/views/Overview.tsx
+++ b/src/atlas/views/Overview.tsx
@@ -26,13 +26,13 @@ import {
   typeMeta,
   relativeTime,
   schemaFor,
-  type Health,
   type ItemType,
   type JobStatus,
 } from "../model";
 import { snapshotCatalogFromData } from "../history";
 import { scorePosture } from "../posture";
 import { workspaceDetailLabel } from "../workspace-display";
+import { summarizeHealth } from "../health-summary";
 
 const JOB_TONE: Record<JobStatus, string> = {
   completed: "bg-status-healthy",
@@ -46,21 +46,18 @@ export function OverviewView({
 }: {
   onOpen: (target: Tab | AtlasNavigation) => void;
 }) {
-  const { data, history, lastSyncedAt } = useAtlas();
+  const {
+    data,
+    history,
+    lastSyncedAt,
+    governanceTargets,
+    governancePolicyLoading,
+    governancePolicyError,
+  } = useAtlas();
+  const targetsAvailable = !governancePolicyLoading && !governancePolicyError;
   const { items, principals, jobs, syncRuns, grants, edges } = data;
 
-  const health = useMemo(() => {
-    const counts: Record<Health, number> = {
-      healthy: 0,
-      stale: 0,
-      failing: 0,
-      unknown: 0,
-    };
-    items.forEach((item) => {
-      counts[item.health] += 1;
-    });
-    return counts;
-  }, [items]);
+  const health = useMemo(() => summarizeHealth(items), [items]);
 
   const byType = useMemo(() => {
     const counts = new Map<ItemType, number>();
@@ -99,8 +96,9 @@ export function OverviewView({
     () =>
       scorePosture(
         currentCatalog ?? snapshotCatalogFromData(data),
+        governanceTargets,
       ),
-    [currentCatalog, data],
+    [currentCatalog, data, governanceTargets],
   );
   const previousSnapshotId = historyAligned
     ? history.summaries[1]?.snapshotId
@@ -109,8 +107,8 @@ export function OverviewView({
     (snapshot) => snapshot.snapshotId === previousSnapshotId,
   )?.catalog;
   const previousPosture = useMemo(() => {
-    return previousCatalog ? scorePosture(previousCatalog) : undefined;
-  }, [previousCatalog]);
+    return previousCatalog ? scorePosture(previousCatalog, governanceTargets) : undefined;
+  }, [previousCatalog, governanceTargets]);
   const postureAtTarget = posture.pillars.filter(
     (pillar) => pillar.score != null && pillar.score >= pillar.target,
   ).length;
@@ -154,11 +152,7 @@ export function OverviewView({
       .map((row) => row.principalKey),
   );
   const attentionCount = health.stale + health.failing;
-  const percentage = (count: number) =>
-    Math.round((count / (items.length || 1)) * 100);
-  const healthPercentage = items.length
-    ? percentage(health.healthy)
-    : undefined;
+  const healthPercentage = health.healthPercentage;
   const syncFreshness = lastSyncedAt
     ? relativeTime(lastSyncedAt)
     : "Not synced yet";
@@ -220,7 +214,7 @@ export function OverviewView({
       tone: "bg-lineage-upstream",
     },
     {
-      label: "Owner assignment",
+      label: "Documented ownership",
       detail: ownerCoverage.denominator
         ? `${ownerCoverage.numerator} of ${ownerCoverage.denominator} eligible items`
         : "Metadata not collected",
@@ -306,11 +300,11 @@ export function OverviewView({
   return (
     <section
       aria-labelledby="overview-title"
-      className="flex flex-col gap-xxl p-l sm:p-xxl"
+      className="atlas-content-frame flex flex-col gap-xl"
     >
       <Card className="atlas-overview-hero relative isolate overflow-hidden border-border shadow-fabric-4">
         <div className="grid lg:grid-cols-5">
-          <div className="flex flex-col justify-between gap-xxxl p-xl sm:p-xxl lg:col-span-3 lg:p-xxxl">
+          <div className="atlas-page-header flex flex-col justify-between lg:col-span-3">
             <div>
               <div className="flex items-center gap-m">
                 <span className="atlas-brand-mark flex icon-size-700 shrink-0 items-center justify-center rounded-xl text-primary-foreground">
@@ -326,11 +320,11 @@ export function OverviewView({
 
               <h1
                 id="overview-title"
-                className="atlas-overview-title mt-xl text-balance font-heading text-hero-800 font-bold leading-hero-800 sm:text-hero-900 sm:leading-hero-900"
+                className="atlas-overview-title mt-m text-balance font-heading text-600 font-bold leading-600"
               >
                 {data.workspace.displayName || "Fabric workspace"}
               </h1>
-              <p className="atlas-overview-copy mt-m text-400 leading-500 text-muted-foreground">
+              <p className="atlas-overview-copy mt-s text-300 leading-300 text-muted-foreground">
                 See what is governed, what needs attention, and where to act
                 across this workspace.
               </p>
@@ -343,7 +337,7 @@ export function OverviewView({
 
             <nav
               aria-label="Overview destinations"
-              className="grid gap-s sm:grid-cols-3"
+              className="atlas-toolbar grid sm:grid-cols-3"
             >
               <button
                 type="button"
@@ -390,27 +384,31 @@ export function OverviewView({
             </nav>
           </div>
 
-          <aside className="flex flex-col justify-center gap-xl border-t border-border bg-secondary/70 p-xl sm:p-xxl lg:col-span-2 lg:border-l lg:border-t-0 lg:p-xxxl">
+          <aside className="atlas-page-header flex flex-col justify-center border-t border-border bg-secondary/70 lg:col-span-2 lg:border-l lg:border-t-0">
             <div className="flex items-center gap-l">
               <span
                 className={`relative flex icon-size-600 shrink-0 items-center justify-center rounded-full border ${pulse.className}`}
                 aria-hidden="true"
               >
-                <span className="absolute inset-0 animate-ping rounded-full bg-current opacity-10 motion-reduce:hidden" />
                 <Activity className="icon-size-300" />
               </span>
               <div>
-                <SectionLabel>Health pulse</SectionLabel>
-                <div className="mt-xs flex items-baseline gap-s">
-                  <span className="font-numeric text-hero-800 font-bold leading-hero-800">
-                    {healthPercentage == null ? "—" : `${healthPercentage}%`}
+                <SectionLabel>Assessed item health</SectionLabel>
+                <div className="mt-xs flex flex-wrap items-baseline gap-s">
+                  <span className="font-numeric text-600 font-bold leading-600">
+                    {healthPercentage == null ? "Not assessed" : `${healthPercentage}%`}
                   </span>
                   <span className="text-300 font-semibold">{pulse.label}</span>
                 </div>
                 <p className="mt-xs text-200 text-muted-foreground">
-                  {items.length
-                    ? `${health.healthy} of ${items.length} items healthy`
-                    : "Health appears after the workspace is indexed"}
+                  {health.assessed
+                    ? `${health.healthy} of ${health.assessed} assessed items healthy`
+                    : "No collected health status is available yet."}
+                </p>
+                <p className="mt-s text-200 text-muted-foreground">
+                  Health coverage: {health.coveragePercentage == null ? "Not applicable" : `${health.coveragePercentage}%`}
+                  {" "}({health.assessed} of {health.total} items assessed).
+                  {health.unknown > 0 && ` ${health.unknown} unknown statuses are excluded from the health score.`}
                 </p>
               </div>
             </div>
@@ -447,7 +445,11 @@ export function OverviewView({
               id="posture-targets-title"
               className="mt-xs text-500 font-semibold"
             >
-              {postureAtTarget} of {posture.pillars.length} pillars at target
+              {targetsAvailable
+                ? `${postureAtTarget} of ${posture.pillars.length} pillars at target`
+                : governancePolicyLoading
+                  ? "Loading governance targets"
+                  : "Governance targets unavailable"}
             </h2>
           </div>
           <button
@@ -466,6 +468,11 @@ export function OverviewView({
             Open posture
           </button>
         </div>
+        {governancePolicyError && (
+          <p role="alert" className="mb-m rounded-lg border border-destructive/30 bg-destructive/10 p-m text-200">
+            {governancePolicyError} Open posture to retry. Raw scores remain visible below.
+          </p>
+        )}
         <Card className="grid gap-s p-m sm:grid-cols-2 xl:grid-cols-6">
           {posture.pillars.map((pillar) => {
             const previous = previousPosture?.pillars.find(
@@ -497,8 +504,8 @@ export function OverviewView({
                 <div className="mt-xs font-numeric text-400 font-bold">
                   {pillar.score == null ? "N/A" : `${pillar.score}%`}
                 </div>
-                <div className="mt-xs text-100 text-muted-foreground">
-                  Target {pillar.target}%
+                <div className="mt-xs text-200 text-muted-foreground">
+                  {targetsAvailable ? `Target ${pillar.target}%` : "Target unavailable"}
                   {delta == null
                     ? ""
                     : ` · ${delta >= 0 ? "+" : ""}${delta} pts`}

--- a/src/atlas/views/WorkspaceHub.tsx
+++ b/src/atlas/views/WorkspaceHub.tsx
@@ -61,7 +61,7 @@ export function WorkspaceHubView({
     >
       <div className="atlas-content-frame flex flex-col gap-l p-xl lg:p-xxl">
       <Card className="atlas-fabric-hero overflow-hidden border-border shadow-fabric-4">
-        <div className="flex flex-col gap-l p-l lg:flex-row lg:items-end lg:justify-between">
+        <div className="atlas-page-header flex flex-col lg:flex-row lg:items-end lg:justify-between">
           <div>
             <SectionLabel>Operate / workspace context</SectionLabel>
             <h1 className="mt-xs font-heading text-600 font-bold leading-600">

--- a/src/global.css
+++ b/src/global.css
@@ -259,6 +259,86 @@ body,
   height: 100%;
 }
 
+:root {
+  --atlas-control-height: 36px;
+  --atlas-control-padding: 6px;
+  --atlas-row-padding: 10px;
+  --atlas-page-spacing: 24px;
+  --atlas-header-padding: 16px;
+  --atlas-card-min-height: 168px;
+  --atlas-touch-target: 44px;
+}
+
+:root[data-atlas-density="compact"] {
+  --atlas-control-height: 32px;
+  --atlas-control-padding: 4px;
+  --atlas-row-padding: 6px;
+  --atlas-page-spacing: 16px;
+  --atlas-header-padding: 12px;
+  --atlas-card-min-height: 136px;
+}
+
+.atlas-control,
+.atlas-toolbar :is(button:not([role="tab"]), select, input:not([type="checkbox"]):not([type="radio"])) {
+  min-height: var(--atlas-control-height);
+  padding-block: var(--atlas-control-padding);
+  font-family: var(--font-base);
+  font-size: var(--text-300);
+  line-height: var(--leading-300);
+}
+
+.atlas-toolbar :is(select, input:not([type="checkbox"]):not([type="radio"])) {
+  height: var(--atlas-control-height);
+}
+
+.atlas-toolbar {
+  gap: var(--spacing-s);
+}
+
+.atlas-page-header {
+  gap: var(--spacing-m);
+  padding-block: var(--atlas-header-padding);
+  padding-inline: var(--spacing-l);
+}
+
+.atlas-row {
+  padding-block: var(--atlas-row-padding);
+}
+
+.atlas-catalog-card {
+  min-height: var(--atlas-card-min-height);
+}
+
+.atlas-catalog-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-300);
+}
+
+.atlas-catalog-table :is(th, td) {
+  padding: var(--atlas-row-padding) var(--spacing-m);
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.atlas-catalog-table th {
+  background: var(--color-secondary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.atlas-catalog-table tbody tr:hover {
+  background: var(--color-accent);
+}
+
+@media (max-width: 639px) {
+  .atlas-control,
+  .atlas-toolbar :is(button:not([role="tab"]), select, input:not([type="checkbox"]):not([type="radio"])) {
+    min-height: var(--atlas-touch-target);
+    min-width: var(--atlas-touch-target);
+  }
+}
+
 /* Animated flow along active lineage edges. */
 @keyframes atlas-flow {
   to {
@@ -369,6 +449,7 @@ body,
     width: 100%;
     max-width: 1480px;
     margin-inline: auto;
+    padding: var(--atlas-page-spacing);
 }
 
 .atlas-sync-grid {


### PR DESCRIPTION
Fabric Atlas v1.11.0 adds generic deep workspace discovery for KQL Database, Fabric SQL Database, Ontology, Graph Model and Data Agent artifacts. It includes verified item/object lineage, workload-specific Asset Catalog objects, object impact, search, history, metadata-only sanitization, multi-audience tokens, and updated README/architecture/data model/installation documentation plus the official-source coverage audit. FGI-MAIN is validation-only; no tenant or item identifiers are hardcoded. Validation: 306 TypeScript tests, 71 UDF tests, lint and production build. Live non-persisting validation completed with all required sections complete, KQL complete, SQL complete, definitions complete, 823 verified object edges, no truncation and no errors. Optional advanced enrichment requires the documented Entra consent.