### PR TITLE
fix: make workspace sync resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-09-05
+
+### Changed
+
+- Initial deployment sync and later workspace refreshes now share the same five-phase progress display with the active stage and elapsed time.
+- Workspace discovery no longer uses a product-level object-lineage relation count cap. Every verified relation returned by the collector is validated, mapped and persisted.
+- The UDF execution budget is now 180 seconds, leaving a 20-second completion reserve below Fabric's documented 200-second function timeout.
+- Deep discovery now runs as an authoritative base scan followed by resumable item batches grouped by Fabric type, with actual completed-item progress.
+
+### Fixed
+
+- Large valid object-lineage payloads no longer fail validation after crossing the parser's internal traversal budget.
+- Synchronization no longer advances to an artificial 42% while the Fabric metadata request is still running.
+- A deadline state returned outside the resumable slice protocol cannot publish a snapshot.
+- Timed-out or oversized enrichment batches now continue automatically, split into smaller batches, or retry a single slow item in an isolated UDF slice.
+- Deterministic single-item size failures and repeated no-progress slices now stop explicitly instead of leaving synchronization in an infinite retry loop.
+- Active synchronization now warns before a browser refresh can discard the in-memory continuation queue.
+
 ## [1.11.0] - 2026-09-05
 
 ### Added
@@ -23,7 +41,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Asset Catalog now uses workload-specific object labels instead of presenting every object as a table or column.
 - Map object mode uses verified metadata edges when available and retains the existing DAX graph as the Semantic Model fallback.
 - Snapshot persistence stores safe item metadata and verified object edges in bounded hidden `ConfigEntry` chunks.
-- Synchronization acquires separate optional Kusto, Azure SQL and OneLake audience tokens for the same authenticated Fabric user.
+- Synchronization acquires separate optional Kusto and Azure SQL audience tokens for the same authenticated Fabric user.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Fabric Atlas collects that metadata without copying business data.
 | Trusted snapshot retention | Keeps 2–50 validated snapshots, supports explicit writer rotation and removes stale rows only after a new manifest is published |
 | Lightweight history | Stores versioned trend summaries in manifests and loads detailed comparisons only when selected |
 | Versioned sync contract | Records required, optional and metadata-capability status for every synchronized snapshot |
-| Bounded UDF execution | Applies one deadline, bounded retries and payload limits below Fabric's public endpoint ceilings |
-| Accessible sync feedback | Announces stages and errors, while reduced-motion preferences disable repeating motion |
+| Bounded UDF execution | Uses a 180-second deadline below Fabric's 200-second function limit, bounded retries and transport-size safety without truncating object-lineage relations by count |
+| Resumable deep discovery | Runs one authoritative base scan, then processes item metadata in type-grouped UDF slices that automatically continue, split or isolate a slow item |
+| Accessible sync feedback | Shows five real phases, the active stage and elapsed time during both initial synchronization and later refreshes |
 | Deployment gate | Requires synchronization for the first deployment or a new major/minor snapshot contract, while compatible patch releases reuse validated history |
 | Trusted synchronizer | Restricts snapshot publication to the configured synchronization account |
 | Snapshot history | Loads previous validated snapshots for comparisons and governance trends |
@@ -231,9 +232,14 @@ Fabric Atlas collects that metadata without copying business data.
 ### Guided deployment sync
 
 The first deployment or a new major/minor snapshot contract starts with a
-controlled metadata refresh. Progress, target workspace and the live progress
-donut stay visible throughout the scan; compatible patch releases reuse the
-validated catalog.
+controlled metadata refresh. A five-phase tracker, active stage, elapsed time
+and target workspace stay visible throughout the scan. The same tracker appears
+during later refreshes, while compatible patch releases reuse the validated
+catalog. Deep discovery advances with the real completed-item count. A slow
+type is continued in a new UDF slice, and an individual slow item is retried in
+isolation. Repeated no-progress attempts stop with an explicit item-level error
+instead of looping forever. The browser warns before leaving while this
+resumable queue is active.
 
 ![Guided Fabric Atlas deployment sync](docs/screenshots/deployment-sync-v191.png)
 
@@ -323,8 +329,12 @@ flowchart LR
 The browser cannot call Fabric management APIs directly. A published User Data
 Function performs the metadata scan server-side with the signed-in user's
 delegated token. Its versioned response reports required, optional and
-capability status. The app validates and size-bounds that result, stores a
-workspace-scoped snapshot through Rayfin, and keeps the previous valid snapshot
+capability status. Atlas first retrieves the authoritative workspace topology,
+then invokes resumable enrichment slices grouped by item type. Each slice
+returns completed and remaining item IDs, so timeout or response-size pressure
+causes automatic continuation instead of truncation. The app validates and
+size-bounds every result, stores one complete workspace-scoped snapshot through
+Rayfin, and keeps the previous valid snapshot
 if a refresh fails.
 
 See [Architecture](docs/architecture.md) for the full data flow.
@@ -345,7 +355,7 @@ available in the current app.
 | P2 | Simultaneous departures | Assess several departing principals together so reassignment does not depend on another departing person |
 | P2 | Entra group membership | Expand group evidence where permissions allow it, while distinguishing direct grants from membership-derived access |
 | P2 | Multi-workspace catalog and verified lineage | Index an explicitly selected workspace scope and show cross-workspace relationships only when Microsoft exposes the evidence |
-| P2 | Resumable synchronization | Process bounded batches and resume failed work without discarding the last validated snapshot |
+| P2 | Durable background synchronization | Persist continuation state server-side so a refresh can survive a closed browser and later support scheduled execution |
 | P3 | Report visual field usage | Read supported report definitions to trace measure and column references to visuals, subject to report permissions and sensitivity restrictions |
 
 ### Multi-workspace milestones

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,10 +80,17 @@ or delete action.
 
 The Sync button calls `runFabricSync` (`src/atlas/backend.ts`). When deployed,
 the browser invokes the published `sync_all` Fabric User Data Function. The
-required Fabric/Power BI token is accompanied by optional Kusto, Azure SQL and
-OneLake tokens acquired for the same signed-in identity. Each token is used
-only by its matching metadata collector. The app maps the response, writes it
-through the Rayfin Data API, and records a `SyncRun`.
+required Fabric/Power BI token is accompanied by optional Kusto and Azure SQL
+tokens acquired for the same signed-in identity. Each token is used only by its
+matching metadata collector. The `storageToken` function parameter is reserved
+for future OneLake discovery and is not currently acquired by the browser. The
+app maps the response, writes it through the Rayfin Data API, and records a
+`SyncRun`.
+
+Initial synchronization and later refreshes use the same five-phase progress
+tracker. The discovery phase reports the actual number of enriched items and
+the active Fabric item type, together with elapsed time, rather than advancing
+a simulated percentage.
 
 Contract version 2 separates required sections from optional enrichment and
 records metadata capabilities for ownership, sensitivity, endorsement, tags,
@@ -92,11 +99,33 @@ the refresh. Optional token, permission, encrypted-label or endpoint failures
 remain visible as evidence but do not invalidate otherwise authoritative
 metadata. Valid empty workspaces are accepted.
 
-The UDF shares one 92-second monotonic deadline across API calls, incremental
-response reads, retries and sleeps. It retries bounded `429` and transient
-`5xx` responses, caps upstream and final payloads at 25 MiB, and returns
-structured safe errors. The browser independently streams and caps the response
-at 26 MiB before parsing.
+Microsoft Fabric currently enforces a
+[200-second User Data Function execution limit](https://learn.microsoft.com/en-us/python/api/fabric-user-data-functions/fabric.functions.userdatafunctiontimeouterror?view=fabric-user-data-functions-python-latest).
+Atlas uses one 180-second monotonic budget across API calls, SQL/KQL
+metadata queries, incremental response reads, retries and sleeps, leaving 20
+seconds for final projection, serialization and platform response handling. It
+retries bounded `429` and transient `5xx` responses, caps upstream and final
+payloads at 25 MiB, and returns structured safe errors. The browser independently
+streams and caps the response at 26 MiB before parsing.
+
+Object-lineage relations are not truncated by count. Synchronization starts
+with a deferred-enrichment base call that returns the authoritative workspace,
+scanner, access and base-lineage envelope. The client then groups workspace
+items by Fabric type and invokes `sync_items` in bounded operational batches.
+Each batch returns `completedItemIds` and `remainingItemIds`. When its remaining
+budget is too short to start another item, the UDF returns a continuation before
+the platform timeout.
+
+The client requeues continuations, splits a timed-out or oversized multi-item
+batch, and retries a single slow item in a fresh function slice. Repeated
+no-progress attempts are bounded, and a deterministic single-item response-size
+failure is surfaced explicitly instead of looping forever. Other item types
+continue independently in the same queue. A platform
+`UserDataFunctionTimeoutError` is therefore a retry signal for the affected
+slice, not a reason to discard completed slices. Non-retryable validation or
+permission failures still preserve the previous validated snapshot. The
+browser warns before refresh or navigation closes the tab while the queue is
+active.
 
 Each refresh writes a new immutable snapshot. Content rows are written first and
 the `Workspace` manifest is written last. A failed or incomplete refresh never

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -107,7 +107,8 @@ retains safe KQL, Ontology, Graph Model and Data Agent structures after reload.
 Verified object-lineage edges use the private `__object_edges__` section. Each
 edge stores source and target item, object kind, stable ID, readable name,
 optional parent/table context, relation and `confidence: verified`. The parser
-rejects inferred, malformed, self-referential or oversized edge sets.
+rejects inferred, malformed or self-referential edges without imposing a
+relation-count cap on the verified set.
 
 No extra Rayfin entity is required, so this metadata follows the same immutable
 snapshot publication and retention boundary as the catalog.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -196,7 +196,8 @@ protection. Unknown labels intentionally produce no downgrade alert.
 
 1. Open the `atlas_sync_functions` item in your workspace (Fabric portal). Make sure its code matches
    [`function_app.py`](../fabric/udf/atlas_sync_functions/function_app.py), then click **Publish** and
-   copy the `sync_all` invoke URL.
+   confirm both `sync_all` and `sync_items` are public endpoints. Copy the `sync_all` invoke URL; the
+   app derives the sibling `sync_items` URL for resumable per-type enrichment.
 2. Put the `sync_all` invoke URL in `RAYFIN_PUBLIC_ATLAS_UDF_URL` as shown above, redeploy, open the
    app and click **Start first sync**. The first-run screen shows live progress but never asks users
    to paste configuration values. After a successful index, future visits open the dashboard

--- a/fabric/udf/atlas_sync_functions/README.md
+++ b/fabric/udf/atlas_sync_functions/README.md
@@ -12,18 +12,33 @@ Per-item access and lineage come from the Fabric **admin scanner** (`getInfo`),
 which needs the `Tenant.Read.All` delegated permission (already consented on the
 `FabricAtlas Sync` app registration) and the tenant's read-only admin API settings
 enabled. The browser rejects any failed required section and keeps the previous
-database snapshot active. Optional enrichment failures remain visible in the
-contract without invalidating complete required metadata. Scanner access is
-therefore required for a synchronized result to become authoritative.
+database snapshot active. Unsupported endpoints and unavailable optional tokens
+remain visible without invalidating complete required metadata. Deadline
+exhaustion in any discovery section rejects the refresh so a partial deep scan
+cannot become authoritative. Scanner access is therefore required for a
+synchronized result to become authoritative.
 
 Lineage uses documented immutable identifiers for Report bindings, Dashboard
 tiles and upstream Dataflow, Datamart and Semantic Model dependencies. A
 dependency is accepted only when its scanner `groupId` is absent or matches the
 current workspace. Display names are never used to invent an edge.
 
-`sync_all` uses one 92-second monotonic deadline, including response reads,
-bounded retries and `Retry-After` sleeps. It caps upstream and final payloads at
-25 MiB, below the 100-second and 30 MB public endpoint limits.
+Fabric enforces a 200-second function timeout. Each Atlas invocation uses one
+180-second monotonic budget, including metadata queries, response reads,
+bounded retries and `Retry-After` sleeps. The remaining 20 seconds are reserved
+for final projection, serialization and platform response handling. Upstream
+and final payloads are capped at 25 MiB. Verified object-lineage relations are
+deduplicated but never truncated by count.
+
+The browser calls `sync_all` with deferred enrichment to obtain the
+authoritative workspace, scanner, access and base-lineage envelope. It then
+invokes `sync_items` with item IDs grouped by Fabric type. A slice stops before
+starting another item when less than 30 seconds remain and returns both
+`completedItemIds` and `remainingItemIds`. The client continues those IDs in a
+fresh slice, splits a timed-out multi-item request, and isolates a slow single
+item. Repeated no-progress attempts are bounded so a deterministic oversized or
+stalled item cannot leave the browser in an infinite loop. No partial slice
+publishes a Rayfin workspace manifest.
 
 For schema-enabled lakehouses, the lakehouse `/tables` endpoint may return a
 schema wrapper or no usable result. The UDF flattens schema/table responses when
@@ -38,7 +53,7 @@ objects or columns.
 | --- | --- |
 | Lakehouse | All objects returned by the paginated Lakehouse Tables REST API (managed/external type). Columns are merged from scanner metadata and downstream semantic models reached through the real SQL endpoint ID. |
 | Warehouse | Tables/views/columns when the admin scanner supplies them. Otherwise downstream semantic-model objects are returned as a clearly labelled subset. Fabric REST item properties are captured, but complete inventory requires SQL catalog access. |
-| SQL Database | Same safe behavior as Warehouse: scanner objects first, downstream model subset second, REST properties/config facts always. Complete inventory requires SQL catalog access. |
+| SQL Database | Schemas, tables, views, columns, primary keys and foreign keys from constant read-only `sys.*` catalog queries against every workspace-resolved Fabric SQL endpoint. |
 | Semantic Model | Scanner tables, columns, measures, descriptions, hidden flags and measure expressions. |
 | Report | Pages from the supported Power BI `Get Pages In Group` API. The admin scanner and Reports REST do not expose visuals or field bindings, so those are explicitly reported as unavailable rather than fabricated. |
 
@@ -75,7 +90,8 @@ and [Get Pages In Group](https://learn.microsoft.com/rest/api/power-bi/reports/g
 | `list_items` | `fabricToken, workspaceId` | workspace items |
 | `list_role_assignments` | `fabricToken, workspaceId` | users/groups + their workspace role |
 | `get_workspace` | `fabricToken, workspaceId` | workspace metadata |
-| `sync_all` | `fabricToken, workspaceId` | Schema v2 payload with workspace data, required/optional section status, metadata capabilities and safe errors |
+| `sync_all` | `fabricToken, workspaceId, kustoToken?, sqlToken?, storageToken?, deferEnrichment?` | Schema v2 payload with workspace data, required/optional section status, metadata capabilities and safe errors |
+| `sync_items` | `fabricToken, workspaceId, itemIds, kustoToken?, sqlToken?, storageToken?` | Resumable deep metadata slice with completed and remaining item IDs |
 
 Required sections are `workspace`, `items`, `roleAssignments`, `scanner`,
 `schema`, `lineage`, `access` and `config`. Optional sections are `jobs`,

--- a/fabric/udf/atlas_sync_functions/function_app.py
+++ b/fabric/udf/atlas_sync_functions/function_app.py
@@ -24,7 +24,11 @@ udf = fn.UserDataFunctions()
 FABRIC = "https://api.fabric.microsoft.com/v1"
 PBI = "https://api.powerbi.com/v1.0/myorg"
 ADMIN = PBI + "/admin"
-EXECUTION_BUDGET_SECONDS = 92
+FABRIC_UDF_TIMEOUT_SECONDS = 200
+PLATFORM_COMPLETION_RESERVE_SECONDS = 20
+EXECUTION_BUDGET_SECONDS = (
+    FABRIC_UDF_TIMEOUT_SECONDS - PLATFORM_COMPLETION_RESERVE_SECONDS
+)
 REQUEST_TIMEOUT_SECONDS = 20
 MAX_REQUEST_ATTEMPTS = 4
 MAX_BACKOFF_SECONDS = 8
@@ -36,10 +40,11 @@ MAX_DEFINITION_DECODED_BYTES = 8 * 1024 * 1024
 MAX_DEFINITION_FACTS_PER_ITEM = 1000
 MAX_SCHEMA_OBJECTS_PER_ITEM = 1000
 MAX_SCHEMA_COLUMNS_PER_OBJECT = 500
-MAX_OBJECT_LINEAGE_EDGES = 1000
 MAX_SQL_CATALOG_ROWS = 50000
 MAX_SQL_RELATIONSHIP_ROWS = 5000
 MAX_SQL_TOKEN_CHARACTERS = 65536
+MAX_SYNC_ITEM_IDS_CHARACTERS = 65536
+MIN_ENRICHMENT_ITEM_BUDGET_SECONDS = 30
 MAX_ARTIFACT_METADATA_ELEMENTS = 2048
 MAX_ARTIFACT_METADATA_COLLECTION = 512
 SQL_COPT_SS_ACCESS_TOKEN = 1256
@@ -163,6 +168,10 @@ class _ExecutionDeadline:
         if remaining <= 0:
             raise DeadlineExceeded("execution deadline exhausted")
         return min(max(0.001, bounded_timeout), remaining)
+
+    def checkpoint(self, reserve_seconds=0):
+        if self.remaining() <= reserve_seconds:
+            raise DeadlineExceeded("execution deadline exhausted")
 
     def sleep(self, seconds, sleeper=None):
         if seconds <= 0:
@@ -721,9 +730,6 @@ def _add_artifact_object_edge(artifact, source, target, relation):
     if not source or not target or not relation:
         return
     edges = artifact.setdefault("_objectEdges", [])
-    if len(edges) >= MAX_OBJECT_LINEAGE_EDGES:
-        artifact["_objectEdgesTruncated"] = True
-        return
     edges.append({
         "source": source,
         "target": target,
@@ -936,7 +942,6 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
 
     edges = []
     seen = set()
-    truncated = False
     containment_parent_types = {
         "KQL table",
         "KQL external table",
@@ -950,7 +955,6 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
     }
 
     def add(source, target, relation):
-        nonlocal truncated
         relation = _bounded_text(relation)
         if not source or not target or not relation:
             return
@@ -964,9 +968,6 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
             relation,
         )
         if key in seen:
-            return
-        if len(edges) >= MAX_OBJECT_LINEAGE_EDGES:
-            truncated = True
             return
         seen.add(key)
         edges.append({
@@ -1022,14 +1023,14 @@ def _collect_atlas_object_edges(schema_by_item, extra_edges=None):
                 reference_for(target_id, value),
                 relation,
             )
-    return edges, truncated
+    return edges
 
 
 def _atlas_object_edges(schema_by_item, extra_edges=None):
     return _collect_atlas_object_edges(
         schema_by_item,
         extra_edges=extra_edges,
-    )[0]
+    )
 
 
 def _artifact_id(value):
@@ -4488,7 +4489,13 @@ def _metadata_endpoint_ids(value):
     return ids
 
 
-def _storage_endpoint_ids(token, ws, storage, arts):
+def _storage_endpoint_ids(
+    token,
+    ws,
+    storage,
+    arts,
+    resolve_details=True,
+):
     storage_id = _artifact_id(storage)
     ids = set()
     for artifact in arts:
@@ -4505,7 +4512,7 @@ def _storage_endpoint_ids(token, ws, storage, arts):
                 ids.add(endpoint_id)
     ids.update(_metadata_endpoint_ids(storage))
     ids.update(_metadata_endpoint_ids(storage.get("_detail")))
-    if storage.get("_type") == "Lakehouse":
+    if resolve_details and storage.get("_type") == "Lakehouse":
         if (
             not storage.get("_detail")
             and not storage.get("_detailAttempted")
@@ -4558,7 +4565,13 @@ def _downstream_semantic_models(arts, start_ids):
     return models
 
 
-def _derive_storage_schemas(token, ws, arts, schema):
+def _derive_storage_schemas(
+    token,
+    ws,
+    arts,
+    schema,
+    resolve_details=True,
+):
     for storage in arts:
         if storage.get("_type") not in (
             "Lakehouse",
@@ -4567,7 +4580,13 @@ def _derive_storage_schemas(token, ws, arts, schema):
         ):
             continue
         storage_id = _artifact_id(storage)
-        endpoint_ids = _storage_endpoint_ids(token, ws, storage, arts)
+        endpoint_ids = _storage_endpoint_ids(
+            token,
+            ws,
+            storage,
+            arts,
+            resolve_details=resolve_details,
+        )
         model_ids = _downstream_semantic_models(
             arts,
             {storage_id, *endpoint_ids},
@@ -4956,7 +4975,7 @@ def _item_config(token, ws, a, typ, item_schema=None):
     return rows
 
 
-def _item_schema(token, ws, a, typ):
+def _item_schema(token, ws, a, typ, defer_enrichment=False):
     """Return only object metadata supplied by supported Fabric/Power BI APIs."""
     if typ == "SemanticModel":
         return _schema_objects(
@@ -4966,11 +4985,12 @@ def _item_schema(token, ws, a, typ):
             include_measures=True,
         )
     elif typ == "Lakehouse":
-        direct_values = (
-            a["_lakehouseTables"]
-            if "_lakehouseTables" in a
-            else _lh_tables(token, ws, a.get("id"))
-        )
+        if defer_enrichment:
+            direct_values = []
+        elif "_lakehouseTables" in a:
+            direct_values = a["_lakehouseTables"]
+        else:
+            direct_values = _lh_tables(token, ws, a.get("id"))
         direct = _schema_objects(
             direct_values,
             "Table",
@@ -5154,6 +5174,229 @@ def _guard_response_size(value, max_bytes=MAX_RESPONSE_BYTES):
     return value
 
 
+def _parse_sync_item_ids(value):
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > MAX_SYNC_ITEM_IDS_CHARACTERS
+    ):
+        raise ValueError("sync item identifiers were invalid")
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("sync item identifiers were invalid") from error
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError("sync item identifiers were invalid")
+    item_ids = []
+    seen = set()
+    for value in parsed:
+        item_id = _normalized_id(value)
+        if not item_id or item_id in seen:
+            raise ValueError("sync item identifiers were invalid")
+        seen.add(item_id)
+        item_ids.append(item_id)
+    return item_ids
+
+
+def _new_sync_trackers():
+    return {
+        "itemDetails": _new_optional_tracker(),
+        "lakehouseTables": _new_optional_tracker(),
+        "reportPages": _new_optional_tracker(),
+        "jobs": _new_optional_tracker(),
+        "definitions": _new_optional_tracker(),
+        "kqlSchema": _new_optional_tracker(),
+        "sqlSchema": _new_optional_tracker(),
+    }
+
+
+def _merge_optional_trackers(target, source):
+    for name, tracker in source.items():
+        current = target[name]
+        for result in ("success", "unsupported", "failed"):
+            current[result] += tracker[result]
+        for code in tracker["codes"]:
+            if code not in current["codes"]:
+                current["codes"].append(code)
+
+
+@udf.function()
+def sync_items(
+    fabricToken: str,
+    workspaceId: str,
+    itemIds: str,
+    kustoToken: str = "",
+    sqlToken: str = "",
+    storageToken: str = "",
+) -> dict:
+    """Return resumable deep metadata for a validated workspace item batch."""
+    ws = _workspace_id(workspaceId)
+    requested_item_ids = _parse_sync_item_ids(itemIds)
+    out = {
+        "schemaVersion": 2,
+        "syncMode": "enrichment",
+        "requestedItemIds": requested_item_ids,
+        "completedItemIds": [],
+        "remainingItemIds": [],
+        "schema": {},
+        "config": [],
+        "jobs": [],
+        "lineage": [],
+        "objectEdges": [],
+        "artifactMetadata": {},
+        "itemMetadata": {},
+        "capabilities": {},
+        "sections": {},
+        "errors": [],
+    }
+    deadline = _ExecutionDeadline()
+    trackers = _new_sync_trackers()
+    completed_artifacts = []
+    internal_schema = {}
+    extra_object_edges = []
+
+    with _deadline_scope(deadline):
+        raw_items = _get_all(
+            fabricToken,
+            f"/workspaces/{ws}/items",
+        )
+        items = [_sanitize_item(item) for item in raw_items]
+        if any(item is None for item in items):
+            raise ValueError("workspace items contained invalid metadata")
+        items_by_id = {item["id"]: item for item in items}
+        missing_item_ids = [
+            item_id
+            for item_id in requested_item_ids
+            if item_id not in items_by_id
+        ]
+        if missing_item_ids:
+            raise ValueError("sync item identifiers were outside the workspace")
+        workspace_item_ids = set(items_by_id)
+
+        for index, item_id in enumerate(requested_item_ids):
+            if (
+                index > 0
+                and deadline.remaining()
+                <= MIN_ENRICHMENT_ITEM_BUDGET_SECONDS
+            ):
+                out["remainingItemIds"] = requested_item_ids[index:]
+                break
+
+            item = items_by_id[item_id]
+            item_type = ITEM_TYPE_ALIASES.get(
+                item.get("type"),
+                item.get("type"),
+            )
+            artifact = dict(item)
+            artifact["_type"] = item_type
+            item_trackers = _new_sync_trackers()
+            item_errors = []
+            try:
+                _enrich_artifact(
+                    fabricToken,
+                    ws,
+                    artifact,
+                    item_trackers,
+                    item_errors,
+                    kusto_token=kustoToken,
+                    sql_token=sqlToken,
+                )
+                deadline.checkpoint()
+                item_schema = _finalize_schema_object_ids(
+                    item_id,
+                    item_type,
+                    _item_schema(
+                        fabricToken,
+                        ws,
+                        artifact,
+                        item_type,
+                    ),
+                )
+                deadline.checkpoint()
+                item_config = _item_config(
+                    fabricToken,
+                    ws,
+                    artifact,
+                    item_type,
+                    item_schema,
+                )
+                deadline.checkpoint()
+            except DeadlineExceeded:
+                out["remainingItemIds"] = requested_item_ids[index:]
+                break
+
+            safe_jobs = []
+            try:
+                jobs = _get_all(
+                    fabricToken,
+                    f"/workspaces/{ws}/items/{item_id}/jobs/instances",
+                )
+                _track_optional(item_trackers["jobs"], "success")
+                safe_jobs = []
+                for value in jobs[:3]:
+                    job = _sanitize_job(value, item)
+                    if job is None:
+                        raise ValueError("job record was invalid")
+                    safe_jobs.append(job)
+                deadline.checkpoint()
+            except urllib.error.HTTPError as error:
+                code = _safe_error_code(error, optional=True)
+                if code == "endpoint-unsupported":
+                    _track_optional(
+                        item_trackers["jobs"],
+                        "unsupported",
+                        code,
+                    )
+                else:
+                    _track_optional(item_trackers["jobs"], "failed", code)
+                    item_errors.append(f"jobs:{item_id}: {code}")
+            except Exception as error:
+                if isinstance(error, DeadlineExceeded):
+                    out["remainingItemIds"] = requested_item_ids[index:]
+                    break
+                code = _safe_error_code(error, optional=True)
+                _track_optional(item_trackers["jobs"], "failed", code)
+                item_errors.append(f"jobs:{item_id}: {code}")
+
+            _merge_optional_trackers(trackers, item_trackers)
+            out["errors"].extend(item_errors)
+            out["completedItemIds"].append(item_id)
+            internal_schema[item_id] = item_schema
+            out["schema"][item_id] = _public_schema(item_schema)
+            out["config"].extend(item_config)
+            out["jobs"].extend(safe_jobs)
+            metadata = artifact.get("_artifactMetadata")
+            if isinstance(metadata, dict):
+                out["artifactMetadata"][item_id] = metadata
+            item_metadata = _metadata_for_item(artifact, False)
+            item_metadata.pop("scannerMatched", None)
+            item_metadata.pop("ownerAvailable", None)
+            if item_metadata:
+                out["itemMetadata"][item_id] = item_metadata
+            extra_object_edges.extend(artifact.get("_objectEdges") or [])
+            completed_artifacts.append(artifact)
+
+        out["lineage"] = _official_lineage(
+            completed_artifacts,
+            workspace_item_ids,
+            ws,
+        )
+        out["objectEdges"] = _collect_atlas_object_edges(
+            internal_schema,
+            extra_edges=extra_object_edges,
+        )
+
+    for name, tracker in trackers.items():
+        _finish_optional_section(out, name, tracker)
+    _set_optional_capabilities(out)
+    out["syncedAt"] = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+    return _guard_response_size(out)
+
+
 @udf.function()
 def sync_all(
     fabricToken: str,
@@ -5161,11 +5404,18 @@ def sync_all(
     kustoToken: str = "",
     sqlToken: str = "",
     storageToken: str = "",
+    deferEnrichment: str = "",
 ) -> dict:
     """Return the v2 metadata-only Fabric Atlas synchronization envelope."""
     ws = _workspace_id(workspaceId)
+    defer_enrichment = str(deferEnrichment).strip().casefold() in (
+        "1",
+        "true",
+        "yes",
+    )
     out = {
         "schemaVersion": 2,
+        "syncMode": "base" if defer_enrichment else "complete",
         "workspace": None,
         "items": [],
         "roleAssignments": [],
@@ -5194,15 +5444,7 @@ def sync_all(
         "errors": [],
     }
     deadline = _ExecutionDeadline()
-    trackers = {
-        "itemDetails": _new_optional_tracker(),
-        "lakehouseTables": _new_optional_tracker(),
-        "reportPages": _new_optional_tracker(),
-        "jobs": _new_optional_tracker(),
-        "definitions": _new_optional_tracker(),
-        "kqlSchema": _new_optional_tracker(),
-        "sqlSchema": _new_optional_tracker(),
-    }
+    trackers = _new_sync_trackers()
 
     with _deadline_scope(deadline):
         try:
@@ -5343,15 +5585,16 @@ def sync_all(
                 if artifact_id not in workspace_item_ids:
                     continue
                 try:
-                    _enrich_artifact(
-                        fabricToken,
-                        ws,
-                        artifact,
-                        trackers,
-                        out["errors"],
-                        kusto_token=kustoToken,
-                        sql_token=sqlToken,
-                    )
+                    if not defer_enrichment:
+                        _enrich_artifact(
+                            fabricToken,
+                            ws,
+                            artifact,
+                            trackers,
+                            out["errors"],
+                            kusto_token=kustoToken,
+                            sql_token=sqlToken,
+                        )
                     out["itemMetadata"][artifact_id] = _metadata_for_item(
                         artifact,
                         artifact_id in scanner_by_id,
@@ -5456,6 +5699,7 @@ def sync_all(
                         ws,
                         artifact,
                         artifact["_type"],
+                        defer_enrichment=defer_enrichment,
                     )
                     if item_schema:
                         all_schema[artifact_id] = item_schema
@@ -5470,6 +5714,7 @@ def sync_all(
                     ws,
                     artifacts,
                     all_schema,
+                    resolve_details=not defer_enrichment,
                 )
             except Exception as error:
                 schema_failed = True
@@ -5500,27 +5745,13 @@ def sync_all(
                 if _artifact_id(artifact) in workspace_item_ids
                 for edge in artifact.get("_objectEdges") or []
             ]
-            object_edges, object_edges_truncated = (
-                _collect_atlas_object_edges(
-                    workspace_schema,
-                    extra_edges=extra_object_edges,
-                )
-            )
-            object_edges_truncated = (
-                object_edges_truncated
-                or any(
-                    artifact.get("_objectEdgesTruncated")
-                    for artifact in artifacts
-                )
+            object_edges = _collect_atlas_object_edges(
+                workspace_schema,
+                extra_edges=extra_object_edges,
             )
             out["objectEdges"] = object_edges
             out["capabilities"]["objectLineage"] = {
                 "status": "complete",
-                **(
-                    {"code": "truncated"}
-                    if object_edges_truncated
-                    else {}
-                ),
             }
             out["schema"] = {
                 item_id: _public_schema(tables)
@@ -5577,39 +5808,42 @@ def sync_all(
                 _set_section(out, name, "failed", scanner_code)
                 out["errors"].append(f"{name}: {scanner_code}")
 
-        for item in out["items"]:
-            try:
-                jobs = _get_all(
-                    fabricToken,
-                    f"/workspaces/{ws}/items/{item['id']}/jobs/instances",
-                )
-                _track_optional(trackers["jobs"], "success")
-                for value in jobs[:3]:
-                    job = _sanitize_job(value, item)
-                    if job is None:
-                        raise ValueError("job record was invalid")
-                    out["jobs"].append(job)
-            except urllib.error.HTTPError as error:
-                code = _safe_error_code(error, optional=True)
-                if code == "endpoint-unsupported":
-                    _track_optional(
-                        trackers["jobs"],
-                        "unsupported",
-                        code,
+        if not defer_enrichment:
+            for item in out["items"]:
+                try:
+                    jobs = _get_all(
+                        fabricToken,
+                        f"/workspaces/{ws}/items/{item['id']}/jobs/instances",
                     )
-                else:
+                    _track_optional(trackers["jobs"], "success")
+                    for value in jobs[:3]:
+                        job = _sanitize_job(value, item)
+                        if job is None:
+                            raise ValueError("job record was invalid")
+                        out["jobs"].append(job)
+                except urllib.error.HTTPError as error:
+                    code = _safe_error_code(error, optional=True)
+                    if code == "endpoint-unsupported":
+                        _track_optional(
+                            trackers["jobs"],
+                            "unsupported",
+                            code,
+                        )
+                    else:
+                        _track_optional(trackers["jobs"], "failed", code)
+                        out["errors"].append(f"jobs: {code}")
+                except Exception as error:
+                    code = _safe_error_code(error, optional=True)
                     _track_optional(trackers["jobs"], "failed", code)
                     out["errors"].append(f"jobs: {code}")
-            except Exception as error:
-                code = _safe_error_code(error, optional=True)
-                _track_optional(trackers["jobs"], "failed", code)
-                out["errors"].append(f"jobs: {code}")
-                if isinstance(error, DeadlineExceeded):
-                    break
+                    if isinstance(error, DeadlineExceeded):
+                        break
 
     for name, tracker in trackers.items():
         _finish_optional_section(out, name, tracker)
     _set_optional_capabilities(out)
+    if defer_enrichment:
+        out["enrichmentItemIds"] = [item["id"] for item in out["items"]]
     out["syncedAt"] = (
         datetime.datetime.now(datetime.timezone.utc)
         .isoformat(timespec="milliseconds")

--- a/fabric/udf/atlas_sync_functions/test_function_app.py
+++ b/fabric/udf/atlas_sync_functions/test_function_app.py
@@ -392,35 +392,34 @@ class LakehouseSchemaTests(unittest.TestCase):
         )
         self.assertEqual(public_schema[0]["objectType"], "KQL table")
 
-    def test_generalized_object_edges_are_bounded(self):
+    def test_generalized_object_edges_keep_the_complete_set(self):
         item_id = "11111111-1111-4111-8111-111111111111"
-        schema = function_app._finalize_schema_object_ids(
-            item_id,
-            "KQLDatabase",
-            [
-                {
-                    "name": "Events",
-                    "objectType": "KQL table",
-                    "columns": [
-                        {"name": f"Column{index}", "dataType": "nvarchar"}
-                        for index in range(4)
-                    ],
-                    "measures": [],
-                }
-            ],
+        extra_edges = [
+            {
+                "source": {
+                    "itemId": item_id,
+                    "kind": "column",
+                    "id": f"source-{index}",
+                    "name": f"Source {index}",
+                },
+                "target": {
+                    "itemId": item_id,
+                    "kind": "property",
+                    "id": f"target-{index}",
+                    "name": f"Target {index}",
+                },
+                "relation": "binds property",
+                "confidence": "verified",
+            }
+            for index in range(2500)
+        ]
+
+        edges = function_app._collect_atlas_object_edges(
+            {},
+            extra_edges=extra_edges,
         )
 
-        with mock.patch.object(
-            function_app,
-            "MAX_OBJECT_LINEAGE_EDGES",
-            2,
-        ):
-            edges, truncated = function_app._collect_atlas_object_edges(
-                {item_id: schema}
-            )
-
-        self.assertEqual(len(edges), 2)
-        self.assertTrue(truncated)
+        self.assertEqual(len(edges), 2500)
         self.assertTrue(
             all(edge["confidence"] == "verified" for edge in edges)
         )
@@ -660,6 +659,15 @@ class ObjectInventoryTests(unittest.TestCase):
 
 
 class RequestReliabilityTests(unittest.TestCase):
+    def test_execution_budget_leaves_platform_completion_reserve(self):
+        self.assertEqual(function_app.FABRIC_UDF_TIMEOUT_SECONDS, 200)
+        self.assertEqual(function_app.EXECUTION_BUDGET_SECONDS, 180)
+        self.assertEqual(
+            function_app.FABRIC_UDF_TIMEOUT_SECONDS
+            - function_app.EXECUTION_BUDGET_SECONDS,
+            function_app.PLATFORM_COMPLETION_RESERVE_SECONDS,
+        )
+
     def test_req_returns_json_and_uses_bounded_timeout(self):
         clock = _Clock()
         deadline = function_app._ExecutionDeadline(5, clock.monotonic)
@@ -3177,6 +3185,7 @@ class SyncOrchestrationTests(unittest.TestCase):
         scan,
         role_assignments=None,
         jobs_error=None,
+        defer_enrichment="",
     ):
         role_assignments = role_assignments or [
             {
@@ -3220,7 +3229,228 @@ class SyncOrchestrationTests(unittest.TestCase):
                 return_value=scan,
             ),
         ):
-            return function_app.sync_all("token", self.workspace_id)
+            return function_app.sync_all(
+                "token",
+                self.workspace_id,
+                deferEnrichment=defer_enrichment,
+            )
+
+    def test_sync_all_can_defer_per_item_enrichment(self):
+        items = [
+            {
+                "id": "flow",
+                "type": "Dataflow",
+                "displayName": "Flow",
+            }
+        ]
+        scan = {"dataflows": [{"objectId": "flow"}]}
+
+        with mock.patch.object(function_app, "_enrich_artifact") as enrich:
+            result = self._run_sync(
+                items,
+                scan,
+                defer_enrichment="true",
+            )
+
+        enrich.assert_not_called()
+        self.assertEqual(result["syncMode"], "base")
+        self.assertEqual(result["enrichmentItemIds"], ["flow"])
+        self.assertEqual(result["jobs"], [])
+
+    def test_sync_items_returns_completed_deep_metadata(self):
+        items = [
+            {
+                "id": "sql",
+                "type": "SQLDatabase",
+                "displayName": "SQL",
+            }
+        ]
+
+        def get_all(_token, path):
+            if path.endswith("/items"):
+                return items
+            if "/jobs/instances" in path:
+                return []
+            raise AssertionError(path)
+
+        with (
+            mock.patch.object(
+                function_app,
+                "_get_all",
+                side_effect=get_all,
+            ),
+            mock.patch.object(
+                function_app,
+                "_enrich_artifact",
+                side_effect=lambda _token, _ws, artifact, *_args, **_kwargs: (
+                    artifact.update(
+                        {
+                            "sensitivity": {
+                                "labelId": "label-1",
+                                "displayName": "Confidential",
+                            },
+                            "tags": [{"id": "tag-1", "displayName": "Finance"}],
+                        }
+                    )
+                ),
+            ),
+            mock.patch.object(
+                function_app,
+                "_item_schema",
+                return_value=[
+                    {
+                        "name": "dbo.Customers",
+                        "objectType": "SQL table",
+                        "columns": [],
+                        "measures": [],
+                    }
+                ],
+            ),
+            mock.patch.object(
+                function_app,
+                "_item_config",
+                return_value=[
+                    {
+                        "itemId": "sql",
+                        "section": "SQL database",
+                        "label": "Database",
+                        "value": "SQL",
+                    }
+                ],
+            ),
+        ):
+            result = function_app.sync_items(
+                "token",
+                self.workspace_id,
+                '["sql"]',
+            )
+
+        self.assertEqual(result["completedItemIds"], ["sql"])
+        self.assertEqual(result["remainingItemIds"], [])
+        self.assertEqual(result["schema"]["sql"][0]["name"], "dbo.Customers")
+        self.assertEqual(len(result["config"]), 1)
+        self.assertEqual(
+            result["itemMetadata"]["sql"]["sensitivity"]["labelId"],
+            "label-1",
+        )
+        self.assertEqual(
+            result["itemMetadata"]["sql"]["tags"][0]["id"],
+            "tag-1",
+        )
+
+    def test_deferred_storage_derivation_skips_lakehouse_detail_calls(self):
+        storage = {
+            "id": "lake",
+            "_type": "Lakehouse",
+        }
+
+        with mock.patch.object(function_app, "_get") as get:
+            endpoint_ids = function_app._storage_endpoint_ids(
+                "token",
+                self.workspace_id,
+                storage,
+                [storage],
+                resolve_details=False,
+            )
+
+        get.assert_not_called()
+        self.assertEqual(endpoint_ids, set())
+
+    def test_sync_items_returns_a_continuation_before_the_deadline(self):
+        items = [
+            {"id": "one", "type": "Lakehouse", "displayName": "One"},
+            {"id": "two", "type": "Lakehouse", "displayName": "Two"},
+        ]
+        processed = []
+
+        class _Deadline:
+            def remaining(self):
+                return 20 if processed else 180
+
+            def checkpoint(self, reserve_seconds=0):
+                if self.remaining() <= reserve_seconds:
+                    raise function_app.DeadlineExceeded(
+                        "execution deadline exhausted"
+                    )
+
+        def get_all(_token, path):
+            if path.endswith("/items"):
+                return items
+            if "/jobs/instances" in path:
+                return []
+            raise AssertionError(path)
+
+        def enrich(_token, _ws, artifact, *_args, **_kwargs):
+            processed.append(artifact["id"])
+
+        with (
+            mock.patch.object(
+                function_app,
+                "_ExecutionDeadline",
+                return_value=_Deadline(),
+            ),
+            mock.patch.object(
+                function_app,
+                "_get_all",
+                side_effect=get_all,
+            ),
+            mock.patch.object(
+                function_app,
+                "_enrich_artifact",
+                side_effect=enrich,
+            ),
+            mock.patch.object(
+                function_app,
+                "_item_schema",
+                return_value=[],
+            ),
+            mock.patch.object(
+                function_app,
+                "_item_config",
+                return_value=[],
+            ),
+        ):
+            result = function_app.sync_items(
+                "token",
+                self.workspace_id,
+                '["one","two"]',
+            )
+
+        self.assertEqual(result["completedItemIds"], ["one"])
+        self.assertEqual(result["remainingItemIds"], ["two"])
+
+    def test_sync_items_requeues_an_item_that_exhausts_its_slice(self):
+        items = [
+            {"id": "graph", "type": "GraphModel", "displayName": "Graph"}
+        ]
+
+        def get_all(_token, path):
+            if path.endswith("/items"):
+                return items
+            raise AssertionError(path)
+
+        with (
+            mock.patch.object(
+                function_app,
+                "_get_all",
+                side_effect=get_all,
+            ),
+            mock.patch.object(
+                function_app,
+                "_enrich_artifact",
+                side_effect=function_app.DeadlineExceeded(
+                    "execution deadline exhausted"
+                ),
+            ),
+        ):
+            result = function_app.sync_items(
+                "token",
+                self.workspace_id,
+                '["graph"]',
+            )
+
+        self.assertEqual(result["completedItemIds"], [])
+        self.assertEqual(result["remainingItemIds"], ["graph"])
 
     def test_sync_all_returns_v2_envelope_and_keeps_top_level_items(self):
         items = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
 import { useThemeContext } from "@/hooks/theme.context";
 import { useAtlas } from "./atlas/store";
 import { CommandPalette } from "./atlas/components/CommandPalette";
+import { SynchronizationProgress } from "./atlas/components/SynchronizationProgress";
 import {
   navigationForSearch,
   type AtlasFocusRequest,
@@ -220,6 +221,7 @@ function App() {
     syncing,
     syncProgress,
     syncStage,
+    syncStartedAt,
     syncError,
     canSync,
     lastSyncedAt,
@@ -470,22 +472,16 @@ function App() {
             </button>
             <Avatar name={currentUser.name} size={30} />
           </div>
-          {(syncing || syncProgress > 0) && (
-            <div
-              role="progressbar"
-              aria-label="Workspace synchronization progress"
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-valuenow={syncProgress}
-              className="absolute inset-x-0 bottom-0 h-[3px] overflow-hidden bg-muted"
-            >
-              <div
-                className="h-full bg-gradient-to-r from-primary to-lineage-downstream transition-[width] duration-500"
-                style={{ width: `${syncProgress}%` }}
-              />
-            </div>
-          )}
         </header>
+        {(syncing || syncProgress > 0) && (
+          <SynchronizationProgress
+            key={syncStartedAt}
+            progress={syncProgress}
+            stage={syncStage}
+            active={syncing}
+            variant="banner"
+          />
+        )}
         {density.error && (
           <p role="status" className="border-b border-status-warning/30 bg-status-warning/10 px-l py-s text-200 text-foreground">
             {density.error}

--- a/src/atlas/backend.ts
+++ b/src/atlas/backend.ts
@@ -296,11 +296,10 @@ export async function runFabricSync(
     return null;
   }
   requireSyncWriter(user);
-  reportProgress?.(8, "Connecting to Microsoft Fabric");
-  const raw = await invokeSyncAll(workspaceId(), user);
-  reportProgress?.(48, "Workspace metadata received");
+  const raw = await invokeSyncAll(workspaceId(), user, reportProgress);
+  reportProgress?.(62, "Workspace metadata complete");
   const atlas = mapSyncToAtlas(raw, WS_FALLBACK);
-  reportProgress?.(58, "Building the governance catalog");
+  reportProgress?.(66, "Building the governance catalog");
   // Carry over comments that already live in the DB (sync doesn't touch them).
   try {
     const existing = await loadFromDb(false);
@@ -308,7 +307,7 @@ export async function runFabricSync(
   } catch {
     /* ignore */
   }
-  reportProgress?.(66, "Preserving team notes");
+  reportProgress?.(69, "Preserving team notes");
   const persisted = await persistSync(atlas, user, reportProgress);
   reportProgress?.(100, "Sync complete");
   return persisted;

--- a/src/atlas/components/SynchronizationProgress.spec.tsx
+++ b/src/atlas/components/SynchronizationProgress.spec.tsx
@@ -1,0 +1,48 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SynchronizationProgress } from "./SynchronizationProgress";
+import {
+  formatSyncElapsed,
+  syncPhaseIndex,
+} from "../synchronization-progress";
+
+describe("SynchronizationProgress", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("maps real synchronization milestones to five visible phases", () => {
+    expect(syncPhaseIndex(3)).toBe(0);
+    expect(syncPhaseIndex(8)).toBe(1);
+    expect(syncPhaseIndex(62)).toBe(2);
+    expect(syncPhaseIndex(70)).toBe(3);
+    expect(syncPhaseIndex(97)).toBe(4);
+  });
+
+  it("shows active discovery and elapsed time without inventing progress", () => {
+    vi.useFakeTimers();
+    render(
+      <SynchronizationProgress
+        progress={8}
+        stage="Discovering workspace metadata"
+        active
+        variant="banner"
+      />,
+    );
+    act(() => vi.advanceTimersByTime(65_000));
+
+    expect(
+      screen.getByRole("region", {
+        name: "Workspace synchronization status",
+      }),
+    ).toHaveTextContent("Phase 2 of 5");
+    expect(screen.getByText("01:05")).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", {
+        name: "Workspace synchronization progress",
+      }),
+    ).toHaveAttribute("aria-valuenow", "8");
+  });
+
+  it("formats elapsed durations beyond one minute", () => {
+    expect(formatSyncElapsed(125.8)).toBe("02:05");
+  });
+});

--- a/src/atlas/components/SynchronizationProgress.tsx
+++ b/src/atlas/components/SynchronizationProgress.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Check, Clock3, RefreshCw } from "lucide-react";
+import {
+  formatSyncElapsed,
+  SYNC_PHASES,
+  syncPhaseIndex,
+} from "../synchronization-progress";
+import { cn } from "../ui";
+
+function useSyncElapsed(active: boolean): number {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const timer = window.setInterval(
+      () => setElapsedSeconds((value) => value + 1),
+      1_000,
+    );
+    return () => window.clearInterval(timer);
+  }, [active]);
+
+  return elapsedSeconds;
+}
+
+export function SynchronizationProgress({
+  progress,
+  stage,
+  active,
+  variant = "hero",
+}: {
+  progress: number;
+  stage: string;
+  active: boolean;
+  variant?: "hero" | "banner";
+}) {
+  const normalizedProgress = Math.min(100, Math.max(0, progress));
+  const phaseIndex = syncPhaseIndex(normalizedProgress);
+  const elapsed = formatSyncElapsed(useSyncElapsed(active));
+  const compact = variant === "banner";
+
+  return (
+    <section
+      aria-label="Workspace synchronization status"
+      className={cn(
+        compact
+          ? "border-b border-border bg-secondary/85 px-m py-s sm:px-l lg:px-xl"
+          : "rounded-xl border border-border bg-secondary p-l",
+      )}
+    >
+      <div className="flex items-center justify-between gap-m">
+        <div className="min-w-0">
+          <div className="flex items-center gap-s">
+            <RefreshCw
+              className={cn(
+                "icon-size-200 shrink-0 text-primary",
+                active && "animate-spin",
+              )}
+              aria-hidden="true"
+            />
+            <span
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="truncate text-300 font-semibold"
+            >
+              {stage}
+            </span>
+          </div>
+          <div className="mt-xxs text-200 text-muted-foreground">
+            Phase {phaseIndex + 1} of {SYNC_PHASES.length} ·{" "}
+            {SYNC_PHASES[phaseIndex].label}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-xs font-numeric text-200 text-muted-foreground">
+          <Clock3 className="icon-size-100" aria-hidden="true" />
+          <span>{elapsed}</span>
+          <span className="sr-only">elapsed</span>
+        </div>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-label="Workspace synchronization progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={normalizedProgress}
+        aria-valuetext={`${stage}. Phase ${phaseIndex + 1} of ${SYNC_PHASES.length}. ${elapsed} elapsed.`}
+        className="relative mt-m h-s overflow-hidden rounded-full bg-muted"
+      >
+        <div
+          className="h-full rounded-full bg-primary transition-[width] duration-500"
+          style={{ width: `${normalizedProgress}%` }}
+        />
+        {active && normalizedProgress < 100 && (
+          <span
+            className="absolute inset-y-0 right-0 animate-pulse bg-primary/10"
+            style={{ left: `${normalizedProgress}%` }}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+
+      <ol
+        aria-label="Synchronization phases"
+        className={cn(
+          "mt-m grid grid-cols-5 gap-xs",
+          compact && "hidden sm:grid",
+        )}
+      >
+        {SYNC_PHASES.map((phase, index) => {
+          const complete =
+            normalizedProgress >= 100 || index < phaseIndex;
+          const current = active && index === phaseIndex;
+          return (
+            <li
+              key={phase.label}
+              aria-current={current ? "step" : undefined}
+              className="min-w-0 text-center"
+            >
+              <span
+                className={cn(
+                  "mx-auto flex h-7 w-7 items-center justify-center rounded-full border font-numeric text-100 font-semibold",
+                  complete
+                    ? "border-status-healthy bg-status-healthy/10 text-status-healthy"
+                    : current
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border bg-card text-muted-foreground",
+                )}
+              >
+                {complete ? (
+                  <Check className="icon-size-100" aria-hidden="true" />
+                ) : (
+                  index + 1
+                )}
+              </span>
+              <span
+                className={cn(
+                  "mt-xs block truncate text-100",
+                  current ? "font-semibold text-foreground" : "text-muted-foreground",
+                )}
+              >
+                {phase.label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+
+      {!compact && active && phaseIndex === 1 && (
+        <p className="mt-m text-200 leading-300 text-muted-foreground">
+          Atlas is processing the workspace by item type. Completed slices are
+          retained until every type is ready for one atomic snapshot.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/atlas/item-metadata.spec.ts
+++ b/src/atlas/item-metadata.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   ITEM_METADATA_SCHEMA_NAME,
   MAX_DATA_AGENT_ELEMENTS,
-  MAX_OBJECT_LINEAGE_EDGES,
   METADATA_OBJECT_TYPES,
   OPTIONAL_METADATA_SYNC_SECTIONS,
   isItemMetadataSchemaEntry,
@@ -902,7 +901,36 @@ describe("metadata lineage", () => {
     });
   });
 
-  it("rejects inferred, malformed, and unbounded object-edge payloads", () => {
+  it("accepts complete object-edge payloads without a relation-count cap", () => {
+    const edgeCount = 2_500;
+    const objectEdges = Array.from(
+      { length: edgeCount },
+      (_, index) => ({
+        source: {
+          itemId: "source",
+          kind: "column",
+          id: `source-column-${index}`,
+          name: `Source column ${index}`,
+          tableName: "Customers",
+        },
+        target: {
+          itemId: "ontology",
+          kind: "property",
+          id: `ontology-property-${index}`,
+          name: `Ontology property ${index}`,
+          tableName: "Customer",
+        },
+        relation: "binds property",
+        confidence: "verified",
+      }),
+    );
+
+    expect(parseObjectLineagePayload({ objectEdges })?.objectEdges).toHaveLength(
+      edgeCount,
+    );
+  });
+
+  it("rejects inferred and malformed object-edge payloads", () => {
     const inferred = {
       source: {
         itemId: "source",
@@ -921,14 +949,6 @@ describe("metadata lineage", () => {
     };
 
     expect(parseObjectLineagePayload({ objectEdges: [inferred] })).toBeUndefined();
-    expect(
-      parseObjectLineagePayload({
-        objectEdges: Array.from(
-          { length: MAX_OBJECT_LINEAGE_EDGES + 1 },
-          () => inferred,
-        ),
-      }),
-    ).toBeUndefined();
     expect(
       parseObjectLineagePayload({
         objectEdges: [

--- a/src/atlas/item-metadata.ts
+++ b/src/atlas/item-metadata.ts
@@ -300,7 +300,6 @@ export const MAX_DATA_AGENT_ELEMENTS = 2_048;
 const MAX_NESTING_DEPTH = 16;
 const MAX_VISITED_VALUES = 10_000;
 const MAX_SERIALIZED_METADATA_LENGTH = 1_000_000;
-export const MAX_OBJECT_LINEAGE_EDGES = 1_000;
 
 const FORBIDDEN_CONTENT_KEYS = new Set([
   "aiinstructions",
@@ -338,19 +337,23 @@ function normalizedKey(value: string): string {
   return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
 }
 
-function containsUnsafeContent(value: unknown): boolean {
+function containsUnsafeContent(
+  value: unknown,
+  maxVisitedValues = MAX_VISITED_VALUES,
+  maxArrayLength = MAX_DATA_AGENT_ELEMENTS,
+): boolean {
   const ancestors = new WeakSet<object>();
   let visited = 0;
 
   const walk = (candidate: unknown, depth: number): boolean => {
     visited += 1;
-    if (visited > MAX_VISITED_VALUES || depth > MAX_NESTING_DEPTH) return true;
+    if (visited > maxVisitedValues || depth > MAX_NESTING_DEPTH) return true;
     if (!candidate || typeof candidate !== "object") return false;
     if (ancestors.has(candidate)) return true;
     ancestors.add(candidate);
 
     if (Array.isArray(candidate)) {
-      if (candidate.length > MAX_DATA_AGENT_ELEMENTS) return true;
+      if (candidate.length > maxArrayLength) return true;
       const unsafe = candidate.some((entry) => walk(entry, depth + 1));
       ancestors.delete(candidate);
       return unsafe;
@@ -2225,26 +2228,14 @@ function parseMetadataObjectRef(
 }
 
 function objectLineageEntries(value: unknown): unknown[] | undefined {
-  if (Array.isArray(value)) {
-    return value.length <= MAX_OBJECT_LINEAGE_EDGES ? value : undefined;
-  }
+  if (Array.isArray(value)) return value;
   if (!isRecord(value)) return undefined;
   const direct = value.objectEdges;
-  if (Array.isArray(direct)) {
-    return direct.length <= MAX_OBJECT_LINEAGE_EDGES
-      ? direct
-      : undefined;
-  }
+  if (Array.isArray(direct)) return direct;
   const lineage = value.objectLineage;
-  if (Array.isArray(lineage)) {
-    return lineage.length <= MAX_OBJECT_LINEAGE_EDGES
-      ? lineage
-      : undefined;
-  }
+  if (Array.isArray(lineage)) return lineage;
   if (isRecord(lineage) && Array.isArray(lineage.edges)) {
-    return lineage.edges.length <= MAX_OBJECT_LINEAGE_EDGES
-      ? lineage.edges
-      : undefined;
+    return lineage.edges;
   }
   return undefined;
 }
@@ -2252,7 +2243,15 @@ function objectLineageEntries(value: unknown): unknown[] | undefined {
 export function parseObjectLineagePayload(
   value: unknown,
 ): ObjectLineagePayload | undefined {
-  if (containsUnsafeContent(value)) return undefined;
+  if (
+    containsUnsafeContent(
+      value,
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+    )
+  ) {
+    return undefined;
+  }
   const entries = objectLineageEntries(value);
   if (!entries) return undefined;
   const edges: MetadataObjectLineageEdge[] = [];

--- a/src/atlas/live-sync.spec.ts
+++ b/src/atlas/live-sync.spec.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   accountMatchesIdentity,
+  buildSyncItemBatches,
   buildSyncRequestBody,
+  isUdfTimeoutFailure,
   mapSyncToAtlas,
+  mergeSyncEnrichment,
   normalizeFabricTimestamp,
   parseSyncResponseText,
   readBoundedResponseText,
   selectMsalAccount,
+  syncDeadlineExceeded,
   validateRawSync,
+  validateSyncEnrichment,
   type MsalAccount,
   type RawSync,
 } from "./live-sync";
@@ -33,6 +38,180 @@ describe("validateRawSync", () => {
     expect(() => validateRawSync(completeSync(), workspaceId)).not.toThrow();
   });
 
+  describe("resumable metadata enrichment", () => {
+    it("groups item slices by type without limiting the complete workspace", () => {
+      const items = [
+        ...Array.from({ length: 10 }, (_, index) => ({
+          id: `sql-${index}`,
+          type: "SQLDatabase",
+        })),
+        ...Array.from({ length: 2 }, (_, index) => ({
+          id: `kql-${index}`,
+          type: "KQLDatabase",
+        })),
+      ];
+
+      expect(buildSyncItemBatches(items, 8)).toEqual([
+        {
+          itemType: "SQLDatabase",
+          itemIds: Array.from({ length: 8 }, (_, index) => `sql-${index}`),
+          attempt: 0,
+        },
+        {
+          itemType: "SQLDatabase",
+          itemIds: ["sql-8", "sql-9"],
+          attempt: 0,
+        },
+        {
+          itemType: "KQLDatabase",
+          itemIds: ["kql-0", "kql-1"],
+          attempt: 0,
+        },
+      ]);
+    });
+
+    it("merges scanner and deep metadata from completed slices", () => {
+      const base: RawSync = {
+        schema: {
+          sql: [
+            {
+              name: "dbo.Customers",
+              objectType: "Table",
+              columns: [{ name: "CustomerId", dataType: "int" }],
+              measures: [],
+            },
+          ],
+        },
+        jobs: [],
+        lineage: [],
+        config: [],
+        artifactMetadata: {},
+        itemMetadata: {
+          sql: {
+            scannerMatched: true,
+            ownerAvailable: true,
+            sensitivity: { labelId: "scanner-label" },
+          },
+        },
+        objectEdges: [],
+        sections: {
+          definitions: { status: "unsupported", code: "not-applicable" },
+        },
+        capabilities: {
+          definitionEnrichment: {
+            status: "unsupported",
+            code: "not-applicable",
+          },
+        },
+        errors: [],
+      };
+      const enrichment: RawSync = {
+        schema: {
+          sql: [
+            {
+              name: "dbo.Customers",
+              objectType: "Managed",
+              columns: [{ name: "Name", dataType: "nvarchar" }],
+              measures: [],
+            },
+          ],
+        },
+        jobs: [{ itemId: "sql", jobType: "Refresh", status: "Completed" }],
+        lineage: [{ source: "sql", target: "report", relation: "report" }],
+        config: [
+          {
+            itemId: "sql",
+            section: "SQL database",
+            label: "Server",
+            value: "example.database.fabric.microsoft.com",
+          },
+        ],
+        artifactMetadata: { sql: { kind: "sql" } },
+        itemMetadata: {
+          sql: {
+            sensitivity: {
+              labelId: "detail-label",
+              displayName: "Confidential",
+            },
+            tags: [{ id: "tag-1", displayName: "Finance" }],
+          },
+        },
+        objectEdges: [{ relation: "contains" }],
+        sections: {
+          definitions: { status: "complete" },
+        },
+        capabilities: {
+          definitionEnrichment: { status: "complete" },
+        },
+        errors: [],
+      };
+
+      const merged = mergeSyncEnrichment(base, enrichment);
+
+      expect(merged.schema?.sql).toHaveLength(1);
+      expect(merged.schema?.sql[0]).toMatchObject({
+        objectType: "Managed",
+      });
+      expect(merged.schema?.sql[0].columns).toHaveLength(2);
+      expect(merged.jobs).toHaveLength(1);
+      expect(merged.lineage).toHaveLength(1);
+      expect(merged.objectEdges).toHaveLength(1);
+      expect(merged.capabilities?.definitionEnrichment?.status).toBe("complete");
+      expect(merged.itemMetadata?.sql).toMatchObject({
+        scannerMatched: true,
+        ownerAvailable: true,
+        sensitivity: {
+          labelId: "detail-label",
+          displayName: "Confidential",
+        },
+        tags: [{ id: "tag-1", displayName: "Finance" }],
+      });
+    });
+
+    it("accepts a completed prefix with an explicit continuation", () => {
+      const enrichment: RawSync = {
+        schemaVersion: 2,
+        syncMode: "enrichment",
+        requestedItemIds: ["one", "two"],
+        completedItemIds: ["one"],
+        remainingItemIds: ["two"],
+        schema: { one: [] },
+        config: [],
+        jobs: [],
+        lineage: [],
+        artifactMetadata: {},
+        itemMetadata: {},
+        objectEdges: [],
+        sections: {},
+        capabilities: {},
+        errors: [],
+      };
+
+      expect(() =>
+        validateSyncEnrichment(enrichment, ["one", "two"]),
+      ).not.toThrow();
+      expect(() =>
+        validateSyncEnrichment(
+          { ...enrichment, remainingItemIds: [] },
+          ["one", "two"],
+        ),
+      ).toThrow(/invalid resumable sync response/i);
+
+      expect(() =>
+        validateSyncEnrichment(
+          {
+            ...enrichment,
+            requestedItemIds: ["one"],
+            completedItemIds: [],
+            remainingItemIds: ["one"],
+            schema: {},
+          },
+          ["one"],
+        ),
+      ).not.toThrow();
+    });
+  });
+
   describe("sync request metadata tokens", () => {
     it("passes available audience tokens without manufacturing missing values", () => {
       expect(
@@ -46,6 +225,7 @@ describe("validateRawSync", () => {
         kustoToken: "kusto-token",
       });
     });
+
   });
 
   describe("sync response parsing", () => {
@@ -75,6 +255,17 @@ describe("validateRawSync", () => {
       await expect(readBoundedResponseText(response, 8)).rejects.toThrow(
         /exceeded.*safety limit/i,
       );
+    });
+
+    it("recognizes Fabric UDF platform timeout responses", () => {
+      expect(isUdfTimeoutFailure(504, "")).toBe(true);
+      expect(
+        isUdfTimeoutFailure(
+          500,
+          "fabric.functions.UserDataFunctionTimeoutError: exceeded the timeout limit",
+        ),
+      ).toBe(true);
+      expect(isUdfTimeoutFailure(500, "unrelated error")).toBe(false);
     });
   });
 
@@ -114,6 +305,37 @@ describe("validateRawSync", () => {
     raw.errors = ["jobs: transient upstream failure"];
 
     expect(() => validateRawSync(raw, workspaceId)).not.toThrow();
+  });
+
+  it("rejects deadline exhaustion even when it occurred in optional metadata", () => {
+    const raw = completeSync();
+    raw.schemaVersion = 2;
+    raw.sections = {
+      workspace: { status: "complete" },
+      items: { status: "complete" },
+      roleAssignments: { status: "complete" },
+      scanner: { status: "complete" },
+      schema: { status: "complete" },
+      lineage: { status: "complete" },
+      access: { status: "complete" },
+      config: { status: "complete" },
+    };
+    raw.capabilities = {
+      endorsement: { status: "complete" },
+      sensitivity: { status: "complete" },
+      tags: { status: "complete" },
+      ownership: { status: "complete", code: "type-specific" },
+      definitions: { status: "failed", code: "deadline-exhausted" },
+    };
+    raw.itemMetadata = {
+      "item-1": { scannerMatched: true },
+    };
+    raw.errors = ["definitions:item-1: deadline-exhausted"];
+
+    expect(() => validateRawSync(raw, workspaceId)).toThrow(
+      /execution budget.*previous snapshot was preserved/i,
+    );
+    expect(syncDeadlineExceeded(raw)).toBe(true);
   });
 
   it("rejects failed required v2 sections", () => {

--- a/src/atlas/live-sync.ts
+++ b/src/atlas/live-sync.ts
@@ -6,7 +6,6 @@
 import { ATLAS_CONFIG, getUdfUrl } from "./config";
 import { normalizeLineageEdges } from "./lineage";
 import {
-  MAX_OBJECT_LINEAGE_EDGES,
   itemMetadataFromSchema,
   metadataItemLineageEdges,
   metadataObjectLineageEdges,
@@ -231,6 +230,8 @@ export interface SyncRequestTokens {
   kustoToken?: string;
   sqlToken?: string;
   storageToken?: string;
+  deferEnrichment?: string;
+  itemIds?: string;
 }
 
 export function buildSyncRequestBody(
@@ -303,6 +304,7 @@ async function acquireFabricSyncToken(
 
 export interface RawSync {
   schemaVersion?: number;
+  syncMode?: string;
   workspace?: Record<string, unknown>;
   items?: Array<Record<string, unknown>>;
   roleAssignments?: Array<Record<string, unknown>>;
@@ -365,6 +367,10 @@ export interface RawSync {
   artifactMetadata?: Record<string, unknown>;
   objectEdges?: unknown;
   objectLineage?: unknown;
+  enrichmentItemIds?: string[];
+  requestedItemIds?: string[];
+  completedItemIds?: string[];
+  remainingItemIds?: string[];
   syncedAt?: string;
   schema?: Record<
     string,
@@ -386,6 +392,7 @@ export interface RawSync {
         name?: string;
         expression?: string;
         expr?: string;
+        objectType?: string;
         description?: string;
         isHidden?: boolean;
       }>;
@@ -393,6 +400,231 @@ export interface RawSync {
     }>
   >;
   errors?: string[];
+}
+
+export interface SyncItemBatch {
+  itemType: string;
+  itemIds: string[];
+  attempt: number;
+}
+
+const SYNC_ITEM_BATCH_SIZE = 8;
+
+export function buildSyncItemBatches(
+  items: Array<Record<string, unknown>>,
+  batchSize = SYNC_ITEM_BATCH_SIZE,
+): SyncItemBatch[] {
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error("Sync batch size must be a positive integer.");
+  }
+  const groups = new Map<string, string[]>();
+  for (const item of items) {
+    const itemId = realText(item.id);
+    const itemType = realText(item.type);
+    if (!itemId || !itemType) continue;
+    const itemIds = groups.get(itemType) ?? [];
+    itemIds.push(itemId);
+    groups.set(itemType, itemIds);
+  }
+  return [...groups.entries()].flatMap(([itemType, itemIds]) => {
+    const batches: SyncItemBatch[] = [];
+    for (let index = 0; index < itemIds.length; index += batchSize) {
+      batches.push({
+        itemType,
+        itemIds: itemIds.slice(index, index + batchSize),
+        attempt: 0,
+      });
+    }
+    return batches;
+  });
+}
+
+function uniqueBy<T>(values: T[], key: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const identity = key(value);
+    if (seen.has(identity)) return false;
+    seen.add(identity);
+    return true;
+  });
+}
+
+type RawSchemaTable = NonNullable<RawSync["schema"]>[string][number];
+type RawSchemaColumn = NonNullable<RawSchemaTable["columns"]>[number];
+type RawSchemaMeasure = NonNullable<RawSchemaTable["measures"]>[number];
+
+function mergeSchemaValues<T extends { name?: string; objectType?: string }>(
+  current: T[] = [],
+  incoming: T[] = [],
+): T[] {
+  const values = new Map<string, T>();
+  for (const value of [...current, ...incoming]) {
+    const key = (value.name ?? "").trim().toLocaleLowerCase();
+    values.set(key, { ...values.get(key), ...value });
+  }
+  return [...values.values()];
+}
+
+function mergeSchemaTables(
+  current: RawSchemaTable[] = [],
+  incoming: RawSchemaTable[] = [],
+): RawSchemaTable[] {
+  const values = new Map<string, RawSchemaTable>();
+  for (const table of [...current, ...incoming]) {
+    const key = (table.name ?? "").trim().toLocaleLowerCase();
+    const previous = values.get(key);
+    values.set(
+      key,
+      previous
+        ? {
+            ...previous,
+            ...table,
+            columns: mergeSchemaValues<RawSchemaColumn>(
+              previous.columns,
+              table.columns,
+            ),
+            measures: mergeSchemaValues<RawSchemaMeasure>(
+              previous.measures,
+              table.measures,
+            ),
+          }
+        : table,
+    );
+  }
+  return [...values.values()];
+}
+
+function mergeSyncStatus(
+  current:
+    | { status?: "complete" | "unsupported" | "failed"; code?: string }
+    | undefined,
+  incoming:
+    | { status?: "complete" | "unsupported" | "failed"; code?: string }
+    | undefined,
+) {
+  if (!current) return incoming;
+  if (!incoming) return current;
+  if (current.status === "unsupported" && current.code === "not-applicable") {
+    return incoming;
+  }
+  if (incoming.status === "unsupported" && incoming.code === "not-applicable") {
+    return current;
+  }
+  if (current.status === "failed") return current;
+  if (incoming.status === "failed") return incoming;
+  if (current.status === "complete" || incoming.status === "complete") {
+    return {
+      status: "complete" as const,
+      code:
+        current.status === "unsupported" || incoming.status === "unsupported"
+          ? "partial-unsupported"
+          : incoming.code ?? current.code,
+    };
+  }
+  return incoming.code ? incoming : current;
+}
+
+function mergeSyncStatusMaps(
+  current: RawSync["sections"],
+  incoming: RawSync["sections"],
+): RawSync["sections"] {
+  const result = { ...(current ?? {}) };
+  for (const [name, status] of Object.entries(incoming ?? {})) {
+    result[name] = mergeSyncStatus(result[name], status) ?? status;
+  }
+  return result;
+}
+
+function mergeItemMetadata(
+  current: RawSync["itemMetadata"],
+  incoming: RawSync["itemMetadata"],
+): RawSync["itemMetadata"] {
+  const result = { ...(current ?? {}) };
+  for (const [itemId, metadata] of Object.entries(incoming ?? {})) {
+    const previous = result[itemId];
+    result[itemId] = {
+      ...previous,
+      ...metadata,
+      scannerMatched:
+        previous?.scannerMatched ?? metadata.scannerMatched,
+      ownerAvailable:
+        previous?.ownerAvailable === true || metadata.ownerAvailable === true,
+      owner:
+        previous?.owner || metadata.owner
+          ? { ...previous?.owner, ...metadata.owner }
+          : undefined,
+      endorsement:
+        previous?.endorsement || metadata.endorsement
+          ? { ...previous?.endorsement, ...metadata.endorsement }
+          : undefined,
+      sensitivity:
+        previous?.sensitivity || metadata.sensitivity
+          ? { ...previous?.sensitivity, ...metadata.sensitivity }
+          : undefined,
+      tags: metadata.tags ?? previous?.tags,
+    };
+  }
+  return result;
+}
+
+export function mergeSyncEnrichment(
+  current: RawSync,
+  enrichment: RawSync,
+): RawSync {
+  const schema = { ...(current.schema ?? {}) };
+  for (const [itemId, tables] of Object.entries(enrichment.schema ?? {})) {
+    schema[itemId] = mergeSchemaTables(schema[itemId], tables);
+  }
+  const currentObjectEdges = Array.isArray(current.objectEdges)
+    ? current.objectEdges
+    : [];
+  const enrichmentObjectEdges = Array.isArray(enrichment.objectEdges)
+    ? enrichment.objectEdges
+    : [];
+  return {
+    ...current,
+    syncMode: "complete",
+    jobs: uniqueBy(
+      [...(current.jobs ?? []), ...(enrichment.jobs ?? [])],
+      (job) =>
+        [
+          job.itemId,
+          job.jobType,
+          job.startTimeUtc,
+          job.endTimeUtc,
+          job.status,
+        ].join("\u0000"),
+    ),
+    lineage: uniqueBy(
+      [...(current.lineage ?? []), ...(enrichment.lineage ?? [])],
+      (edge) => [edge.source, edge.target, edge.relation].join("\u0000"),
+    ),
+    config: uniqueBy(
+      [...(current.config ?? []), ...(enrichment.config ?? [])],
+      (entry) =>
+        [entry.itemId, entry.section, entry.label, entry.value].join("\u0000"),
+    ),
+    schema,
+    artifactMetadata: {
+      ...(current.artifactMetadata ?? {}),
+      ...(enrichment.artifactMetadata ?? {}),
+    },
+    itemMetadata: mergeItemMetadata(
+      current.itemMetadata,
+      enrichment.itemMetadata,
+    ),
+    objectEdges: [...currentObjectEdges, ...enrichmentObjectEdges],
+    sections: mergeSyncStatusMaps(current.sections, enrichment.sections),
+    capabilities: mergeSyncStatusMaps(
+      current.capabilities,
+      enrichment.capabilities,
+    ),
+    errors: uniqueBy(
+      [...(current.errors ?? []), ...(enrichment.errors ?? [])],
+      (error) => error,
+    ),
+    syncedAt: enrichment.syncedAt ?? current.syncedAt,
+  };
 }
 
 function itemEndorsement(value: unknown): Item["endorsement"] {
@@ -532,6 +764,21 @@ function validatedSyncSections(
   return result;
 }
 
+export function syncDeadlineExceeded(raw: RawSync): boolean {
+  return (
+    raw.errors?.some(
+      (error) =>
+        typeof error === "string" && error.includes("deadline-exhausted"),
+    ) === true ||
+    Object.values(raw.sections ?? {}).some(
+      (section) => section?.code === "deadline-exhausted",
+    ) ||
+    Object.values(raw.capabilities ?? {}).some(
+      (section) => section?.code === "deadline-exhausted",
+    )
+  );
+}
+
 const REQUIRED_ARRAYS = [
   "items",
   "roleAssignments",
@@ -638,6 +885,11 @@ export function validateRawSync(
   if (raw.errors.some((error) => typeof error !== "string")) {
     throw new Error(
       "The sync result contained invalid completion status. The previous snapshot was preserved.",
+    );
+  }
+  if (syncDeadlineExceeded(raw)) {
+    throw new Error(
+      "Fabric metadata discovery reached its safe execution budget before the workspace was complete. The previous snapshot was preserved.",
     );
   }
   if (raw.schemaVersion === 2) {
@@ -902,20 +1154,201 @@ export function validateRawSync(
   }
 }
 
+export function validateSyncEnrichment(
+  raw: RawSync,
+  expectedItemIds: string[],
+): void {
+  if (
+    raw.schemaVersion !== 2 ||
+    raw.syncMode !== "enrichment" ||
+    !Array.isArray(raw.requestedItemIds) ||
+    !Array.isArray(raw.completedItemIds) ||
+    !Array.isArray(raw.remainingItemIds) ||
+    !raw.requestedItemIds.every((value) => typeof value === "string") ||
+    !raw.completedItemIds.every((value) => typeof value === "string") ||
+    !raw.remainingItemIds.every((value) => typeof value === "string")
+  ) {
+    throw new Error(
+      "Fabric returned an invalid resumable sync response. The previous snapshot was preserved.",
+    );
+  }
+  const expected = new Set(expectedItemIds);
+  const requested = new Set(raw.requestedItemIds);
+  const completed = new Set(raw.completedItemIds);
+  const remaining = new Set(raw.remainingItemIds);
+  const returned = new Set([...completed, ...remaining]);
+  if (
+    requested.size !== expectedItemIds.length ||
+    completed.size !== raw.completedItemIds.length ||
+    remaining.size !== raw.remainingItemIds.length ||
+    [...expected].some((itemId) => !requested.has(itemId)) ||
+    [...requested].some((itemId) => !expected.has(itemId)) ||
+    [...completed].some((itemId) => remaining.has(itemId)) ||
+    returned.size !== expected.size ||
+    [...expected].some((itemId) => !returned.has(itemId)) ||
+    !Array.isArray(raw.jobs) ||
+    !Array.isArray(raw.lineage) ||
+    !Array.isArray(raw.config) ||
+    !isRecord(raw.schema) ||
+    !isRecord(raw.artifactMetadata) ||
+    !isRecord(raw.itemMetadata) ||
+    !Array.isArray(raw.objectEdges) ||
+    !Array.isArray(raw.errors) ||
+    raw.errors.some((error) => typeof error !== "string")
+  ) {
+    throw new Error(
+      "Fabric returned an invalid resumable sync response. The previous snapshot was preserved.",
+    );
+  }
+  if (syncDeadlineExceeded(raw)) {
+    throw new Error(
+      "Fabric returned an invalid resumable sync deadline state. The previous snapshot was preserved.",
+    );
+  }
+  if (!parseObjectLineagePayload(raw.objectEdges)) {
+    throw new Error(
+      "Fabric returned invalid resumable object lineage. The previous snapshot was preserved.",
+    );
+  }
+}
+
 export function isSyncConfigured(): boolean {
   return !!getUdfUrl();
 }
 
-// The portal gives one invoke URL per function; if the user pastes another
-// function's URL (e.g. ping), retarget the last function segment to sync_all.
-function retargetToSyncAll(url: string): string {
-  if (/sync_all/i.test(url)) return url;
-  return url.replace(/\/(ping|list_items|list_role_assignments|get_workspace)(\/|:|\?|$)/i, "/sync_all$2");
+export function isUdfTimeoutFailure(status: number, body: string): boolean {
+  return (
+    status === 408 ||
+    status === 504 ||
+    /UserDataFunctionTimeoutError|exceeded the timeout limit|function timed out/i.test(
+      body,
+    )
+  );
+}
+
+function retargetSyncFunction(url: string, functionName: string): string {
+  return url.replace(
+    /\/(ping|list_items|list_role_assignments|get_workspace|sync_all|sync_items)(\/|:|\?|$)/i,
+    `/${functionName}$2`,
+  );
+}
+
+type RetryableSyncSliceReason = "timeout" | "response-size";
+
+class RetryableSyncSliceError extends Error {
+  constructor(
+    readonly reason: RetryableSyncSliceReason,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const MAX_BASE_SLICE_ATTEMPTS = 4;
+const MAX_SINGLE_ITEM_SLICE_ATTEMPTS = 6;
+
+function syncItemTypeLabel(itemType: string): string {
+  return (
+    {
+      SQLDatabase: "SQL Database",
+      KQLDatabase: "KQL Database",
+      SemanticModel: "Semantic Model",
+      DataAgent: "Data Agent",
+      GraphModel: "Graph Model",
+      KQLQueryset: "KQL Queryset",
+      KQLDashboard: "KQL Dashboard",
+    }[itemType] ?? itemType
+  );
+}
+
+async function invokeSyncFunctionSlice(
+  baseUrl: string,
+  functionName: "sync_all" | "sync_items",
+  workspaceId: string,
+  tokens: SyncRequestTokens,
+  parameters: Partial<SyncRequestTokens>,
+): Promise<RawSync> {
+  const response = await fetch(retargetSyncFunction(baseUrl, functionName), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tokens.fabricToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(
+      buildSyncRequestBody(workspaceId, {
+        ...tokens,
+        ...parameters,
+      }),
+    ),
+  });
+  if (!response.ok) {
+    console.warn("[atlas] resumable UDF invocation failed", response.status);
+    const body = await readBoundedResponseText(response, 64 * 1024).catch(
+      () => "",
+    );
+    if (
+      isUdfTimeoutFailure(response.status, body)
+    ) {
+      throw new RetryableSyncSliceError(
+        "timeout",
+        "The Fabric metadata slice must be resumed.",
+      );
+    }
+    if (/ResponseSizeExceeded|response exceeded the safe size limit/i.test(body)) {
+      throw new RetryableSyncSliceError(
+        "response-size",
+        "The Fabric metadata slice exceeded the safe response size.",
+      );
+    }
+    throw new Error(
+      `Fabric synchronization failed (HTTP ${response.status}). The previous snapshot was preserved.`,
+    );
+  }
+  const contentLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(contentLength) &&
+    contentLength > MAX_SYNC_RESPONSE_BYTES
+  ) {
+    throw new RetryableSyncSliceError(
+      "response-size",
+      "The Fabric metadata slice exceeded the safe response size.",
+    );
+  }
+  try {
+    return parseSyncResponseText(await readBoundedResponseText(response));
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /exceeded the Atlas safety limit/i.test(error.message)
+    ) {
+      throw new RetryableSyncSliceError(
+        "response-size",
+        "The Fabric metadata slice exceeded the safe response size.",
+      );
+    }
+    throw error;
+  }
+}
+
+async function invokeSyncItemSlice(
+  baseUrl: string,
+  workspaceId: string,
+  tokens: SyncRequestTokens,
+  batch: SyncItemBatch,
+): Promise<RawSync> {
+  return invokeSyncFunctionSlice(
+    baseUrl,
+    "sync_items",
+    workspaceId,
+    tokens,
+    { itemIds: JSON.stringify(batch.itemIds) },
+  );
 }
 
 export async function invokeSyncAll(
   workspaceId: string,
   identity: SyncIdentity,
+  reportProgress?: (progress: number, stage: string) => void,
 ): Promise<RawSync> {
   const raw = getUdfUrl();
   if (!raw) {
@@ -923,43 +1356,236 @@ export async function invokeSyncAll(
       "Sync endpoint not configured yet — publish the atlas_sync_functions UDF and paste its invoke URL.",
     );
   }
-  const url = retargetToSyncAll(raw);
+  const url = retargetSyncFunction(raw, "sync_all");
+  reportProgress?.(5, "Authorizing Fabric metadata access");
   const fabricToken = await acquireFabricSyncToken(identity);
   const metadataTokens = await acquireOptionalMetadataTokens(identity);
-  const resp = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${fabricToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(
-      buildSyncRequestBody(workspaceId, {
-        fabricToken,
-        ...metadataTokens,
-      }),
-    ),
-  });
-  if (!resp.ok) {
-    console.warn("[atlas] UDF invocation failed", resp.status);
-    throw new Error(
-      `Fabric sync failed (HTTP ${resp.status}). The previous snapshot was preserved.`,
+  const tokens: SyncRequestTokens = {
+    fabricToken,
+    ...metadataTokens,
+  };
+  let baseAttempt = 0;
+  let result: RawSync;
+  while (true) {
+    reportProgress?.(
+      8,
+      baseAttempt === 0
+        ? "Discovering workspace topology"
+        : "Continuing workspace topology in a fresh Fabric function slice",
+    );
+    try {
+      result = await invokeSyncFunctionSlice(
+        url,
+        "sync_all",
+        workspaceId,
+        tokens,
+        { deferEnrichment: "true" },
+      );
+    } catch (error) {
+      if (!(error instanceof RetryableSyncSliceError)) throw error;
+      baseAttempt += 1;
+      if (
+        error.reason === "response-size" ||
+        baseAttempt >= MAX_BASE_SLICE_ATTEMPTS
+      ) {
+        throw new Error(
+          "Fabric could not return the authoritative workspace topology within a safe function slice. The previous snapshot was preserved.",
+        );
+      }
+      await new Promise((resolve) =>
+        window.setTimeout(
+          resolve,
+          Math.min(10_000, 1_000 * 2 ** Math.min(baseAttempt, 3)),
+        ),
+      );
+      continue;
+    }
+    if (!syncDeadlineExceeded(result)) break;
+    baseAttempt += 1;
+    if (baseAttempt >= MAX_BASE_SLICE_ATTEMPTS) {
+      throw new Error(
+        "Fabric could not complete the authoritative workspace topology after multiple function slices. The previous snapshot was preserved.",
+      );
+    }
+    await new Promise((resolve) =>
+      window.setTimeout(
+        resolve,
+        Math.min(10_000, 1_000 * 2 ** Math.min(baseAttempt, 3)),
+      ),
     );
   }
-  const contentLength = Number(resp.headers.get("content-length"));
-  if (
-    Number.isFinite(contentLength) &&
-    contentLength > MAX_SYNC_RESPONSE_BYTES
-  ) {
-    throw new Error(
-      "Fabric returned a sync payload that exceeded the Atlas safety limit. The previous snapshot was preserved.",
-    );
-  }
-  // Fabric UDF wraps the return under `output`; accept a raw body too.
-  const result = parseSyncResponseText(
-    await readBoundedResponseText(resp),
-  );
   validateRawSync(result, workspaceId);
-  return result;
+  if (result.syncMode !== "base") {
+    reportProgress?.(60, "Deep workspace discovery complete");
+    return result;
+  }
+  if (!Array.isArray(result.enrichmentItemIds)) {
+    throw new Error(
+      "Fabric did not return the resumable enrichment plan. The previous snapshot was preserved.",
+    );
+  }
+  reportProgress?.(20, "Workspace topology received");
+
+  const enrichmentItemIds = new Set(
+    (result.enrichmentItemIds ?? [])
+      .map((itemId) => realText(itemId))
+      .filter((itemId): itemId is string => !!itemId),
+  );
+  const batches = buildSyncItemBatches(
+    (result.items ?? []).filter((item) => {
+      const itemId = realText(item.id);
+      return itemId && enrichmentItemIds.has(itemId);
+    }),
+  );
+  const totalItems = enrichmentItemIds.size;
+  if (totalItems !== (result.items ?? []).length) {
+    throw new Error(
+      "Fabric returned an incomplete resumable enrichment plan. The previous snapshot was preserved.",
+    );
+  }
+  const completedItemIds = new Set<string>();
+  let merged = result;
+
+  while (batches.length > 0) {
+    const next = batches.shift()!;
+    const itemIds = next.itemIds.filter(
+      (itemId) => !completedItemIds.has(itemId),
+    );
+    if (itemIds.length === 0) continue;
+    const batch = { ...next, itemIds };
+    const label = syncItemTypeLabel(batch.itemType);
+    reportProgress?.(
+      20 + Math.floor((completedItemIds.size / Math.max(1, totalItems)) * 40),
+      `Discovering ${label} metadata (${completedItemIds.size}/${totalItems})`,
+    );
+
+    let enrichment: RawSync;
+    try {
+      enrichment = await invokeSyncItemSlice(
+        raw,
+        workspaceId,
+        tokens,
+        batch,
+      );
+    } catch (error) {
+      if (!(error instanceof RetryableSyncSliceError)) throw error;
+      if (itemIds.length > 1) {
+        const middle = Math.ceil(itemIds.length / 2);
+        batches.push(
+          {
+            ...batch,
+            itemIds: itemIds.slice(0, middle),
+            attempt: batch.attempt + 1,
+          },
+          {
+            ...batch,
+            itemIds: itemIds.slice(middle),
+            attempt: batch.attempt + 1,
+          },
+        );
+      } else {
+        if (
+          error.reason === "response-size" ||
+          batch.attempt + 1 >= MAX_SINGLE_ITEM_SLICE_ATTEMPTS
+        ) {
+          throw new Error(
+            `${label} metadata for one item could not complete within safe Fabric function slices. The previous snapshot was preserved.`,
+          );
+        }
+        reportProgress?.(
+          20 +
+            Math.floor(
+              (completedItemIds.size / Math.max(1, totalItems)) * 40,
+            ),
+          `Continuing ${label} item in a fresh Fabric function slice`,
+        );
+        await new Promise((resolve) =>
+          window.setTimeout(
+            resolve,
+            Math.min(10_000, 1_000 * 2 ** Math.min(batch.attempt, 3)),
+          ),
+        );
+        batches.push({ ...batch, attempt: batch.attempt + 1 });
+      }
+      continue;
+    }
+
+    validateSyncEnrichment(enrichment, itemIds);
+    merged = mergeSyncEnrichment(merged, enrichment);
+    for (const itemId of enrichment.completedItemIds ?? []) {
+      completedItemIds.add(itemId);
+    }
+    const remainingItemIds = (enrichment.remainingItemIds ?? []).filter(
+      (itemId) => !completedItemIds.has(itemId),
+    );
+    if (remainingItemIds.length > 0) {
+      if (
+        (enrichment.completedItemIds?.length ?? 0) === 0 &&
+        remainingItemIds.length > 1
+      ) {
+        const middle = Math.ceil(remainingItemIds.length / 2);
+        batches.push(
+          {
+            ...batch,
+            itemIds: remainingItemIds.slice(0, middle),
+            attempt: batch.attempt + 1,
+          },
+          {
+            ...batch,
+            itemIds: remainingItemIds.slice(middle),
+            attempt: batch.attempt + 1,
+          },
+        );
+      } else if ((enrichment.completedItemIds?.length ?? 0) === 0) {
+        if (batch.attempt + 1 >= MAX_SINGLE_ITEM_SLICE_ATTEMPTS) {
+          throw new Error(
+            `${label} metadata for one item made no progress across multiple Fabric function slices. The previous snapshot was preserved.`,
+          );
+        }
+        reportProgress?.(
+          20 +
+            Math.floor(
+              (completedItemIds.size / Math.max(1, totalItems)) * 40,
+            ),
+          `Continuing ${label} item in a fresh Fabric function slice`,
+        );
+        await new Promise((resolve) =>
+          window.setTimeout(
+            resolve,
+            Math.min(10_000, 1_000 * 2 ** Math.min(batch.attempt, 3)),
+          ),
+        );
+        batches.push({
+          ...batch,
+          itemIds: remainingItemIds,
+          attempt: batch.attempt + 1,
+        });
+      } else {
+        batches.push({
+          ...batch,
+          itemIds: remainingItemIds,
+          attempt: 0,
+        });
+      }
+    }
+  }
+
+  if (completedItemIds.size !== totalItems) {
+    throw new Error(
+      "Fabric did not complete every resumable metadata slice. The previous snapshot was preserved.",
+    );
+  }
+  merged = {
+    ...merged,
+    syncMode: "complete",
+    enrichmentItemIds: undefined,
+    requestedItemIds: undefined,
+    completedItemIds: undefined,
+    remainingItemIds: undefined,
+  };
+  reportProgress?.(60, "Deep workspace discovery complete");
+  validateRawSync(merged, workspaceId);
+  return merged;
 }
 
 /* ------------------------------ mapping -------------------------------- */
@@ -1364,8 +1990,6 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
         index === 0 ||
         JSON.stringify(edge) !== JSON.stringify(values[index - 1]),
     );
-  const objectEdges = allObjectEdges.slice(0, MAX_OBJECT_LINEAGE_EDGES);
-
   const ws = (raw.workspace ?? {}) as Record<string, unknown>;
   const workspace: WorkspaceInfo = {
     fabricId: String(ws.id ?? fallback.fabricId),
@@ -1381,14 +2005,6 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
           status,
         ]),
       ),
-      ...(allObjectEdges.length > objectEdges.length
-        ? {
-            metadataObjectLineage: {
-              status: "failed" as const,
-              code: "object-edge-limit",
-            },
-          }
-        : {}),
     },
   };
 
@@ -1402,7 +2018,7 @@ export function mapSyncToAtlas(raw: RawSync, fallback: WorkspaceInfo): AtlasData
     config,
     schema,
     itemMetadata,
-    objectEdges,
+    objectEdges: allObjectEdges,
     comments: [],
     syncRuns: [],
   };

--- a/src/atlas/release.ts
+++ b/src/atlas/release.ts
@@ -15,7 +15,7 @@ export const REPOSITORY_URL =
   "https://github.com/fredgis/FabricAtlas";
 
 export const APP_VERSION =
-  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.9.2";
+  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.11.1";
 
 export const BUILD_COMMIT =
   (import.meta.env.VITE_APP_BUILD_COMMIT as string | undefined) ?? "development";

--- a/src/atlas/store.spec.tsx
+++ b/src/atlas/store.spec.tsx
@@ -296,6 +296,50 @@ describe("AtlasProvider synchronization", () => {
     expect(screen.getByTestId("stage")).toHaveTextContent("Workspace is ready");
   });
 
+  it("warns before a refresh while resumable synchronization is active", async () => {
+    let finishSync: ((value: typeof SAMPLE_DATA) => void) | undefined;
+    backend.runFabricSync.mockImplementation(
+      async (
+        _isPreview: boolean,
+        _user: unknown,
+        report: (progress: number, stage: string) => void,
+      ) => {
+        report(20, "Workspace topology received");
+        return new Promise<typeof SAMPLE_DATA>((resolve) => {
+          finishSync = resolve;
+        });
+      },
+    );
+
+    render(
+      <AtlasProvider isPreview={false} currentUser={currentUser}>
+        <Harness />
+      </AtlasProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("hydrating")).toHaveTextContent("false"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Sync" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("syncing")).toHaveTextContent("true"),
+    );
+
+    const duringSync = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(duringSync);
+    expect(duringSync.defaultPrevented).toBe(true);
+
+    await act(async () => {
+      finishSync?.(structuredClone(SAMPLE_DATA));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("syncing")).toHaveTextContent("false"),
+    );
+
+    const afterSync = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(afterSync);
+    expect(afterSync.defaultPrevented).toBe(false);
+  });
+
   it("uses the unique synchronized principal display name for comments", async () => {
     const principal = SAMPLE_DATA.principals.find(
       (candidate) => candidate.kind === "user" && candidate.email,

--- a/src/atlas/store.tsx
+++ b/src/atlas/store.tsx
@@ -86,6 +86,7 @@ export interface AtlasContextValue {
   syncing: boolean;
   syncProgress: number;
   syncStage: string;
+  syncStartedAt?: number;
   lastSyncedAt?: string;
   isPreview: boolean;
   configured: boolean;
@@ -248,6 +249,7 @@ export function AtlasProvider({
   const [syncing, setSyncing] = useState(false);
   const [syncProgress, setSyncProgress] = useState(0);
   const [syncStage, setSyncStage] = useState("Ready to sync");
+  const [syncStartedAt, setSyncStartedAt] = useState<number | undefined>();
   const [lastSyncedAt, setLastSyncedAt] = useState<string | undefined>(
     isPreview ? SAMPLE_DATA.syncRuns[0]?.finishedAt : undefined,
   );
@@ -310,6 +312,16 @@ export function AtlasProvider({
     },
     [],
   );
+
+  useEffect(() => {
+    if (!syncing) return;
+    const preventRefresh = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", preventRefresh);
+    return () => window.removeEventListener("beforeunload", preventRefresh);
+  }, [syncing]);
 
   useEffect(() => {
     if (isPreview) return;
@@ -544,19 +556,13 @@ export function AtlasProvider({
     setSyncing(true);
     setSyncProgress(3);
     setSyncStage("Starting workspace sync");
+    const syncStartedAtMs = Date.now();
+    setSyncStartedAt(syncStartedAtMs);
     setSyncError(undefined);
     setHistoryLoading(false);
-    const startedAt = new Date().toISOString();
+    const startedAt = new Date(syncStartedAtMs).toISOString();
     let succeeded = false;
     let reportedProgress = 3;
-    const heartbeat = window.setInterval(() => {
-      if (operationGeneration.current !== generation) return;
-      if (reportedProgress < 42) {
-        reportedProgress += 1;
-        setSyncProgress(reportedProgress);
-        if (reportedProgress >= 12) setSyncStage("Scanning workspace metadata");
-      }
-    }, 900);
     try {
       const fresh = await runFabricSync(
         isPreview,
@@ -635,8 +641,8 @@ export function AtlasProvider({
       setSyncError(err instanceof Error ? err.message : String(err));
       setSyncProgress(0);
       setSyncStage("Sync failed");
+      setSyncStartedAt(undefined);
     } finally {
-      window.clearInterval(heartbeat);
       if (operationGeneration.current === generation) {
         setSyncing(false);
       }
@@ -644,6 +650,7 @@ export function AtlasProvider({
         progressResetTimer.current = window.setTimeout(() => {
           setSyncProgress(0);
           setSyncStage("Ready to sync");
+          setSyncStartedAt(undefined);
         }, 1200);
       }
     }
@@ -1086,6 +1093,7 @@ export function AtlasProvider({
       syncing,
       syncProgress,
       syncStage,
+      syncStartedAt,
       lastSyncedAt,
       isPreview,
       configured,
@@ -1108,7 +1116,7 @@ export function AtlasProvider({
       removeGovernanceException: removeSharedGovernanceException,
       loadHistorySnapshot,
     }),
-    [data, history, hydrating, historyLoading, historyError, historyFailedSnapshotIds, savedViews, savedViewsLoading, savedViewsError, findingAcks, findingAcksLoading, findingAcksError, findingAckPendingIds, governancePolicy.targets, governancePolicyLoading, governancePolicyError, governanceExceptions, governanceExceptionsLoading, governanceExceptionsError, governanceExceptionPendingIds, syncing, syncProgress, syncStage, lastSyncedAt, isPreview, configured, canSync, hasData, requiresDeploymentSync, syncError, currentUser, sync, addComment, addSavedView, removeSavedView, saveFindingAcknowledgement, removeFindingAcknowledgement, reloadGovernancePolicy, saveGovernanceTargets, resetGovernanceTargets, reloadGovernanceExceptions, saveSharedGovernanceException, removeSharedGovernanceException, loadHistorySnapshot],
+    [data, history, hydrating, historyLoading, historyError, historyFailedSnapshotIds, savedViews, savedViewsLoading, savedViewsError, findingAcks, findingAcksLoading, findingAcksError, findingAckPendingIds, governancePolicy.targets, governancePolicyLoading, governancePolicyError, governanceExceptions, governanceExceptionsLoading, governanceExceptionsError, governanceExceptionPendingIds, syncing, syncProgress, syncStage, syncStartedAt, lastSyncedAt, isPreview, configured, canSync, hasData, requiresDeploymentSync, syncError, currentUser, sync, addComment, addSavedView, removeSavedView, saveFindingAcknowledgement, removeFindingAcknowledgement, reloadGovernancePolicy, saveGovernanceTargets, resetGovernanceTargets, reloadGovernanceExceptions, saveSharedGovernanceException, removeSharedGovernanceException, loadHistorySnapshot],
   );
 
   return <AtlasContext.Provider value={value}>{children}</AtlasContext.Provider>;

--- a/src/atlas/synchronization-progress.ts
+++ b/src/atlas/synchronization-progress.ts
@@ -1,0 +1,24 @@
+export const SYNC_PHASES = [
+  { label: "Connect", threshold: 0 },
+  { label: "Discover", threshold: 8 },
+  { label: "Map", threshold: 62 },
+  { label: "Persist", threshold: 70 },
+  { label: "Finalize", threshold: 97 },
+] as const;
+
+export function syncPhaseIndex(progress: number): number {
+  const normalized = Math.min(100, Math.max(0, progress));
+  let phaseIndex = 0;
+  for (let index = 1; index < SYNC_PHASES.length; index += 1) {
+    if (normalized < SYNC_PHASES[index].threshold) break;
+    phaseIndex = index;
+  }
+  return phaseIndex;
+}
+
+export function formatSyncElapsed(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(remainder).padStart(2, "0")}`;
+}

--- a/src/atlas/views/FirstSync.spec.tsx
+++ b/src/atlas/views/FirstSync.spec.tsx
@@ -5,7 +5,7 @@ import { AtlasProvider } from "../store";
 import { FirstSyncView } from "./FirstSync";
 
 describe("FirstSyncView", () => {
-  it("shows an accessible donut driven by synchronization progress", () => {
+  it("shows the shared accessible synchronization progress display", () => {
     render(
       <ThemeContext.Provider
         value={{ isDark: false, toggleTheme: () => undefined }}
@@ -18,18 +18,16 @@ describe("FirstSyncView", () => {
 
     expect(
       screen.getByRole("progressbar", {
-        name: "Workspace synchronization donut",
+        name: "Workspace synchronization progress",
       }),
     ).toHaveAttribute("aria-valuenow", "0");
     expect(
+      screen.getByRole("region", {
+        name: "Workspace synchronization status",
+      }),
+    ).toHaveTextContent("Phase 1 of 5");
+    expect(
       screen.queryByLabelText(/Animated preview of Fabric lineage/),
     ).not.toBeInTheDocument();
-    expect(
-      screen
-        .getByRole("progressbar", {
-          name: "Workspace synchronization donut",
-        })
-        .querySelector("svg"),
-    ).toHaveClass("h-full", "w-full");
   });
 });

--- a/src/atlas/views/FirstSync.tsx
+++ b/src/atlas/views/FirstSync.tsx
@@ -15,10 +15,10 @@ import {
 } from "lucide-react";
 import { useThemeContext } from "@/hooks/theme.context";
 import { ATLAS_CONFIG } from "../config";
+import { SynchronizationProgress } from "../components/SynchronizationProgress";
 import { REPOSITORY_URL } from "../release";
 import { useAtlas } from "../store";
 import { syncContactMessage } from "../sync-contact";
-import { cn } from "../ui";
 
 const CAPABILITIES = [
   {
@@ -41,14 +41,6 @@ const CAPABILITIES = [
     title: "Configuration",
     detail: "Schemas, settings and jobs",
   },
-];
-
-const SYNC_STEPS = [
-  "Connect",
-  "Discover",
-  "Map",
-  "Secure",
-  "Persist",
 ];
 
 function safeText(value: string | undefined, fallback: string): string {
@@ -86,6 +78,7 @@ export function FirstSyncView() {
     syncError,
     syncProgress,
     syncStage,
+    syncStartedAt,
     hasData,
     requiresDeploymentSync,
   } = useAtlas();
@@ -94,12 +87,6 @@ export function FirstSyncView() {
     data.workspace.displayName,
     ATLAS_CONFIG.workspaceName,
   );
-  const donutProgress = syncing ? syncProgress : 0;
-  const donutRadius = 76;
-  const donutCircumference = 2 * Math.PI * donutRadius;
-  const donutOffset =
-    donutCircumference * (1 - Math.min(100, donutProgress) / 100);
-
   return (
     <div className="relative min-h-screen overflow-auto bg-background text-foreground">
       <div className="atlas-first-sync-bg pointer-events-none fixed inset-0" />
@@ -239,107 +226,18 @@ export function FirstSyncView() {
               }}
               className="flex flex-col gap-l bg-secondary/65 p-xl sm:p-xxl"
             >
-              <div className="relative overflow-hidden rounded-xl border border-border bg-secondary p-l">
-                <div className="flex items-center justify-between gap-m">
-                  <div>
-                    <div className="text-100 font-bold uppercase tracking-[0.16em] text-lineage-downstream">
-                      Synchronization progress
-                    </div>
-                    <div className="mt-xs text-300 font-semibold">
-                      {syncing
-                        ? syncStage
-                        : deploymentRefresh
-                          ? "Ready to refresh the map"
-                          : "Ready to build the first atlas"}
-                    </div>
-                  </div>
-                  <span className="flex items-center gap-xs text-200 text-muted-foreground">
-                    <span
-                      className={cn(
-                        "h-xs w-xs rounded-full",
-                        syncing
-                          ? "animate-pulse bg-lineage-downstream"
-                          : "bg-lineage-neutral",
-                      )}
-                    />
-                    {syncing ? "live" : "waiting"}
-                  </span>
-                </div>
-
-                <div className="mt-l flex flex-col items-center">
-                  <div
-                    role="progressbar"
-                    aria-label="Workspace synchronization donut"
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-valuenow={donutProgress}
-                    className="relative h-56 w-56"
-                  >
-                    <svg
-                      viewBox="0 0 200 200"
-                      className="h-full w-full -rotate-90"
-                      aria-hidden="true"
-                    >
-                      <circle
-                        cx="100"
-                        cy="100"
-                        r={donutRadius}
-                        fill="none"
-                        stroke="var(--color-muted)"
-                        strokeWidth="18"
-                      />
-                      <circle
-                        cx="100"
-                        cy="100"
-                        r={donutRadius}
-                        fill="none"
-                        stroke="var(--color-primary)"
-                        strokeWidth="18"
-                        strokeLinecap="round"
-                        strokeDasharray={donutCircumference}
-                        strokeDashoffset={donutOffset}
-                        style={{
-                          transition: reduceMotion
-                            ? "none"
-                            : "stroke-dashoffset 500ms ease",
-                        }}
-                      />
-                    </svg>
-                    <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-                      <span className="font-numeric text-hero-700 font-bold text-foreground">
-                        {donutProgress}%
-                      </span>
-                      <span className="mt-xs max-w-32 text-200 text-muted-foreground">
-                        {syncing ? syncStage : "Ready"}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="mt-l grid w-full grid-cols-5 gap-xs">
-                    {SYNC_STEPS.map((step, index) => {
-                      const threshold = index * 20;
-                      const active = donutProgress >= threshold;
-                      return (
-                        <div key={step} className="text-center">
-                          <span
-                            className={cn(
-                              "mx-auto flex h-7 w-7 items-center justify-center rounded-full border font-numeric text-100 font-semibold",
-                              active
-                                ? "border-primary bg-primary/10 text-brand-foreground"
-                                : "border-border bg-card text-muted-foreground",
-                            )}
-                          >
-                            {index + 1}
-                          </span>
-                          <span className="mt-xs block truncate text-100 text-muted-foreground">
-                            {step}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
+              <SynchronizationProgress
+                key={syncStartedAt ?? "ready"}
+                progress={syncing ? syncProgress : 0}
+                stage={
+                  syncing
+                    ? syncStage
+                    : deploymentRefresh
+                      ? "Ready to refresh the map"
+                      : "Ready to build the first atlas"
+                }
+                active={syncing}
+              />
 
               <div className="mt-auto rounded-xl border border-border bg-card p-l shadow-fabric-4">
                 <div className="flex items-start justify-between gap-m">
@@ -354,39 +252,6 @@ export function FirstSyncView() {
                   <div className="font-numeric text-500 font-bold text-primary">
                     {syncing ? `${syncProgress}%` : "01"}
                   </div>
-                </div>
-
-                <div
-                  role="status"
-                  aria-live="polite"
-                  aria-atomic="true"
-                  className="mt-l flex items-center justify-between gap-m text-200"
-                >
-                  <span className="font-semibold">
-                    {syncing
-                      ? syncStage
-                      : deploymentRefresh
-                        ? "Ready to refresh this deployment"
-                        : "Ready to create the catalog"}
-                  </span>
-                  <span className="text-muted-foreground">
-                    {syncing ? "in progress" : "one full pass"}
-                  </span>
-                </div>
-                <div
-                  role="progressbar"
-                  aria-label="Workspace synchronization progress"
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={syncing ? syncProgress : 0}
-                  className="mt-s h-s overflow-hidden rounded-full bg-muted"
-                >
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-primary via-lineage-downstream to-status-healthy transition-[width] duration-500"
-                    style={{
-                      width: `${syncing ? Math.max(syncProgress, 3) : 0}%`,
-                    }}
-                  />
                 </div>
 
                 <button
@@ -460,23 +325,6 @@ export function FirstSyncView() {
             </motion.section>
           </div>
 
-          <footer className="border-t border-border bg-secondary px-xl py-m sm:px-xxl">
-            <div className="grid grid-cols-5 gap-s">
-              {SYNC_STEPS.map((step, index) => (
-                <div key={step} className="flex items-center gap-s">
-                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10 font-numeric text-100 font-bold text-primary">
-                    {index + 1}
-                  </span>
-                  <span className="hidden text-200 font-semibold text-muted-foreground sm:inline">
-                    {step}
-                  </span>
-                  {index < SYNC_STEPS.length - 1 && (
-                    <span className="h-px flex-1 bg-border" />
-                  )}
-                </div>
-              ))}
-            </div>
-          </footer>
         </motion.div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- remove object-lineage count truncation and the 10,000-value false rejection
- split deep discovery into resumable UDF slices grouped by Fabric item type
- keep a 180-second execution budget under Fabric's 200-second timeout
- show real phase, item-count and elapsed progress on initial and later syncs
- preserve atomic manifest-last snapshot publication

## Validation
- 316 app tests
- 77 UDF tests
- lint without errors
- production build
- live FGI-MAIN scan: 78 items, 22 slices, slowest 24.3 seconds, zero errors