### PR TITLE
fix: preserve local object graphs with ontology links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.4] - 2026-09-05
+
+### Changed
+
+- Impact mode now renders non-impacted items and links at very low opacity while preserving the complete graph and its positions.
+- Object item grouping is shown in a dedicated, persistent bar with per-item counts and prominent global expand/collapse controls.
+- Reduced item and object lineage arrowhead size without removing directional clarity.
+
+### Fixed
+
+- Lakehouse, Warehouse, SQL Database and Semantic Model object views now prioritize their local schema graph when they also participate in Ontology lineage.
+- Ontology, Graph Model, Data Agent and KQL Database items continue to use their verified metadata-native object graph.
+
 ## [1.11.3] - 2026-09-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.11.3",
+      "version": "1.11.4",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.11.3",
+  "version": "1.11.4",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/rayfin/rayfin.yml
+++ b/rayfin/rayfin.yml
@@ -1,6 +1,6 @@
 id: fabricatlas
 name: FabricAtlas
-version: 1.11.3
+version: 1.11.4
 services:
   auth:
     enabled: true

--- a/src/atlas/metadata-object-graph.ts
+++ b/src/atlas/metadata-object-graph.ts
@@ -60,6 +60,25 @@ export interface ObjectItemGroup {
   objectCount: number;
 }
 
+const METADATA_NATIVE_ITEM_TYPES = new Set([
+  "Ontology",
+  "GraphModel",
+  "DataAgent",
+  "KQLDatabase",
+]);
+
+export function shouldUseVerifiedMetadataGraph(
+  item: Item | undefined,
+  schemaCount: number,
+  edgeCount: number,
+): boolean {
+  return (
+    edgeCount > 0 &&
+    (!!item &&
+      (schemaCount === 0 || METADATA_NATIVE_ITEM_TYPES.has(item.itemType)))
+  );
+}
+
 function objectNodeItemId(node: ObjectGraphNode, activeItemId: string): string {
   return node.itemId ?? activeItemId;
 }

--- a/src/atlas/release.ts
+++ b/src/atlas/release.ts
@@ -15,7 +15,7 @@ export const REPOSITORY_URL =
   "https://github.com/fredgis/FabricAtlas";
 
 export const APP_VERSION =
-  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.11.3";
+  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.11.4";
 
 export const BUILD_COMMIT =
   (import.meta.env.VITE_APP_BUILD_COMMIT as string | undefined) ?? "development";

--- a/src/atlas/views/Map.spec.tsx
+++ b/src/atlas/views/Map.spec.tsx
@@ -14,6 +14,7 @@ import {
   groupObjectGraphByItem,
   MAX_VISIBLE_OBJECT_EDGES,
   objectItemGroups,
+  shouldUseVerifiedMetadataGraph,
 } from "../metadata-object-graph";
 import { SAMPLE_DATA, typeMeta } from "../model";
 import { AtlasProvider } from "../store";
@@ -199,6 +200,23 @@ describe("MapView selection", () => {
         grouped.nodes.some((node) => node.label === "Installed at"),
       ).toBe(true);
     });
+
+    it("keeps local schema graphs for relational items connected to ontologies", () => {
+      expect(
+        shouldUseVerifiedMetadataGraph(
+          items.get("warehouse"),
+          3,
+          edges.length,
+        ),
+      ).toBe(false);
+      expect(
+        shouldUseVerifiedMetadataGraph(
+          items.get("ontology"),
+          3,
+          edges.length,
+        ),
+      ).toBe(true);
+    });
   });
 
   const selectInspectorTab = async (
@@ -339,6 +357,12 @@ describe("MapView selection", () => {
         before.get(item.fabricId),
       );
     }
+    expect(
+      screen.getByLabelText("alpinerent_dw, Warehouse, healthy"),
+    ).toHaveClass("opacity-[0.14]");
+    expect(
+      document.querySelector('marker[id="atlas-up"]'),
+    ).toHaveAttribute("markerWidth", "7");
   });
 
   it("pans the complete graph by dragging its background", () => {
@@ -563,9 +587,11 @@ describe("MapView selection", () => {
     fireEvent.click(screen.getByRole("button", { name: "objects" }));
     await selectInspectorTab("Summary", "Schema");
     const tableToggles = () =>
-      screen
-        .getAllByRole("button")
-        .filter((button) => button.hasAttribute("aria-expanded"));
+      [
+        ...screen
+          .getByLabelText("Item details inspector")
+          .querySelectorAll<HTMLButtonElement>("button[aria-expanded]"),
+      ];
 
     expect(tableToggles().length).toBeGreaterThan(1);
     expect(
@@ -605,14 +631,14 @@ describe("MapView selection", () => {
     ).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Expand item groups" }),
+      screen.getByRole("button", { name: "Expand all item groups" }),
     );
     expect(
       screen.getByLabelText("AlpineRent Executive Dashboard, Report"),
     ).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Collapse item groups" }),
+      screen.getByRole("button", { name: "Collapse all item groups" }),
     );
     expect(
       screen.getByLabelText(

--- a/src/atlas/views/Map.tsx
+++ b/src/atlas/views/Map.tsx
@@ -36,6 +36,7 @@ import {
   groupObjectGraphByItem,
   MAX_VISIBLE_OBJECT_EDGES,
   objectItemGroups,
+  shouldUseVerifiedMetadataGraph,
   type ObjectGraph,
   type ObjectGraphEdge as ObjectEdge,
   type ObjectGraphNode as ObjectNode,
@@ -663,7 +664,11 @@ export function MapView() {
     : "all";
   const ungroupedObjects = useMemo(
     () =>
-      selectedMetadataEdges.length > 0
+      shouldUseVerifiedMetadataGraph(
+        selected,
+        schema.length,
+        selectedMetadataEdges.length,
+      )
         ? buildMetadataObjectGraph(
             selectedMetadataEdges,
             activeId,
@@ -1408,30 +1413,6 @@ export function MapView() {
             Focus selection
           </button>
         )}
-        {mode === "objects" && objectGroups.length > 1 && (
-          <>
-            <button
-              type="button"
-              onClick={() =>
-                setExpandedObjectItemIds(
-                  new Set(objectGroups.map((group) => group.itemId)),
-                )
-              }
-              className="flex items-center gap-s rounded-lg border border-border px-m font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <ChevronDown size={13} />
-              Expand item groups
-            </button>
-            <button
-              type="button"
-              onClick={() => setExpandedObjectItemIds(new Set())}
-              className="flex items-center gap-s rounded-lg border border-border px-m font-semibold text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <ChevronRight size={13} />
-              Collapse item groups
-            </button>
-          </>
-        )}
         {(mode === "items"
           ? selectedItemIds.size
           : selectedObjectIds.size) > 1 && (
@@ -1451,6 +1432,87 @@ export function MapView() {
           Reset
         </button>
       </div>
+
+      {mode === "objects" && objectGroups.length > 0 && (
+        <section
+          aria-label="Object item groups"
+          className="flex flex-wrap items-center gap-m border-b border-border bg-secondary/70 px-l py-s"
+        >
+          <div className="shrink-0">
+            <div className="text-200 font-semibold text-foreground">
+              Object item groups
+            </div>
+            <div className="text-200 text-muted-foreground">
+              {objectGroups.length} connected Fabric items
+            </div>
+          </div>
+          <div className="flex min-w-0 flex-1 gap-s overflow-x-auto py-xxs">
+            {objectGroups.map((group) => {
+              const item = itemById.get(group.itemId);
+              const expanded = expandedObjectItemIds.has(group.itemId);
+              const active = group.itemId === activeId;
+              return (
+                <button
+                  key={group.itemId}
+                  type="button"
+                  aria-expanded={expanded}
+                  onClick={() => {
+                    if (!active) {
+                      switchActiveItem(group.itemId);
+                      return;
+                    }
+                    setExpandedObjectItemIds((previous) => {
+                      const next = new Set(previous);
+                      if (next.has(group.itemId)) next.delete(group.itemId);
+                      else next.add(group.itemId);
+                      return next;
+                    });
+                  }}
+                  className={cn(
+                    "flex shrink-0 items-center gap-s rounded-lg border bg-card px-m py-s text-left shadow-fabric-2 hover:bg-accent",
+                    active
+                      ? "border-primary/60 text-foreground"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {expanded ? (
+                    <ChevronDown size={14} aria-hidden="true" />
+                  ) : (
+                    <ChevronRight size={14} aria-hidden="true" />
+                  )}
+                  {item && <TypeGlyph type={item.itemType} size={23} />}
+                  <span className="max-w-[190px] truncate text-200 font-semibold">
+                    {group.label}
+                  </span>
+                  <span className="rounded-md bg-muted px-s py-xxs font-numeric text-200">
+                    {group.objectCount}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex shrink-0 items-center gap-s">
+            <button
+              type="button"
+              onClick={() =>
+                setExpandedObjectItemIds(
+                  new Set(objectGroups.map((group) => group.itemId)),
+                )
+              }
+              className="rounded-lg border border-primary/35 bg-primary/10 px-m py-s text-200 font-semibold text-primary hover:bg-primary/15"
+            >
+              Expand all item groups
+            </button>
+            <button
+              type="button"
+              onClick={() => setExpandedObjectItemIds(new Set())}
+              className="rounded-lg border border-border bg-card px-m py-s text-200 font-semibold text-foreground hover:bg-accent"
+            >
+              Collapse all item groups
+            </button>
+          </div>
+        </section>
+      )}
 
       <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
         <div
@@ -1529,13 +1591,13 @@ export function MapView() {
                         <marker
                           key={id}
                           id={`atlas-${id}`}
-                          markerWidth="8"
-                          markerHeight="8"
-                          refX="7"
-                          refY="4"
+                          markerWidth="7"
+                          markerHeight="7"
+                          refX="6.2"
+                          refY="3.5"
                           orient="auto"
                         >
-                          <path d="M0 0 8 4 0 8Z" fill={fill} />
+                          <path d="M0 0 7 3.5 0 7Z" fill={fill} />
                         </marker>
                       ))}
                     </defs>
@@ -1563,7 +1625,15 @@ export function MapView() {
                             stroke={color}
                             strokeWidth={active ? 2.6 : 1.5}
                             strokeOpacity={
-                              edge.broken ? 0.9 : active ? 0.96 : activeId ? 0.3 : 0.55
+                              active
+                                ? 0.96
+                                : impactMode
+                                  ? 0.08
+                                  : edge.broken
+                                    ? 0.9
+                                    : activeId
+                                      ? 0.3
+                                      : 0.55
                             }
                             strokeDasharray={
                               edge.broken
@@ -1632,7 +1702,10 @@ export function MapView() {
                       selectedItemIds.has(item.fabricId) || primaryNode;
                     const isUp = impact.upstream.ids.has(item.fabricId);
                     const isDown = impact.downstream.ids.has(item.fabricId);
-                    const dim = !!activeId && !connected.has(item.fabricId);
+                    const dim =
+                      impactMode &&
+                      !!activeId &&
+                      !connected.has(item.fabricId);
                     const activeDrag = dragId === item.fabricId;
                     const accent = primaryNode
                       ? "var(--color-primary)"
@@ -1655,7 +1728,8 @@ export function MapView() {
                         className={cn(
                           "absolute flex touch-none select-none items-center gap-[10px] rounded-lg border bg-card px-[12px] text-left shadow-fabric-2 transition-[box-shadow,opacity,border-color,transform] hover:-translate-y-[1px] hover:shadow-fabric-8",
                           selectedNode ? "border-primary/70" : "border-border",
-                          dim && "border-border/70 bg-card/85 shadow-none",
+                          dim &&
+                            "border-border/50 bg-card/60 opacity-[0.14] shadow-none",
                           "cursor-grab active:cursor-grabbing",
                         )}
                         style={{
@@ -1721,33 +1795,33 @@ export function MapView() {
                     <defs>
                       <marker
                         id="atlas-object-downstream"
-                        markerWidth="8"
-                        markerHeight="8"
-                        refX="7"
-                        refY="4"
+                        markerWidth="7"
+                        markerHeight="7"
+                        refX="6.2"
+                        refY="3.5"
                         orient="auto"
                       >
-                        <path d="M0 0 8 4 0 8Z" fill={DOWN} />
+                        <path d="M0 0 7 3.5 0 7Z" fill={DOWN} />
                       </marker>
                       <marker
                         id="atlas-object-upstream"
-                        markerWidth="8"
-                        markerHeight="8"
-                        refX="7"
-                        refY="4"
+                        markerWidth="7"
+                        markerHeight="7"
+                        refX="6.2"
+                        refY="3.5"
                         orient="auto"
                       >
-                        <path d="M0 0 8 4 0 8Z" fill={UP} />
+                        <path d="M0 0 7 3.5 0 7Z" fill={UP} />
                       </marker>
                       <marker
                         id="atlas-object-neutral"
-                        markerWidth="8"
-                        markerHeight="8"
-                        refX="7"
-                        refY="4"
+                        markerWidth="7"
+                        markerHeight="7"
+                        refX="6.2"
+                        refY="3.5"
                         orient="auto"
                       >
-                        <path d="M0 0 8 4 0 8Z" fill="var(--color-lineage-neutral)" />
+                        <path d="M0 0 7 3.5 0 7Z" fill="var(--color-lineage-neutral)" />
                       </marker>
                     </defs>
                     {objects.edges.map((edge) => {


### PR DESCRIPTION
## Summary
- keep Lakehouse, Warehouse, SQL Database and Semantic Model local schema graphs when linked to Ontology
- keep metadata-native graphs for Ontology, Graph Model, Data Agent and KQL Database
- add a prominent object item-group bar with per-item expand/collapse
- dim non-impact nodes and links to near transparency without moving the graph
- reduce lineage arrowhead size

## Validation
- 323 app tests
- lint without errors
- production build
- deployed as deploy-20260905193832-5dbe9592