### PR TITLE
fix: keep impact mode viewport stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.5] - 2026-09-05
+
+### Fixed
+
+- Impact mode no longer changes the layout focus, reorders disconnected graph components or moves a selected middle item toward the top.
+- The lineage viewport and every node coordinate remain unchanged when Impact mode is toggled; only path highlighting and non-impact opacity change.
+
 ## [1.11.4] - 2026-09-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.11.4",
+  "version": "1.11.5",
   "type": "module",
   "scripts": {
     "predev": "rayfin env --framework vite",

--- a/rayfin/rayfin.yml
+++ b/rayfin/rayfin.yml
@@ -1,6 +1,6 @@
 id: fabricatlas
 name: FabricAtlas
-version: 1.11.4
+version: 1.11.5
 services:
   auth:
     enabled: true

--- a/src/atlas/release.ts
+++ b/src/atlas/release.ts
@@ -15,7 +15,7 @@ export const REPOSITORY_URL =
   "https://github.com/fredgis/FabricAtlas";
 
 export const APP_VERSION =
-  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.11.4";
+  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.11.5";
 
 export const BUILD_COMMIT =
   (import.meta.env.VITE_APP_BUILD_COMMIT as string | undefined) ?? "development";

--- a/src/atlas/views/Map.spec.tsx
+++ b/src/atlas/views/Map.spec.tsx
@@ -329,11 +329,17 @@ describe("MapView selection", () => {
 
   it("keeps the complete graph and node positions when impact mode changes", () => {
     window.history.replaceState(null, "", "/#map");
-    render(
+    const { container } = render(
       <AtlasProvider isPreview>
         <MapView />
       </AtlasProvider>,
     );
+    fireEvent.click(
+      screen.getByLabelText("alpinerent_lakehouse, Lakehouse, healthy"),
+    );
+    const viewport = container.querySelector<HTMLDivElement>(".atlas-map-grid")!;
+    viewport.scrollLeft = 360;
+    viewport.scrollTop = 420;
 
     const before = new Map(
       SAMPLE_DATA.items.map((item) => {
@@ -349,6 +355,8 @@ describe("MapView selection", () => {
 
     fireEvent.click(screen.getByRole("switch", { name: "Impact mode" }));
 
+    expect(viewport.scrollLeft).toBe(360);
+    expect(viewport.scrollTop).toBe(420);
     for (const item of SAMPLE_DATA.items) {
       const node = screen.getByLabelText(
         `${item.displayName}, ${typeMeta(item.itemType).label}, ${item.health}`,
@@ -363,6 +371,79 @@ describe("MapView selection", () => {
     expect(
       document.querySelector('marker[id="atlas-up"]'),
     ).toHaveAttribute("markerWidth", "7");
+  });
+
+  it("does not reorder disconnected components when impact mode is enabled", () => {
+    const model = SAMPLE_DATA.items.find(
+      (item) => item.itemType === "SemanticModel",
+    )!;
+    const report = SAMPLE_DATA.items.find((item) => item.itemType === "Report")!;
+    const lakehouse = SAMPLE_DATA.items.find(
+      (item) => item.itemType === "Lakehouse",
+    )!;
+    const warehouse = SAMPLE_DATA.items.find(
+      (item) => item.itemType === "Warehouse",
+    )!;
+    const originalEdges = SAMPLE_DATA.edges;
+    SAMPLE_DATA.edges = [
+      { source: model.fabricId, target: report.fabricId, relation: "report" },
+      {
+        source: lakehouse.fabricId,
+        target: warehouse.fabricId,
+        relation: "loads",
+      },
+    ];
+    window.history.replaceState(null, "", "/#map");
+    const { container } = render(
+      <AtlasProvider isPreview>
+        <MapView />
+      </AtlasProvider>,
+    );
+    SAMPLE_DATA.edges = originalEdges;
+
+    fireEvent.click(
+      screen.getByLabelText("alpinerent_lakehouse, Lakehouse, healthy"),
+    );
+    const viewport = container.querySelector<HTMLDivElement>(".atlas-map-grid")!;
+    viewport.scrollTop = 500;
+    const before = {
+      lakehouse: {
+        left: screen.getByLabelText(
+          "alpinerent_lakehouse, Lakehouse, healthy",
+        ).style.left,
+        top: screen.getByLabelText(
+          "alpinerent_lakehouse, Lakehouse, healthy",
+        ).style.top,
+      },
+      model: {
+        left: screen.getByLabelText(
+          "AlpineRent Sales Model, Semantic model, healthy",
+        ).style.left,
+        top: screen.getByLabelText(
+          "AlpineRent Sales Model, Semantic model, healthy",
+        ).style.top,
+      },
+    };
+
+    fireEvent.click(screen.getByRole("switch", { name: "Impact mode" }));
+
+    expect(viewport.scrollTop).toBe(500);
+    expect({
+      left: screen.getByLabelText(
+        "alpinerent_lakehouse, Lakehouse, healthy",
+      ).style.left,
+      top: screen.getByLabelText(
+        "alpinerent_lakehouse, Lakehouse, healthy",
+      ).style.top,
+    }).toEqual(before.lakehouse);
+    expect({
+      left: screen.getByLabelText(
+        "AlpineRent Sales Model, Semantic model, healthy",
+      ).style.left,
+      top: screen.getByLabelText(
+        "AlpineRent Sales Model, Semantic model, healthy",
+      ).style.top,
+    }).toEqual(before.model);
   });
 
   it("pans the complete graph by dragging its background", () => {

--- a/src/atlas/views/Map.tsx
+++ b/src/atlas/views/Map.tsx
@@ -1380,11 +1380,7 @@ export function MapView() {
           type="button"
           role="switch"
           aria-checked={impactMode}
-          onClick={() => {
-            const next = !impactMode;
-            if (next) setFocusId(activeId);
-            setImpactMode(next);
-          }}
+          onClick={() => setImpactMode((current) => !current)}
           className={cn(
             "ml-auto flex items-center gap-s rounded-lg border px-m font-semibold",
             impactMode


### PR DESCRIPTION
Impact mode no longer changes ocusId. This preserves disconnected component order, every node coordinate and the current lineage viewport when the selected item is in the middle of the graph.

Validation: 324 app tests, lint without errors, production build. Deployed as deploy-20260905195013-3575fc70.