### PR TITLE
fix: bound synchronized metadata before persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Fabric Atlas are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-09-10
+
+### Fixed
+
+- External Fabric metadata is normalized to the Rayfin entity limits before
+  snapshot writes, with explicit truncation markers for display values and
+  stable shortened keys for long identifiers.
+- Schema objects keep their original names after chunked persistence even when
+  the storage key must be shortened.
+- Live synchronization is reported as unconfigured when the tenant is missing,
+  and the application shell disables Sync when required settings are invalid.
+- Saved views cannot be created while their initial personal state is loading.
+- Team-note documentation now matches the authenticated email and subject
+  binding used by the application.
+
 ## [1.12.0] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -515,12 +515,10 @@ without hiding it or improving the underlying score, and it remains separate
 from a user's personal mute.
 
 Team notes are append-only in v1.x. Creation is bound to the authenticated
-email and subject. Atlas resolves a unique synchronized Fabric principal by
-email and stores that display name separately; when no unique principal exists,
-the authenticated session label remains the fallback. The stored label remains
-stable after reload. When the label differs from the policy-bound email, the
-note displays both so readers can verify the author. Notes cannot currently be
-edited or deleted.
+email and subject. Atlas stores the authenticated session email as the author
+label, and that label remains stable after reload. Client-selected catalog
+labels cannot impersonate another note author. Notes cannot currently be edited
+or deleted.
 
 Only the configured synchronization administrator can publish or prune
 snapshots. When another user reaches the first-sync gate, Atlas displays the

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -122,17 +122,18 @@ A team note on the workspace or an item.
 
 Comments are not tied to a catalog snapshot, so they survive every refresh.
 They are append-only in v1.x because `Comment` exposes create and read but no
-update or delete action. `authorName` stores the uniquely resolved synchronized
-principal display name when available, with the authenticated session label as
-a fallback. `authorEmail` is the authoritative authenticated identity and the
-UI shows it whenever it differs from `authorName`.
+update or delete action. `authorName` and `authorEmail` store the authenticated
+email supplied by the Rayfin session. `authorId` is bound to the authenticated
+subject. Client-selected catalog labels cannot impersonate another note author.
 
 ## SyncRun
 
-The audit record for a completed snapshot.
+The durable audit record for a running, completed or failed synchronization
+attempt.
 
-`workspace_id`, `snapshotId`, `writerEmail?`, `startedAt`, `finishedAt?`, `status`,
-`itemsSynced?`, `triggeredBy?`, `summary?`
+`workspace_id`, `snapshotId`, `correlationId?`, `writerEmail?`, `startedAt`,
+`finishedAt?`, `status`, `itemsSynced?`, `durationMs?`, `failureCode?`,
+`failureMessage?`, `triggeredBy?`, `summary?`
 
 ## SavedView
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -255,9 +255,9 @@ created, then re-add the new hosting origin to the app registration.
 | `npm run test` | Vitest |
 | `npx rayfin up` | Deploy app + apply schema to Fabric |
 
-Team notes are shared and append-only in v1.x. Atlas stores the uniquely
-resolved synchronized principal display name when available and otherwise uses
-the authenticated session email. That stored author label survives reload, but
-notes cannot currently be edited or deleted.
+Team notes are shared and append-only in v1.x. Atlas stores the authenticated
+session email as the author label and binds the note to the authenticated
+subject. That label survives reload, but notes cannot currently be edited or
+deleted.
 
 See [architecture.md](architecture.md) for how it all fits together.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-atlas",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-atlas",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^4.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "fredgis",
   "license": "MIT",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "packageManager": "npm@11.13.0",
   "engines": {
     "node": ">=24 <25",

--- a/rayfin-template.yml
+++ b/rayfin-template.yml
@@ -9,7 +9,7 @@ metadata:
     Microsoft Fabric workspace governance explorer — items, lineage, catalog,
     access, jobs, config, sensitivity labels and a shared comment layer, built
     as a Rayfin Data App.
-  version: 1.12.0
+  version: 1.12.1
   tags:
     - fabric
     - governance

--- a/rayfin/rayfin.yml
+++ b/rayfin/rayfin.yml
@@ -1,6 +1,6 @@
 id: fabricatlas
 name: FabricAtlas
-version: 1.12.0
+version: 1.12.1
 services:
   auth:
     enabled: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,6 +224,7 @@ function App() {
     syncStage,
     syncStartedAt,
     syncError,
+    configured,
     canSync,
     lastSyncedAt,
     currentUser,
@@ -439,13 +440,18 @@ function App() {
                 if (syncing) cancelSync();
                 else void sync();
               }}
-              disabled={!syncing && !canSync}
+              disabled={
+                !syncing &&
+                (!canSync || (!isPreview && !configured))
+              }
               title={
                 syncing
                   ? "Cancel synchronization"
-                  : canSync
-                  ? undefined
-                  : "Only the configured Atlas sync administrator can synchronize"
+                  : !canSync
+                    ? "Only the configured Atlas sync administrator can synchronize"
+                    : !isPreview && !configured
+                      ? "Atlas synchronization is not configured"
+                      : undefined
               }
               className="flex h-[32px] items-center gap-[7px] rounded-md bg-primary px-[12px] text-[13px] font-semibold text-primary-foreground shadow-fabric-2 hover:bg-primary-hover disabled:opacity-70"
             >

--- a/src/atlas/backend.spec.ts
+++ b/src/atlas/backend.spec.ts
@@ -392,6 +392,123 @@ describe("Rayfin snapshot persistence", () => {
     expect(hydrated?.principals[0].workspaceRole).toBe("Admin");
   });
 
+  it("bounds external metadata before Rayfin writes without breaking references", async () => {
+    const atlas = structuredClone(SAMPLE_DATA);
+    const item = atlas.items[0];
+    const principal = atlas.principals[0];
+    const originalPrincipalRefs = new Set([
+      principal.principalId,
+      principal.displayName,
+      principal.email,
+    ]);
+    const longPrincipalId = `principal-${"p".repeat(220)}`;
+    const longTableName = `table-${"t".repeat(220)}`;
+
+    atlas.workspace.fabricId = workspaceId;
+    atlas.workspace.displayName = "w".repeat(260);
+    item.displayName = "i".repeat(260);
+    item.description = "d".repeat(700);
+    item.ownerName = "o".repeat(180);
+    item.ownerEmail = `${"e".repeat(160)}@example.com`;
+    item.configuredBy = "c".repeat(220);
+    item.modifiedBy = "m".repeat(220);
+    item.tags = Array.from(
+      { length: 20 },
+      (_, index) => `tag-${index}-${"x".repeat(30)}`,
+    );
+    item.tagIds = Array.from(
+      { length: 80 },
+      (_, index) => `tag-id-${index}-${"y".repeat(30)}`,
+    );
+    principal.principalId = longPrincipalId;
+    principal.displayName = "n".repeat(260);
+    principal.email = `${"a".repeat(180)}@example.com`;
+    atlas.grants = atlas.grants.map((grant) => ({
+      ...grant,
+      principalRef: originalPrincipalRefs.has(grant.principalRef)
+        ? longPrincipalId
+        : grant.principalRef,
+      roleName: "r".repeat(90),
+    }));
+    atlas.jobs[0].itemName = "j".repeat(260);
+    atlas.jobs[0].jobType = "k".repeat(90);
+    atlas.jobs[0].message = "q".repeat(500);
+    atlas.edges[0].relation = "l".repeat(90);
+    atlas.config = [
+      {
+        itemFabricId: item.fabricId,
+        section: "s".repeat(100),
+        label: "b".repeat(220),
+        value: "v".repeat(2200),
+      },
+    ];
+    atlas.schema = {
+      [item.fabricId]: [
+        {
+          name: longTableName,
+          objectType: "Table",
+          columns: [],
+          measures: [],
+        },
+      ],
+    };
+    atlas.objectEdges = [];
+    mocks.mapSyncToAtlas.mockReturnValue(atlas);
+
+    const persisted = await runFabricSync(false, identity);
+
+    const persistedItem = mocks.data.FabricItem.rows.find(
+      (row) => row.fabricId === item.fabricId,
+    )!;
+    expect(String(persistedItem.displayName)).toHaveLength(200);
+    expect(String(persistedItem.description)).toHaveLength(600);
+    expect(String(persistedItem.description)).toMatch(/\[truncated\]$/);
+    expect(String(persistedItem.ownerName).length).toBeLessThanOrEqual(120);
+    expect(String(persistedItem.ownerEmail).length).toBeLessThanOrEqual(150);
+    expect(String(persistedItem.tags).length).toBeLessThanOrEqual(300);
+    expect(String(persistedItem.tags)).toContain(
+      "[additional values omitted]",
+    );
+    expect(String(persistedItem.tagIds).length).toBeLessThanOrEqual(2000);
+
+    const persistedPrincipal = mocks.data.Principal.rows[0];
+    const persistedGrant = mocks.data.AccessGrant.rows.find(
+      (row) => row.principalRef === persistedPrincipal.principalId,
+    );
+    expect(String(persistedPrincipal.principalId).length).toBeLessThanOrEqual(
+      150,
+    );
+    expect(String(persistedPrincipal.principalId)).toContain("[sha256:");
+    expect(persistedGrant).toBeDefined();
+    expect(String(persistedPrincipal.displayName).length).toBeLessThanOrEqual(
+      200,
+    );
+
+    expect(
+      mocks.data.JobRun.rows.every(
+        (row) =>
+          String(row.itemName).length <= 200 &&
+          String(row.jobType).length <= 60 &&
+          String(row.message ?? "").length <= 400,
+      ),
+    ).toBe(true);
+    expect(
+      mocks.data.LineageEdge.rows.every(
+        (row) => String(row.relation).length <= 60,
+      ),
+    ).toBe(true);
+    expect(
+      mocks.data.ConfigEntry.rows.every(
+        (row) =>
+          String(row.section).length <= 80 &&
+          String(row.label).length <= 160 &&
+          String(row.value ?? "").length <= 2000,
+      ),
+    ).toBe(true);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.schema?.[item.fabricId][0].name).toBe(longTableName);
+  });
+
   it("cleans orphan snapshot rows after a later successful publication", async () => {
     const orphanSnapshotId = "99999999-9999-4999-8999-999999999999";
     mocks.data.SyncRun.rows.push({

--- a/src/atlas/backend.ts
+++ b/src/atlas/backend.ts
@@ -11,7 +11,7 @@
 //    shown without re-calling Fabric.
 //  - `persistComment` writes a new comment to the Comment entity.
 //
-// Every backend call is wired defensively so a missing/ës misconfigured backend
+// Every backend call is wired defensively so a missing/misconfigured backend
 // never breaks the UI — see docs/architecture.md for the full flow.
 
 import { ATLAS_CONFIG } from "./config";
@@ -56,6 +56,148 @@ export type SyncProgressReporter = (progress: number, stage: string) => void;
 type Row = Record<string, unknown>;
 const SNAPSHOT_WRITE_BATCH_SIZE = 8;
 const SYNC_RUN_UPDATE_RETRY_DELAYS_MS = [0, 100, 400];
+const PERSISTED_TEXT_LIMITS = {
+  reference: {
+    fabricId: 100,
+  },
+  workspace: {
+    displayName: 200,
+    capacity: 120,
+    region: 120,
+  },
+  item: {
+    displayName: 200,
+    itemType: 60,
+    size: 200,
+    description: 600,
+    ownerName: 120,
+    ownerEmail: 150,
+    configuredBy: 160,
+    modifiedBy: 160,
+    endorsementRaw: 60,
+    endorsementBy: 160,
+    sensitivity: 60,
+    sensitivityLabelId: 100,
+    tags: 300,
+    tagIds: 2000,
+  },
+  edge: {
+    relation: 60,
+  },
+  principal: {
+    id: 150,
+    displayName: 200,
+    email: 150,
+  },
+  grant: {
+    roleName: 60,
+    flag: 80,
+  },
+  job: {
+    itemName: 200,
+    jobType: 60,
+    message: 400,
+  },
+  config: {
+    section: 80,
+    label: 160,
+    value: 2000,
+  },
+  syncRun: {
+    triggeredBy: 160,
+    summary: 500,
+  },
+} as const;
+const PERSISTED_TRUNCATION_MARKER = " [truncated]";
+
+function persistedText(
+  value: unknown,
+  maxLength: number,
+): string | undefined {
+  const text = realText(value);
+  if (!text) return undefined;
+  if (text.length <= maxLength) return text;
+  const marker =
+    PERSISTED_TRUNCATION_MARKER.length < maxLength
+      ? PERSISTED_TRUNCATION_MARKER
+      : "";
+  return `${text.slice(0, maxLength - marker.length)}${marker}`;
+}
+
+function requiredPersistedText(
+  value: unknown,
+  maxLength: number,
+  label: string,
+): string {
+  const text = persistedText(value, maxLength);
+  if (!text) throw new Error(`${label} is required for snapshot persistence`);
+  return text;
+}
+
+function requiredExactPersistedText(
+  value: unknown,
+  maxLength: number,
+  label: string,
+): string {
+  const text = realText(value);
+  if (!text) throw new Error(`${label} is required for snapshot persistence`);
+  if (text.length > maxLength) {
+    throw new Error(`${label} exceeded the snapshot persistence limit`);
+  }
+  return text;
+}
+
+function normalizedPersistenceKey(value: unknown): string {
+  return realText(value)?.toLocaleLowerCase() ?? "";
+}
+
+async function stablePersistedKey(
+  value: unknown,
+  maxLength: number,
+  label: string,
+): Promise<string> {
+  const text = realText(value);
+  if (!text) throw new Error(`${label} is required for snapshot persistence`);
+  if (text.length <= maxLength) return text;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  const suffix = ` [sha256:${[...new Uint8Array(digest)]
+    .slice(0, 12)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}]`;
+  return `${text.slice(0, maxLength - suffix.length)}${suffix}`;
+}
+
+function persistedList(
+  values: string[] | undefined,
+  maxLength: number,
+  separator: string,
+): string | undefined {
+  const normalized = (values ?? [])
+    .map((value) => realText(value))
+    .filter((value): value is string => !!value);
+  if (normalized.length === 0) return undefined;
+  const joined = normalized.join(separator);
+  if (joined.length <= maxLength) return joined;
+
+  const marker = "[additional values omitted]";
+  const kept: string[] = [];
+  for (const value of normalized) {
+    const candidate = [...kept, value, marker].join(separator);
+    if (candidate.length > maxLength) break;
+    kept.push(value);
+  }
+  if (kept.length > 0) return [...kept, marker].join(separator);
+  const firstLimit = Math.max(1, maxLength - marker.length - separator.length);
+  return [
+    persistedText(normalized[0], firstLimit),
+    marker,
+  ]
+    .filter((value): value is string => !!value)
+    .join(separator);
+}
 
 function assertSyncActive(signal?: AbortSignal): void {
   if (signal?.aborted) {
@@ -273,14 +415,24 @@ function requireSyncWriter(user: SyncIdentity): string {
       "Only the configured Atlas sync administrator can publish workspace snapshots.",
     );
   }
-  return ATLAS_CONFIG.syncAdminEmail.trim().toLowerCase();
+  const writerEmail = ATLAS_CONFIG.syncAdminEmail.trim().toLowerCase();
+  if (!writerEmail || writerEmail.length > 160) {
+    throw new Error(
+      "The configured Atlas sync administrator email is invalid.",
+    );
+  }
+  return writerEmail;
 }
 
 async function startSyncAttempt(user: SyncIdentity): Promise<SyncAttempt> {
   const attempt: SyncAttempt = {
     id: crypto.randomUUID(),
     snapshotId: crypto.randomUUID(),
-    workspaceId: workspaceId(),
+    workspaceId: requiredExactPersistedText(
+      workspaceId(),
+      PERSISTED_TEXT_LIMITS.reference.fabricId,
+      "Workspace ID",
+    ),
     writerEmail: requireSyncWriter(user),
     startedAt: new Date(),
     data: await dataApi(),
@@ -294,7 +446,10 @@ async function startSyncAttempt(user: SyncIdentity): Promise<SyncAttempt> {
     writerEmail: attempt.writerEmail,
     startedAt: attempt.startedAt,
     status: "running",
-    triggeredBy: user.name,
+    triggeredBy: persistedText(
+      user.name,
+      PERSISTED_TEXT_LIMITS.syncRun.triggeredBy,
+    ),
     summary: "Synchronization in progress.",
   });
   return attempt;
@@ -330,7 +485,10 @@ async function updateSyncAttempt(
             status === "failed"
               ? "Synchronization failed before snapshot publication."
               : undefined,
-          summary,
+          summary: persistedText(
+            summary,
+            PERSISTED_TEXT_LIMITS.syncRun.summary,
+          ),
         },
       );
       return;
@@ -476,88 +634,231 @@ async function persistSync(
   reportProgress?.(70, "Preparing the Atlas database");
   reportProgress?.(76, "Writing workspace items");
 
+  const itemRows = atlas.items.map((item) => ({
+    fabricId: requiredExactPersistedText(
+      item.fabricId,
+      PERSISTED_TEXT_LIMITS.reference.fabricId,
+      "Fabric item ID",
+    ),
+    displayName: requiredPersistedText(
+      item.displayName || item.fabricId,
+      PERSISTED_TEXT_LIMITS.item.displayName,
+      "Fabric item display name",
+    ),
+    itemType: requiredPersistedText(
+      item.itemType,
+      PERSISTED_TEXT_LIMITS.item.itemType,
+      "Fabric item type",
+    ),
+    size: persistedText(item.size, PERSISTED_TEXT_LIMITS.item.size),
+    description: persistedText(
+      item.description,
+      PERSISTED_TEXT_LIMITS.item.description,
+    ),
+    ownerName: persistedText(
+      item.ownerName,
+      PERSISTED_TEXT_LIMITS.item.ownerName,
+    ),
+    ownerEmail: persistedText(
+      item.ownerEmail,
+      PERSISTED_TEXT_LIMITS.item.ownerEmail,
+    ),
+    configuredBy: persistedText(
+      item.configuredBy,
+      PERSISTED_TEXT_LIMITS.item.configuredBy,
+    ),
+    modifiedBy: persistedText(
+      item.modifiedBy,
+      PERSISTED_TEXT_LIMITS.item.modifiedBy,
+    ),
+    health: item.health,
+    endorsement: item.endorsement,
+    endorsementRaw: persistedText(
+      item.endorsementRaw,
+      PERSISTED_TEXT_LIMITS.item.endorsementRaw,
+    ),
+    endorsementBy: persistedText(
+      item.endorsementBy,
+      PERSISTED_TEXT_LIMITS.item.endorsementBy,
+    ),
+    sensitivity: persistedText(
+      item.sensitivity,
+      PERSISTED_TEXT_LIMITS.item.sensitivity,
+    ),
+    sensitivityLabelId: persistedText(
+      item.sensitivityLabelId,
+      PERSISTED_TEXT_LIMITS.item.sensitivityLabelId,
+    ),
+    tags: persistedList(
+      item.tags,
+      PERSISTED_TEXT_LIMITS.item.tags,
+      ", ",
+    ),
+    tagIds: persistedList(
+      item.tagIds,
+      PERSISTED_TEXT_LIMITS.item.tagIds,
+      ",",
+    ),
+    ownerMetadataAvailable: item.ownerMetadataAvailable,
+    sensitivityMetadataAvailable: item.sensitivityMetadataAvailable,
+    endorsementMetadataAvailable: item.endorsementMetadataAvailable,
+    tagMetadataAvailable: item.tagMetadataAvailable,
+    lastRefresh: item.lastRefresh ? new Date(item.lastRefresh) : undefined,
+    itemCreatedAt: item.createdAt ? new Date(item.createdAt) : undefined,
+    itemUpdatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
+  }));
   await insertAll(
     "FabricItem",
-    atlas.items.map((i) => ({
-      fabricId: i.fabricId,
-      displayName: i.displayName,
-      itemType: i.itemType,
-      size: i.size,
-      description: i.description,
-      ownerName: i.ownerName,
-      ownerEmail: i.ownerEmail,
-      configuredBy: i.configuredBy,
-      modifiedBy: i.modifiedBy,
-      health: i.health,
-      endorsement: i.endorsement,
-      endorsementRaw: i.endorsementRaw,
-      endorsementBy: i.endorsementBy,
-      sensitivity: i.sensitivity,
-      sensitivityLabelId: i.sensitivityLabelId,
-      tags: i.tags?.length ? i.tags.join(", ") : undefined,
-      tagIds: i.tagIds?.length ? i.tagIds.join(",") : undefined,
-      ownerMetadataAvailable: i.ownerMetadataAvailable,
-      sensitivityMetadataAvailable: i.sensitivityMetadataAvailable,
-      endorsementMetadataAvailable: i.endorsementMetadataAvailable,
-      tagMetadataAvailable: i.tagMetadataAvailable,
-      lastRefresh: i.lastRefresh ? new Date(i.lastRefresh) : undefined,
-      itemCreatedAt: i.createdAt ? new Date(i.createdAt) : undefined,
-      itemUpdatedAt: i.updatedAt ? new Date(i.updatedAt) : undefined,
-    })),
+    itemRows,
   );
+
   reportProgress?.(82, "Writing principals and access");
-  await insertAll(
-    "Principal",
-    atlas.principals.map((p) => ({
-      principalId: p.principalId,
-      displayName: p.displayName,
-      kind: p.kind,
-      email: p.email,
-      external: p.external,
-      workspaceRole: p.workspaceRole,
+  const principalAliases = new Map<string, Set<string>>();
+  const addPrincipalAlias = (value: unknown, persistedId: string) => {
+    const key = normalizedPersistenceKey(value);
+    if (!key) return;
+    const ids = principalAliases.get(key) ?? new Set<string>();
+    ids.add(persistedId);
+    principalAliases.set(key, ids);
+  };
+  const principalRows = await Promise.all(
+    atlas.principals.map(async (principal) => {
+      const principalId = await stablePersistedKey(
+        principal.principalId,
+        PERSISTED_TEXT_LIMITS.principal.id,
+        "Principal ID",
+      );
+      addPrincipalAlias(principal.principalId, principalId);
+      addPrincipalAlias(principal.email, principalId);
+      addPrincipalAlias(principal.displayName, principalId);
+      return {
+        principalId,
+        displayName: requiredPersistedText(
+          principal.displayName || principal.principalId,
+          PERSISTED_TEXT_LIMITS.principal.displayName,
+          "Principal display name",
+        ),
+        kind: principal.kind,
+        email: persistedText(
+          principal.email,
+          PERSISTED_TEXT_LIMITS.principal.email,
+        ),
+        external: principal.external,
+        workspaceRole: principal.workspaceRole,
+      };
+    }),
+  );
+  await insertAll("Principal", principalRows);
+
+  const principalReference = async (value: string): Promise<string> => {
+    const aliases = principalAliases.get(normalizedPersistenceKey(value));
+    if (aliases?.size === 1) return [...aliases][0];
+    return stablePersistedKey(
+      value,
+      PERSISTED_TEXT_LIMITS.principal.id,
+      "Principal reference",
+    );
+  };
+  const grantRows = await Promise.all(
+    atlas.grants.map(async (grant) => ({
+      itemFabricId: grant.itemFabricId
+        ? requiredExactPersistedText(
+            grant.itemFabricId,
+            PERSISTED_TEXT_LIMITS.reference.fabricId,
+            "Grant item ID",
+          )
+        : undefined,
+      principalRef: await principalReference(grant.principalRef),
+      accessLevel: grant.accessLevel,
+      source: grant.source,
+      roleName: persistedText(
+        grant.roleName,
+        PERSISTED_TEXT_LIMITS.grant.roleName,
+      ),
+      flag: persistedText(grant.flag, PERSISTED_TEXT_LIMITS.grant.flag),
     })),
   );
   await insertAll(
     "AccessGrant",
-    atlas.grants.map((g) => ({
-      itemFabricId: g.itemFabricId,
-      principalRef: g.principalRef,
-      accessLevel: g.accessLevel,
-      source: g.source,
-      roleName: g.roleName,
-      flag: g.flag,
-    })),
+    grantRows,
   );
+
   reportProgress?.(88, "Writing jobs and lineage");
   await insertAll(
     "JobRun",
-    atlas.jobs.map((j) => ({
-      itemFabricId: j.itemFabricId,
-      itemName: j.itemName,
-      jobType: j.jobType,
-      status: j.status,
-      startedAt: j.startedAt ? new Date(j.startedAt) : undefined,
-      durationSec: j.durationSec,
-      message: j.message,
+    atlas.jobs.map((job) => ({
+      itemFabricId: requiredExactPersistedText(
+        job.itemFabricId,
+        PERSISTED_TEXT_LIMITS.reference.fabricId,
+        "Job item ID",
+      ),
+      itemName: requiredPersistedText(
+        job.itemName || job.itemFabricId,
+        PERSISTED_TEXT_LIMITS.job.itemName,
+        "Job item name",
+      ),
+      jobType: requiredPersistedText(
+        job.jobType,
+        PERSISTED_TEXT_LIMITS.job.jobType,
+        "Job type",
+      ),
+      status: job.status,
+      startedAt: job.startedAt ? new Date(job.startedAt) : undefined,
+      durationSec: job.durationSec,
+      message: persistedText(
+        job.message,
+        PERSISTED_TEXT_LIMITS.job.message,
+      ),
     })),
   );
   await insertAll(
     "LineageEdge",
-    atlas.edges.map((e) => ({
-      sourceFabricId: e.source,
-      targetFabricId: e.target,
-      relation: e.relation,
-      broken: !!e.broken,
+    atlas.edges.map((edge) => ({
+      sourceFabricId: requiredExactPersistedText(
+        edge.source,
+        PERSISTED_TEXT_LIMITS.reference.fabricId,
+        "Lineage source ID",
+      ),
+      targetFabricId: requiredExactPersistedText(
+        edge.target,
+        PERSISTED_TEXT_LIMITS.reference.fabricId,
+        "Lineage target ID",
+      ),
+      relation: requiredPersistedText(
+        edge.relation,
+        PERSISTED_TEXT_LIMITS.edge.relation,
+        "Lineage relationship",
+      ),
+      broken: !!edge.broken,
+    })),
+  );
+
+  const configRows = await Promise.all(
+    atlas.config.map(async (entry) => ({
+      itemFabricId: requiredExactPersistedText(
+        entry.itemFabricId,
+        PERSISTED_TEXT_LIMITS.reference.fabricId,
+        "Configuration item ID",
+      ),
+      section: await stablePersistedKey(
+        entry.section,
+        PERSISTED_TEXT_LIMITS.config.section,
+        "Configuration section",
+      ),
+      label: await stablePersistedKey(
+        entry.label,
+        PERSISTED_TEXT_LIMITS.config.label,
+        "Configuration label",
+      ),
+      value: persistedText(
+        entry.value,
+        PERSISTED_TEXT_LIMITS.config.value,
+      ),
     })),
   );
   await insertAll(
     "ConfigEntry",
-    atlas.config.map((c) => ({
-      itemFabricId: c.itemFabricId,
-      section: c.section,
-      label: c.label,
-      value: c.value,
-    })),
+    configRows,
   );
   reportProgress?.(94, "Writing object metadata");
   // Persist the sub-object schema as hidden ConfigEntry
@@ -567,7 +868,13 @@ async function persistSync(
   const schemaRows: Row[] = [];
   for (const [itemId, tables] of Object.entries(atlas.schema ?? {})) {
     for (const t of tables) {
+      const storedLabel = await stablePersistedKey(
+        t.name,
+        PERSISTED_TEXT_LIMITS.config.label,
+        "Schema object name",
+      );
       const serialized = JSON.stringify({
+        name: t.name,
         rows:
           typeof t.rows === "number" &&
           Number.isFinite(t.rows) &&
@@ -584,9 +891,13 @@ async function persistSync(
       const chunks = serialized.match(/[\s\S]{1,1960}/g) ?? [""];
       for (let part = 0; part < chunks.length; part += 1) {
         schemaRows.push({
-          itemFabricId: itemId,
+          itemFabricId: requiredExactPersistedText(
+            itemId,
+            PERSISTED_TEXT_LIMITS.reference.fabricId,
+            "Schema item ID",
+          ),
           section: "__schema__",
-          label: t.name,
+          label: storedLabel,
           value: `v1:${String(part + 1).padStart(4, "0")}:${String(chunks.length).padStart(4, "0")}:${chunks[part]}`,
         });
       }
@@ -601,7 +912,11 @@ async function persistSync(
       : serializedObjectEdges.match(/[\s\S]{1,1960}/g) ?? [];
   for (let part = 0; part < objectEdgeChunks.length; part += 1) {
     objectEdgeRows.push({
-      itemFabricId: atlas.workspace.fabricId,
+      itemFabricId: requiredExactPersistedText(
+        atlas.workspace.fabricId,
+        PERSISTED_TEXT_LIMITS.reference.fabricId,
+        "Object lineage workspace ID",
+      ),
       section: "__object_edges__",
       label: "workspace",
       value: `v1:${String(part + 1).padStart(4, "0")}:${String(objectEdgeChunks.length).padStart(4, "0")}:${objectEdgeChunks[part]}`,
@@ -621,10 +936,24 @@ async function persistSync(
     syncSectionsJson: atlas.workspace.syncSections
       ? JSON.stringify(atlas.workspace.syncSections)
       : undefined,
-    fabricId: atlas.workspace.fabricId,
-    displayName: atlas.workspace.displayName,
-    capacity: atlas.workspace.capacity,
-    region: atlas.workspace.region,
+    fabricId: requiredExactPersistedText(
+      atlas.workspace.fabricId,
+      PERSISTED_TEXT_LIMITS.reference.fabricId,
+      "Workspace Fabric ID",
+    ),
+    displayName: requiredPersistedText(
+      atlas.workspace.displayName || atlas.workspace.fabricId,
+      PERSISTED_TEXT_LIMITS.workspace.displayName,
+      "Workspace display name",
+    ),
+    capacity: persistedText(
+      atlas.workspace.capacity,
+      PERSISTED_TEXT_LIMITS.workspace.capacity,
+    ),
+    region: persistedText(
+      atlas.workspace.region,
+      PERSISTED_TEXT_LIMITS.workspace.region,
+    ),
     itemCount: atlas.items.length,
     edgeCount: atlas.edges.length,
     principalCount: atlas.principals.length,
@@ -871,6 +1200,7 @@ function parseSchemaRows(
       "snapshot contains an incomplete schema",
     );
     const parsed = JSON.parse(serialized) as {
+      name?: string;
       rows?: number;
       objectType?: string;
       source?: string;
@@ -882,7 +1212,7 @@ function parseSchemaRows(
     };
     const tables = schema[itemId] ?? [];
     tables.push({
-      name: label,
+      name: realText(parsed.name) ?? label,
       rows: parsed.rows,
       objectType: parsed.objectType,
       source: parsed.source,

--- a/src/atlas/components/SavedViewsMenu.spec.tsx
+++ b/src/atlas/components/SavedViewsMenu.spec.tsx
@@ -3,6 +3,29 @@ import { describe, expect, it, vi } from "vitest";
 import { SavedViewsMenu } from "./SavedViewsMenu";
 
 describe("SavedViewsMenu", () => {
+  it("prevents creating a view while the initial list is loading", () => {
+    const onCreate = vi.fn();
+    render(
+      <SavedViewsMenu
+        views={[]}
+        loading
+        activeSection="governance"
+        currentFilters={{ section: "findings" }}
+        onCreate={onCreate}
+        onApply={() => undefined}
+        onDelete={async () => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Saved views/ }));
+    const create = screen.getByRole("button", {
+      name: "Save current filters",
+    });
+    expect(create).toBeDisabled();
+    fireEvent.click(create);
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
   it("shows mutation failures instead of leaving an unhandled action", async () => {
     const onCreate = vi.fn().mockRejectedValue(new Error("Save failed"));
     render(

--- a/src/atlas/components/SavedViewsMenu.tsx
+++ b/src/atlas/components/SavedViewsMenu.tsx
@@ -54,7 +54,7 @@ export function SavedViewsMenu({
   }, [open]);
 
   const save = async () => {
-    if (!name.trim()) return;
+    if (loading || !name.trim()) return;
     setSaving(true);
     setOperationError(undefined);
     try {
@@ -146,7 +146,7 @@ export function SavedViewsMenu({
                 <button
                   type="button"
                   onClick={() => void save()}
-                  disabled={!name.trim() || saving}
+                  disabled={loading || !name.trim() || saving}
                   className="rounded-lg bg-primary px-m py-s text-200 font-semibold text-primary-foreground disabled:opacity-50"
                 >
                   {saving ? (
@@ -161,7 +161,8 @@ export function SavedViewsMenu({
             <button
               type="button"
               onClick={() => setCreating(true)}
-              className="flex w-full items-center gap-s border-b border-border px-m py-s text-left text-200 font-semibold text-brand-foreground hover:bg-primary/10"
+              disabled={loading}
+              className="flex w-full items-center gap-s border-b border-border px-m py-s text-left text-200 font-semibold text-brand-foreground hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Plus className="icon-size-100" aria-hidden="true" />
               Save current filters

--- a/src/atlas/config.spec.ts
+++ b/src/atlas/config.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { validateUdfUrl } from "./config";
+import {
+  hasValidSyncConfiguration,
+  validateUdfUrl,
+} from "./config";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const functionId = "22222222-2222-4222-8222-222222222222";
@@ -31,4 +34,30 @@ describe("validateUdfUrl", () => {
       ),
     ).toThrow(/invalid UDF endpoint/i);
   });
+});
+
+describe("hasValidSyncConfiguration", () => {
+  const config = {
+    clientId: "44444444-4444-4444-8444-444444444444",
+    tenantId: "55555555-5555-4555-8555-555555555555",
+    workspaceId,
+    syncAdminEmail: "admin@example.com",
+    syncAdminSubject: "66666666-6666-4666-8666-666666666666",
+  };
+
+  it("accepts a complete synchronization configuration", () => {
+    expect(hasValidSyncConfiguration(config, validUrl)).toBe(true);
+  });
+
+  it.each(["clientId", "tenantId", "workspaceId"] as const)(
+    "rejects a missing %s before synchronization starts",
+    (field) => {
+      expect(
+        hasValidSyncConfiguration(
+          { ...config, [field]: "" },
+          validUrl,
+        ),
+      ).toBe(false);
+    },
+  );
 });

--- a/src/atlas/config.ts
+++ b/src/atlas/config.ts
@@ -123,21 +123,36 @@ export function validateUdfUrl(value: string, workspaceId: string): string {
   return url.toString();
 }
 
-/** True once the UDF `sync_all` invoke URL is known. */
-export function isSyncConfigured(): boolean {
-  const udfUrl = getUdfUrl();
+export function hasValidSyncConfiguration(
+  config: Pick<
+    typeof ATLAS_CONFIG,
+    | "clientId"
+    | "tenantId"
+    | "workspaceId"
+    | "syncAdminEmail"
+    | "syncAdminSubject"
+  >,
+  udfUrl: string | null,
+): boolean {
   if (
     !udfUrl ||
-    !ATLAS_CONFIG.clientId ||
-    !ATLAS_CONFIG.syncAdminEmail ||
-    !ATLAS_CONFIG.syncAdminSubject
+    !config.clientId ||
+    !config.tenantId ||
+    !config.workspaceId ||
+    !config.syncAdminEmail ||
+    !config.syncAdminSubject
   ) {
     return false;
   }
   try {
-    validateUdfUrl(udfUrl, ATLAS_CONFIG.workspaceId);
+    validateUdfUrl(udfUrl, config.workspaceId);
     return true;
   } catch {
     return false;
   }
+}
+
+/** True once every required live synchronization value is present and valid. */
+export function isSyncConfigured(): boolean {
+  return hasValidSyncConfiguration(ATLAS_CONFIG, getUdfUrl());
 }

--- a/src/atlas/release.ts
+++ b/src/atlas/release.ts
@@ -15,7 +15,7 @@ export const REPOSITORY_URL =
   "https://github.com/fredgis/FabricAtlas";
 
 export const APP_VERSION =
-  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.12.0";
+  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "1.12.1";
 
 export const BUILD_COMMIT =
   (import.meta.env.VITE_APP_BUILD_COMMIT as string | undefined) ?? "development";
@@ -59,8 +59,8 @@ export const RELEASES: AtlasRelease[] = [
       {
         title: "Collaboration correctness",
         items: [
-          "Team notes resolve a unique synchronized Fabric principal display name and preserve it through persistence and reload.",
-          "A distinct note display label is shown together with the policy-bound authenticated email.",
+          "Team notes preserve the authenticated session email as the author label through persistence and reload.",
+          "Client-selected catalog labels cannot replace the authenticated note author.",
           "Comment creation binds both the authenticated email and subject to the stored author identity.",
           "The guided sync gate tells blocked users which configured synchronizer account to contact.",
         ],

--- a/src/atlas/store.tsx
+++ b/src/atlas/store.tsx
@@ -258,6 +258,7 @@ export function AtlasProvider({
   const findingAcksRef = useRef(findingAcks);
   const findingAckQueues = useRef(new Map<string, Promise<void>>());
   const findingAckGeneration = useRef(0);
+  const savedViewsLoadingRef = useRef(savedViewsLoading);
   const findingAcksLoadingRef = useRef(findingAcksLoading);
   const governancePolicyGeneration = useRef(0);
   const governancePolicyLoadingRef = useRef(governancePolicyLoading);
@@ -277,6 +278,10 @@ export function AtlasProvider({
   useEffect(() => {
     findingAcksRef.current = findingAcks;
   }, [findingAcks]);
+
+  useEffect(() => {
+    savedViewsLoadingRef.current = savedViewsLoading;
+  }, [savedViewsLoading]);
 
   useEffect(() => {
     findingAcksLoadingRef.current = findingAcksLoading;
@@ -327,7 +332,11 @@ export function AtlasProvider({
 
   useEffect(() => {
     if (isPreview) return;
+    savedViewsLoadingRef.current = true;
     let alive = true;
+    window.queueMicrotask(() => {
+      if (alive) setSavedViewsLoading(true);
+    });
     void loadSavedViews(
       false,
       data.workspace.fabricId,
@@ -344,7 +353,10 @@ export function AtlasProvider({
         }
       })
       .finally(() => {
-        if (alive) setSavedViewsLoading(false);
+        if (alive) {
+          savedViewsLoadingRef.current = false;
+          setSavedViewsLoading(false);
+        }
       });
     return () => {
       alive = false;
@@ -701,6 +713,11 @@ export function AtlasProvider({
       section: SavedViewSection;
       filters: SavedViewFilters;
     }) => {
+      if (savedViewsLoadingRef.current) {
+        const error = new Error("Personal saved views are still loading.");
+        setSavedViewsError(error.message);
+        throw error;
+      }
       setSavedViewsError(undefined);
       try {
         const view = await createSavedView(


### PR DESCRIPTION
## Summary
- bound synchronized Fabric metadata to Rayfin entity limits before snapshot writes
- preserve stable principal references and original schema names when storage keys are shortened
- reject incomplete tenant configuration before Sync is enabled
- prevent saved-view writes during initial loading
- align team-note documentation with authenticated email and subject binding
- bump Fabric Atlas to v1.12.1

## Validation
- 348 frontend tests
- 90 UDF tests
- npm run lint
- npm run build
- npm audit --omit=dev